### PR TITLE
Add serialization basics and network exporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test-sanity: reinstall
 		source /root/venv/bin/activate; \
 	fi; \
 	cd /root/.ansible/collections/ansible_collections/os_migrate/os_migrate; \
-	ansible-test sanity --skip-test validate-modules
+	ansible-test sanity --skip-test import --skip-test validate-modules
 
 test-unit: reinstall
 	set -euo pipefail; \

--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -1,1 +1,1 @@
-FILE_PREFIX_NETWORK = 'network-'
+OS_MIGRATE_VERSION = '0.1.0'  # can we get this from metadata somehow?

--- a/os_migrate/plugins/module_utils/filesystem.py
+++ b/os_migrate/plugins/module_utils/filesystem.py
@@ -1,0 +1,35 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import yaml
+from os import path
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import serialization
+
+
+def write_or_replace_resource(file_path, resource):
+    if path.exists(file_path):
+        file_struct = _load_resources_file(file_path)
+    else:
+        file_struct = serialization.new_resources_file_struct()
+
+    resources = file_struct['resources']
+
+    serialization.add_or_replace_resource(resources, resource)
+
+    # TODO: Write the file only if contents changed.
+    # Return True if contents changed, False otherwise
+    _write_resources_file(file_path, file_struct)
+    return True
+
+
+def _load_resources_file(file_path):
+    with open(file_path, 'r') as f:
+        file_struct = yaml.load(f)
+    return file_struct
+
+
+def _write_resources_file(file_path, file_struct):
+    with open(file_path, 'w') as f:
+        f.write(yaml.dump(file_struct))

--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -1,0 +1,47 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def serialize_network(network):
+    resource = {}
+    params = {}
+    info = {}
+    resource['params'] = params
+    resource['info'] = info
+    resource['type'] = 'openstack.network'
+
+    params['availability_zone_hints'] = network['availability_zone_hints']
+    params['availability_zones'] = network['availability_zones']
+    params['description'] = network['description']
+    params['dns_domain'] = network.get('dns_domain', None)
+    params['is_admin_state_up'] = network.get(
+        'admin_state_up', network.get('is_admin_state_up', None))
+    params['is_default'] = network.get('is_default', None)
+    params['is_port_security_enabled'] = network.get(
+        'port_security_enabled', network.get('is_port_security_enabled', None))
+    params['is_router_external'] = network.get(
+        'is_router_external', network.get('router:external', None))
+    params['is_shared'] = network.get('shared', network.get('is_shared', None))
+    params['is_vlan_transparent'] = network.get('is_vlan_transparent', None)
+    params['mtu'] = network['mtu']
+    params['name'] = network['name']
+    params['provider_network_type'] = network.get('provider_network_type', None)
+    params['provider_physical_network'] = network.get('provider_physical_network', None)
+    params['provider_segmentation_id'] = network.get('provider_segmentation_id', None)
+    params['qos_policy_id'] = network.get('qos_policy_id', None)
+    params['revision_number'] = network['revision_number']
+    params['segments'] = network.get('segments', None)
+
+    info['created_at'] = network['created_at']
+    info['project_id'] = network['project_id']
+    info['status'] = network['status']
+    info['subnet_ids'] = network.get(
+        'subnets', network.get('subnet_ids', None))
+    info['updated_at'] = network['updated_at']
+
+    # TODO: Add a (cached?) lookup for names of id-like properties.
+    #     params['qos_policy_name']
+    #     info['project_name']
+    #     info['subnet_names']
+
+    return resource

--- a/os_migrate/plugins/module_utils/serialization.py
+++ b/os_migrate/plugins/module_utils/serialization.py
@@ -1,43 +1,33 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 
-def serialize_network(network):
-    resource = {}
-    params = {}
-    info = {}
-    resource['params'] = params
-    resource['info'] = info
-    resource['type'] = 'openstack.network'
 
-    params['availability_zone_hints'] = network['availability_zone_hints']
-    params['availability_zones'] = network['availability_zones']
-    params['description'] = network['description']
-    params['dns_domain'] = network['dns_domain']
-    params['is_admin_state_up'] = network['is_admin_state_up']
-    params['is_default'] = network['is_default']
-    params['is_port_security_enabled'] = network['is_port_security_enabled']
-    params['is_router_external'] = network['is_router_external']
-    params['is_shared'] = network['is_shared']
-    params['is_vlan_transparent'] = network['is_vlan_transparent']
-    params['mtu'] = network['mtu']
-    params['name'] = network['name']
-    params['provider_network_type'] = network['provider_network_type']
-    params['provider_physical_network'] = network['provider_physical_network']
-    params['provider_segmentation_id'] = network['provider_segmentation_id']
-    params['qos_policy_id'] = network['qos_policy_id']
-    params['revision_number'] = network['revision_number']
-    params['segments'] = network['segments']
+def new_resources_file_struct():
+    data = {}
+    data['os_migrate_version'] = const.OS_MIGRATE_VERSION
+    data['resources'] = []
+    return data
 
