### PR TITLE
Resource file reading and networks import

### DIFF
--- a/os_migrate/playbooks/import_networks.yml
+++ b/os_migrate/playbooks/import_networks.yml
@@ -1,0 +1,3 @@
+- hosts: migrator
+  roles:
+    - os_migrate.os_migrate.import_networks

--- a/os_migrate/plugins/module_utils/exc.py
+++ b/os_migrate/plugins/module_utils/exc.py
@@ -1,0 +1,12 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class UnexpectedResourceType(Exception):
+    """Unexpected resource type."""
+
+    msg_format = "Expected resource type '{}' but got '{}'."
+
+    def __init__(self, expected_type, got_type):
+        message = self.msg_format.format(expected_type, got_type)
+        super(UnexpectedResourceType, self).__init__(message)

--- a/os_migrate/plugins/module_utils/filesystem.py
+++ b/os_migrate/plugins/module_utils/filesystem.py
@@ -10,7 +10,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import seria
 
 def write_or_replace_resource(file_path, resource):
     if path.exists(file_path):
-        file_struct = _load_resources_file(file_path)
+        file_struct = load_resources_file(file_path)
     else:
         file_struct = serialization.new_resources_file_struct()
 
@@ -24,7 +24,7 @@ def write_or_replace_resource(file_path, resource):
     return True
 
 
-def _load_resources_file(file_path):
+def load_resources_file(file_path):
     with open(file_path, 'r') as f:
         file_struct = yaml.load(f)
     return file_struct

--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -2,6 +2,11 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.serialization \
+    import set_sdk_params_same_name
+
+
 def serialize_network(network):
     resource = {}
     params = {}
@@ -11,7 +16,6 @@ def serialize_network(network):
     resource['type'] = 'openstack.network'
 
     params['availability_zone_hints'] = network['availability_zone_hints']
