### PR TITLE
Prevent nesting of toolbox commands

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -27,6 +27,10 @@ ephemeral container using the provided wrapper:
 
     ./toolbox/run echo "Hello from os-migrate toolbox."
 
+Note: the `./toolbox/<cmd>` commands are alternatives to each
+other. They shouldn't be nested, e.g. running `./toolbox/run` from
+`./toolbox/shell` will deliberately fail.
+
 
 Sanity and unit tests
 ---------------------

--- a/toolbox/build/build.sh
+++ b/toolbox/build/build.sh
@@ -27,3 +27,6 @@ pip install -r /build/venv-requirements.txt
 
 cp /build/venv-wrapper /usr/local/bin/venv-wrapper
 chmod a+x /usr/local/bin/venv-wrapper
+
+touch /.os-migrate-toolbox
+chmod 0444 /.os-migrate-toolbox

--- a/toolbox/run
+++ b/toolbox/run
@@ -2,6 +2,12 @@
 
 set -eu
 
+if [ -e /.os-migrate-toolbox ]; then
+    echo "ERROR: You're already within an os-migrate toolbox container."
+    echo "Calls to toolbox shouldn't be nested."
+    exit 1
+fi
+
 DIR=$(dirname $(realpath $0))
 OS_MIGRATE_DIR=$(realpath "$DIR/..")
 if [ -t 1 ]; then

--- a/toolbox/vagrant-run
+++ b/toolbox/vagrant-run
@@ -2,6 +2,12 @@
 
 set -eu
 
+if [ -e /.os-migrate-toolbox ]; then
+    echo "ERROR: You're already within an os-migrate toolbox container."
+    echo "Calls to toolbox shouldn't be nested."
+    exit 1
+fi
+
 DIR=$(dirname $(realpath $0))
 OS_MIGRATE_DIR=$(realpath "$DIR/..")
 if [ -t 1 ]; then


### PR DESCRIPTION
`make toolbox-clean toolbox-build` is required to get the new image with `/.os-migrate-toolbox` file present.

Tested:

```
$ ./toolbox/shell 
[root@axon os_migrate]# ./toolbox/run echo test
ERROR: You're already within an os-migrate toolbox container.
Calls to toolbox shouldn't be nested.
[root@axon os_migrate]# ./toolbox/vagrant-shell 
ERROR: You're already within an os-migrate toolbox container.
Calls to toolbox shouldn't be nested.
[root@axon os_migrate]# 
```