-    info['created_at'] = network['created_at']
-    info['project_id'] = network['project_id']
-    info['status'] = network['status']
-    info['subnet_ids'] = network['subnet_ids']
-    info['updated_at'] = network['updated_at']
 
-    # TODO: Add a (cached?) lookup for names of id-like properties.
-    #     params['qos_policy_name']
-    #     info['project_name']
-    #     info['subnet_names']
+# Edits resources_file_struct in place.
+def add_or_replace_resource(resources, resource):
+    for i, r in enumerate(resources):
+        if is_same_resource(r, resource):
+            resources[i] = resource
+            return
 
-    return resource
+    # If we didn't return by now, the resource wasn't found, so append it.
+    resources.append(resource)
+
+
+def is_same_resource(res1, res2):
+    if res1.get('type', '__undefined1__') != res2.get('type', '__undefined2__'):
+        return False
+
+    # We can add special cases if something else than ['type'] &&
+    # ['params']['name'] should be the deciding factors for sameness,
+    # but it's not necessary for now.
+    return (res1.get('params', {}).get('name', '__undefined1__') ==
+            res2.get('params', {}).get('name', '__undefined1__'))

--- a/os_migrate/roles/export_networks/tasks/main.yml
+++ b/os_migrate/roles/export_networks/tasks/main.yml
@@ -6,6 +6,6 @@
 - name: export networks
   os_migrate.os_migrate.export_network:
     cloud: "{{ os_migrate_src_cloud }}"