-    params['availability_zones'] = network['availability_zones']
     params['description'] = network['description']
     params['dns_domain'] = network.get('dns_domain', None)
     params['is_admin_state_up'] = network.get(
@@ -29,11 +33,12 @@ def serialize_network(network):
     params['provider_physical_network'] = network.get('provider_physical_network', None)
     params['provider_segmentation_id'] = network.get('provider_segmentation_id', None)
     params['qos_policy_id'] = network.get('qos_policy_id', None)
-    params['revision_number'] = network['revision_number']
     params['segments'] = network.get('segments', None)
 
+    info['availability_zones'] = network['availability_zones']
     info['created_at'] = network['created_at']
     info['project_id'] = network['project_id']
+    info['revision_number'] = network['revision_number']
     info['status'] = network['status']
     info['subnet_ids'] = network.get(
         'subnets', network.get('subnet_ids', None))
@@ -45,3 +50,33 @@ def serialize_network(network):
     #     info['subnet_names']
 
     return resource
+
+
+def network_sdk_params(serialized):
+    res_type = serialized.get('type', None)
+    if res_type != 'openstack.network':
+        raise exc.UnexpectedResourceType('openstack.network', res_type)
+
+    ser_params = serialized['params']
+    sdk_params = {}
+
+    set_sdk_params_same_name(ser_params, sdk_params, [
+        'availability_zone_hints',
+        'description',
+        'dns_domain',
+        'is_admin_state_up',
+        'is_default',
+        'is_port_security_enabled',
+        'is_router_external',
+        'is_shared',
+        'is_vlan_transparent',
+        'mtu',
+        'name',
+        'provider_network_type',
+        'provider_physical_network',
+        'provider_segmentation_id',
+        'qos_policy_id',
+        'segments',
+    ])
+
+    return sdk_params

--- a/os_migrate/plugins/module_utils/serialization.py
+++ b/os_migrate/plugins/module_utils/serialization.py
@@ -31,3 +31,13 @@ def is_same_resource(res1, res2):
     # but it's not necessary for now.
     return (res1.get('params', {}).get('name', '__undefined1__') ==
             res2.get('params', {}).get('name', '__undefined1__'))
+
+
+def set_sdk_param(ser_params, ser_key, sdk_params, sdk_key):
+    if ser_params.get(ser_key, None) is not None:
+        sdk_params[sdk_key] = ser_params[ser_key]
+
+
+def set_sdk_params_same_name(ser_params, sdk_params, param_names):
+    for p_name in param_names:
+        set_sdk_param(ser_params, p_name, sdk_params, p_name)

--- a/os_migrate/plugins/modules/import_network.py
+++ b/os_migrate/plugins/modules/import_network.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: os_migrate.os_migrate.import_network
+
+short_description: Import OpenStack network
+
+version_added: "2.9"
+
+description:
+  - "Import OpenStack network from an OS-Migrate YAML structure"
+
+options:
+  cloud:
+    description:
+      - Named cloud to operate against.
+    required: true
+  data:
+    description:
+      - Data structure with network parameters as loaded from OS-Migrate YAML file.
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Import mynetwork into /opt/os-migrate/networks.yml
+  os_migrate.os_migrate.import_network:
+    cloud: source_cloud
+    data:
+      - type: openstack.network
+        params:
+          name: my_net
+'''
+
+RETURN = '''
+'''
+
+import openstack
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import network
+
+
+def run_module():
+    module_args = dict(
+        cloud=dict(type='str', required=True),
+        data=dict(type='dict', required=True),
+    )
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        # TODO: Consider check mode. We'd fetch the resource and check
+        # if the file representation matches it.
+        # supports_check_mode=True,
+    )
+
+    conn = openstack.connect(cloud=module.params['cloud'])
+    net_params = network.network_sdk_params(module.params['data'])
+    if conn.network.find_network(net_params['name']):
+        conn.network.update_network(net_params['name'], **net_params)
+        result['changed'] = True
+    else:
+        conn.network.create_network(**net_params)
+        result['changed'] = True
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/read_resources.py
+++ b/os_migrate/plugins/modules/read_resources.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: os_migrate.os_migrate.read_resources
+
+short_description: Import OpenStack network
+
+version_added: "2.9"
+
+description:
+  - "Read an OS-Migrate YAML resources file structure"
+
+options:
+  path:
+    description:
+      - Resources YAML file to read.
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Read resources from /opt/os-migrate/networks.yml
+  os_migrate.os_migrate.read_resources:
+    path: /opt/os-migrate/networks.yml
+  register: read_networks
+
+- name: Debug-print resources
+  debug:
+    msg: "{{ read_networks.resources }}"
+'''
+
+RETURN = '''
+resources:
+    description: List of resources deserialized from YAML file
+    returned: success
+    type: complex
+    contains:
+        type:
+            description: Type of the resource.
+            returned: success
+            type: str
+        params:
+            description: Resource parameters important for import.
+            returned: success
+            type: complex
+        info:
+            description: Additional resource information, not needed for import.
+            returned: success
+            type: complex
+'''
+
+import openstack
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import filesystem
+
+
+def run_module():
+    module_args = dict(
+        path=dict(type='str', required=True),
+    )
+
+    result = dict(
+        # This module doesn't change anything.
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        # Module doesn't change anything, we can let it run as-is in
+        # check mode.
+        supports_check_mode=True,
+    )
+
+    struct = filesystem.load_resources_file(module.params['path'])
+    result['resources'] = struct['resources']
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/roles/import_networks/tasks/main.yml
+++ b/os_migrate/roles/import_networks/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: read networks resource file
+  os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/networks.yml"
+  register: read_networks
+
+- name: import networks
+  os_migrate.os_migrate.import_network:
+    cloud: "{{ os_migrate_dst_cloud }}"
+    data: "{{ item }}"
+  loop: "{{ read_networks.resources }}"

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -23,7 +23,7 @@ def minimal_resource_file_struct():
     }
 
 
-def network():
+def sdk_network():
     return openstack.network.v2.network.Network(
         availability_zone_hints=['nova', 'zone2'],
         availability_zones=['nova', 'zone3'],
@@ -51,3 +51,36 @@ def network():
         updated_at='2020-01-06T15:51:00Z',
         is_vlan_transparent=False,
     )
