### PR TITLE
Read version information from collection's manifest

### DIFF
--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -1,1 +1,19 @@
-OS_MIGRATE_VERSION = '0.1.0'  # can we get this from metadata somehow?
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+from os import path
+
+
+class Manifest():
+
+    manifest = None
+
+    def __init__(self):
+        if not self.manifest:
+            with open(path.join(
+                    path.dirname(__file__), '..', '..', 'MANIFEST.json')) as f:
+                self.manifest = json.load(f)
+
+    def os_migrate_version(self):
+        return self.manifest['collection_info']['version']

--- a/os_migrate/plugins/module_utils/serialization.py
+++ b/os_migrate/plugins/module_utils/serialization.py
@@ -6,7 +6,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 
 def new_resources_file_struct():
     data = {}
-    data['os_migrate_version'] = const.OS_MIGRATE_VERSION
+    data['os_migrate_version'] = const.Manifest().os_migrate_version()
     data['resources'] = []
     return data
 

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -18,7 +18,7 @@ def minimal_resource():
 
 def minimal_resource_file_struct():
     return {
-        'os_migrate_version': const.OS_MIGRATE_VERSION,
+        'os_migrate_version': const.Manifest().os_migrate_version(),
         'resources': [minimal_resource()],
     }
 


### PR DESCRIPTION
We had 2 sources of version information: MANIFEST.json (compiled from
galaxy.yml) and const.py. Now const.py loads the manifest, so
galaxy.yml is the single source of truth in the codebase for version
information. This prevents const.py from getting out of sync with
galaxy.yml.

Closes #12