### PR TITLE
Fix filesystem ownership in CI

### DIFF
--- a/.github/workflows/devstack.yml
+++ b/.github/workflows/devstack.yml
@@ -47,6 +47,13 @@ jobs:
     - name: Clone devstack
       run: |
         git clone https://opendev.org/openstack/devstack
+    # We're hitting filesystem ownership issue on some GH Actions workers:
+    # https://ubuntuforums.org/showthread.php?t=2406453
+    - name: Make sure filesystem ownership is correct
+      run: |
+        set -x
+        sudo chown root:root /
+        sudo chown root:root /bin
     - name: Install devstack
       run: |
         cd devstack


### PR DESCRIPTION
We were hitting weird issues in filesystem ownership [1] which failed
devstack install. Making sure the ownership is correct seems to fix
the problems.

[1] https://ubuntuforums.org/showthread.php?t=2406453