+
+
+def serialized_network():
+    return {
+        'params': {
+            'availability_zone_hints': ['nova', 'zone2'],
+            'description': 'test network',
+            'dns_domain': 'example.org',
+            'is_admin_state_up': True,
+            'is_default': False,
+            'is_port_security_enabled': True,
+            'is_router_external': False,
+            'is_shared': False,
+            'is_vlan_transparent': False,
+            'mtu': 1400,
+            'name': 'test-net',
+            'provider_network_type': 'vxlan',
+            'provider_physical_network': 'physnet',
+            'provider_segmentation_id': '456',
+            'qos_policy_id': 'uuid-test-qos-policy',
+            'segments': [],
+        },
+        'info': {
+            'availability_zones': ['nova', 'zone3'],
+            'created_at': '2020-01-06T15:50:55Z',
+            'project_id': 'uuid-test-project',
+            'revision_number': 3,
+            'status': 'ACTIVE',
+            'subnet_ids': ['uuid-test-subnet1', 'uuid-test-subnet2'],
+            'updated_at': '2020-01-06T15:51:00Z',
+        },
+        'type': 'openstack.network',
+    }

--- a/os_migrate/tests/unit/test_filesystem.py
+++ b/os_migrate/tests/unit/test_filesystem.py
@@ -18,7 +18,7 @@ class TestFilesystem(unittest.TestCase):
             filesystem.write_or_replace_resource(
                 file_path, fixtures.minimal_resource())
 
-            file_struct = filesystem._load_resources_file(file_path)
+            file_struct = filesystem.load_resources_file(file_path)
             resource = file_struct['resources'][0]
             self.assertEqual(resource['type'], 'openstack.minimal')
             self.assertEqual(resource['params']['name'], 'minimal')
@@ -36,7 +36,7 @@ class TestFilesystem(unittest.TestCase):
             minimal2['params']['description'] = 'minimal two'
             filesystem.write_or_replace_resource(file_path, minimal2)
 
-            file_struct = filesystem._load_resources_file(file_path)
+            file_struct = filesystem.load_resources_file(file_path)
             resource0 = file_struct['resources'][0]
             resource1 = file_struct['resources'][1]
             self.assertEqual(resource0['type'], 'openstack.minimal')

--- a/os_migrate/tests/unit/test_network.py
+++ b/os_migrate/tests/unit/test_network.py
@@ -11,15 +11,13 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
 class TestNetwork(unittest.TestCase):
 
     def test_serialize_network(self):
-        net = fixtures.network()
+        net = fixtures.sdk_network()
         serialized = network.serialize_network(net)
         s_params = serialized['params']
         s_info = serialized['info']
 
         self.assertEqual(serialized['type'], 'openstack.network')
-        self.assertEqual(s_params['name'], 'test-net')
         self.assertEqual(s_params['availability_zone_hints'], ['nova', 'zone2'])
-        self.assertEqual(s_params['availability_zones'], ['nova', 'zone3'])
         self.assertEqual(s_params['description'], 'test network')
         self.assertEqual(s_params['dns_domain'], 'example.org')
         self.assertEqual(s_params['is_admin_state_up'], True)
@@ -34,11 +32,36 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual(s_params['provider_physical_network'], 'physnet')
         self.assertEqual(s_params['provider_segmentation_id'], '456')
         self.assertEqual(s_params['qos_policy_id'], 'uuid-test-qos-policy')
-        self.assertEqual(s_params['revision_number'], 3)
         self.assertEqual(s_params['segments'], [])
 
+        self.assertEqual(s_info['availability_zones'], ['nova', 'zone3'])
         self.assertEqual(s_info['created_at'], '2020-01-06T15:50:55Z')
         self.assertEqual(s_info['project_id'], 'uuid-test-project')
+        self.assertEqual(s_info['revision_number'], 3)
         self.assertEqual(s_info['status'], 'ACTIVE')
         self.assertEqual(s_info['subnet_ids'], ['uuid-test-subnet1', 'uuid-test-subnet2'])
         self.assertEqual(s_info['updated_at'], '2020-01-06T15:51:00Z')