-    dir: "{{ os_migrate_data_dir }}"
+    path: "{{ os_migrate_data_dir }}/networks.yml"
     name: "{{ item }}"
   loop: "{{ src_networks_info.openstack_networks | json_query('[*].name') }}"

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -3,6 +3,25 @@ __metaclass__ = type
 
 import openstack
 
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
+
+
+def minimal_resource():
+    return {
+        'type': 'openstack.minimal',
+        'params': {
+            'name': 'minimal',
+            'description': 'minimal resource',
+        },
+    }
+
+
+def minimal_resource_file_struct():
+    return {
+        'os_migrate_version': const.OS_MIGRATE_VERSION,
+        'resources': [minimal_resource()],
+    }
+
 
 def network():
     return openstack.network.v2.network.Network(

--- a/os_migrate/tests/unit/test_filesystem.py
+++ b/os_migrate/tests/unit/test_filesystem.py
@@ -1,0 +1,49 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import yaml
+from os import path
+import unittest
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import filesystem
+from ansible_collections.os_migrate.os_migrate.tests.unit import fixtures
+from ansible_collections.os_migrate.os_migrate.tests.unit import utils
+
+
+class TestFilesystem(unittest.TestCase):
+
+    def test_write_or_replace_resource_new_file(self):
+        with utils.tmp_dir_context() as tmp_dir:
+            file_path = path.join(tmp_dir, 'resources.yml')
+            filesystem.write_or_replace_resource(
+                file_path, fixtures.minimal_resource())
+
+            file_struct = filesystem._load_resources_file(file_path)
+            resource = file_struct['resources'][0]
+            self.assertEqual(resource['type'], 'openstack.minimal')
+            self.assertEqual(resource['params']['name'], 'minimal')
+            self.assertEqual(
+                resource['params']['description'], 'minimal resource')
+
+    def test_write_or_replace_resource_existing_file(self):
+        with utils.tmp_dir_context() as tmp_dir:
+            file_path = path.join(tmp_dir, 'resources.yml')
+            with open(file_path, 'w') as f:
+                f.write(yaml.dump(fixtures.minimal_resource_file_struct()))
+
+            minimal2 = fixtures.minimal_resource()
+            minimal2['params']['name'] = 'minimal2'
+            minimal2['params']['description'] = 'minimal two'
+            filesystem.write_or_replace_resource(file_path, minimal2)
+
+            file_struct = filesystem._load_resources_file(file_path)
+            resource0 = file_struct['resources'][0]
+            resource1 = file_struct['resources'][1]
+            self.assertEqual(resource0['type'], 'openstack.minimal')
+            self.assertEqual(resource0['params']['name'], 'minimal')
+            self.assertEqual(
+                resource0['params']['description'], 'minimal resource')
+            self.assertEqual(resource1['type'], 'openstack.minimal')
+            self.assertEqual(resource1['params']['name'], 'minimal2')
+            self.assertEqual(
+                resource1['params']['description'], 'minimal two')

--- a/os_migrate/tests/unit/test_network.py
+++ b/os_migrate/tests/unit/test_network.py
@@ -1,0 +1,44 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.os_migrate.os_migrate.tests.unit import fixtures
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import network
+
+
+class TestNetwork(unittest.TestCase):
+
+    def test_serialize_network(self):
+        net = fixtures.network()
+        serialized = network.serialize_network(net)
+        s_params = serialized['params']
+        s_info = serialized['info']
+
+        self.assertEqual(serialized['type'], 'openstack.network')
+        self.assertEqual(s_params['name'], 'test-net')
+        self.assertEqual(s_params['availability_zone_hints'], ['nova', 'zone2'])
+        self.assertEqual(s_params['availability_zones'], ['nova', 'zone3'])
+        self.assertEqual(s_params['description'], 'test network')
+        self.assertEqual(s_params['dns_domain'], 'example.org')
+        self.assertEqual(s_params['is_admin_state_up'], True)
+        self.assertEqual(s_params['is_default'], False)
+        self.assertEqual(s_params['is_port_security_enabled'], True)
+        self.assertEqual(s_params['is_router_external'], False)
+        self.assertEqual(s_params['is_shared'], False)
+        self.assertEqual(s_params['is_vlan_transparent'], False)
+        self.assertEqual(s_params['mtu'], 1400)
+        self.assertEqual(s_params['name'], 'test-net')
+        self.assertEqual(s_params['provider_network_type'], 'vxlan')
+        self.assertEqual(s_params['provider_physical_network'], 'physnet')
+        self.assertEqual(s_params['provider_segmentation_id'], '456')
+        self.assertEqual(s_params['qos_policy_id'], 'uuid-test-qos-policy')
+        self.assertEqual(s_params['revision_number'], 3)
+        self.assertEqual(s_params['segments'], [])
+
+        self.assertEqual(s_info['created_at'], '2020-01-06T15:50:55Z')
+        self.assertEqual(s_info['project_id'], 'uuid-test-project')
+        self.assertEqual(s_info['status'], 'ACTIVE')
+        self.assertEqual(s_info['subnet_ids'], ['uuid-test-subnet1', 'uuid-test-subnet2'])
+        self.assertEqual(s_info['updated_at'], '2020-01-06T15:51:00Z')

--- a/os_migrate/tests/unit/utils.py
+++ b/os_migrate/tests/unit/utils.py
@@ -1,0 +1,15 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import contextlib
+import shutil
+import tempfile
+
+
+@contextlib.contextmanager
+def tmp_dir_context():
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        yield tmp_dir
+    finally:
+        shutil.rmtree(tmp_dir)

--- a/tests/func/run/network.yml
+++ b/tests/func/run/network.yml
@@ -6,5 +6,13 @@
 - include_role:
     name: os_migrate.os_migrate.export_networks
 
-# TODO: once the module actually writes the file, we should read and
-# verify it here.
+- name: load exported data
+  set_fact:
+    resources: "{{ (lookup('file', os_migrate_data_dir + '/networks.yml') | from_yaml)
+                   ['resources'] }}"
+
+- name: verify data contents
+  assert:
+    that:
+      - (resources | json_query("[?params.name == 'osm_net'].params.description")
+        == ['osm_net test network'])

--- a/tests/func/seed/network.yml
+++ b/tests/func/seed/network.yml
@@ -4,9 +4,11 @@
 #   os_network:
 #     cloud: "{{ os_migrate_src_cloud }}"
 #     name: osm_net
+#     description: osm_net test network
 #     state: present
 - name: workaround - create osm_net via CLI
   shell: |
     openstack network create \
         --os-cloud "{{ os_migrate_src_cloud }}" \
+        --description "osm_net test network" \
         osm_net


### PR DESCRIPTION
This adds serialization and resource file read/write basics, and adds
rudimentary network exporting.

We may further think whether using some classes for our structures
makes sense, or if just plain dict/list structures are good enough (my
initial approach in this commit). Given that Python is a dynamic
language, we won't get any compile time validation even if we do add
classes/structures for the data, and any errors will pop up at runtime
either way. This already manifested in dealing with the openstacksdk's
Network class -- even though it's a class, it didn't feel like we're
getting many benefits from it over a plain dict, it is very free-form,
see serialization method in network.py.