+
+    def test_network_sdk_params(self):
+        ser_net = fixtures.serialized_network()
+        sdk_params = network.network_sdk_params(ser_net)
+
+        self.assertEqual(sdk_params['availability_zone_hints'], ['nova', 'zone2'])
+        self.assertEqual(sdk_params['description'], 'test network')
+        self.assertEqual(sdk_params['dns_domain'], 'example.org')
+        self.assertEqual(sdk_params['is_admin_state_up'], True)
+        self.assertEqual(sdk_params['is_default'], False)
+        self.assertEqual(sdk_params['is_port_security_enabled'], True)
+        self.assertEqual(sdk_params['is_router_external'], False)
+        self.assertEqual(sdk_params['is_shared'], False)
+        self.assertEqual(sdk_params['is_vlan_transparent'], False)
+        self.assertEqual(sdk_params['mtu'], 1400)
+        self.assertEqual(sdk_params['name'], 'test-net')
+        self.assertEqual(sdk_params['provider_network_type'], 'vxlan')
+        self.assertEqual(sdk_params['provider_physical_network'], 'physnet')
+        self.assertEqual(sdk_params['provider_segmentation_id'], '456')
+        self.assertEqual(sdk_params['qos_policy_id'], 'uuid-test-qos-policy')
+        self.assertEqual(sdk_params['segments'], [])
+        # disallowed params when creating a network
+        self.assertNotIn('availability_zones', sdk_params)
+        self.assertNotIn('revision_number', sdk_params)

--- a/os_migrate/tests/unit/test_serialization.py
+++ b/os_migrate/tests/unit/test_serialization.py
@@ -66,3 +66,20 @@ class TestSerialization(unittest.TestCase):
                 'params': {'name': 'three', 'description': 'three'},
             },
         ])
+
+    def test_set_sdk_param(self):
+        ser_params = {'a': 'b', 'c': 'd', 'e': 'f'}
+        sdk_params = {'g': 'h'}
+        serialization.set_sdk_param(ser_params, 'a', sdk_params, 'a')
+        self.assertEqual(sdk_params, {'a': 'b', 'g': 'h'})
+        serialization.set_sdk_param(ser_params, 'z', sdk_params, 'z')
+        self.assertEqual(sdk_params, {'a': 'b', 'g': 'h'})
+        serialization.set_sdk_param(ser_params, 'c', sdk_params, 'e')
+        self.assertEqual(sdk_params, {'a': 'b', 'g': 'h', 'e': 'd'})
+
+    def test_set_sdk_params_same_name(self):
+        ser_params = {'a': 'b', 'c': 'd', 'e': 'f'}
+        sdk_params = {'g': 'h'}
+        serialization.set_sdk_params_same_name(
+            ser_params, sdk_params, ['a', 'e', 'z'])
+        self.assertEqual(sdk_params, {'a': 'b', 'g': 'h', 'e': 'f'})

--- a/tests/func/run/network.yml
+++ b/tests/func/run/network.yml
@@ -16,3 +16,22 @@
     that:
       - (resources | json_query("[?params.name == 'osm_net'].params.description")
         == ['osm_net test network'])
+
+# FIXME: replace this with nice filtering on export, then delete this whole block
+# https://github.com/os-migrate/os-migrate/issues/22
+- name: ugly rewrite of resource file to only contain osm_net
+  block:
+    - set_fact:
+        file_struct: "{{ (lookup('file', os_migrate_data_dir + '/networks.yml') | from_yaml) }}"
+
+    - set_fact:
+        new_file_struct:
+          os_migrate_version: "{{ file_struct['os_migrate_version'] }}"
+          resources: "{{ file_struct['resources'] | json_query(\"[?params.name == 'osm_net']\") }}"
+
+    - copy:
+        dest: "{{ os_migrate_data_dir }}/networks.yml"
+        content: "{{ new_file_struct | to_nice_yaml }}"
+
+- include_role:
+    name: os_migrate.os_migrate.import_networks

--- a/toolbox/build/venv-requirements.txt
+++ b/toolbox/build/venv-requirements.txt
@@ -1,6 +1,8 @@
+# runtime
 ansible>=2.9.1,<2.10
 openstacksdk>=0.39.0
 
+# test
 pylint>=2.4.0
 pytest-xdist>=1.30.0
 pycodestyle>=2.5.0


### PR DESCRIPTION
The import_networks playbook and role, and import_network module are
for importing networks specifically.

The read_resources module is meant for all importing in general. It
loads the resource YAML file structure into an Ansible variable so
that individual resources can be iterated on inside the roles.

Small deserialization utility functions are added too, for
transforming serialized data into parameters for OpenStack SDK when
creating/updating resources.

There is a block in functional tests that isn't very nice but it can
be fully removed once we implement name-based filtering on export:

https://github.com/os-migrate/os-migrate/issues/22

The PR closes #14.