### PR TITLE
Update version in const.py based on galaxy.yml when building the collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,7 @@ unlink-latest:
 	rm os_migrate-os_migrate-latest.tar.gz || true
 
 os_migrate-os_migrate-latest.tar.gz:
-	set -euo pipefail; \
-	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
-		source /root/venv/bin/activate; \
-	fi; \
-	ansible-galaxy collection build --force os_migrate; \
-	LATEST=$$(ls os_migrate-os_migrate*.tar.gz | grep -v latest | sort -V | tail -n1); \
-	ln -sf $$LATEST os_migrate-os_migrate-latest.tar.gz
+	./scripts/build.sh
 
 
 # TESTS

--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -1,1 +1,1 @@
-OS_MIGRATE_VERSION = '0.1.0'  # can we get this from metadata somehow?
+OS_MIGRATE_VERSION = '0.1.0'  # updated by build.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z "$${VIRTUAL_ENV:-}" ]; then
+    source /root/venv/bin/activate
+fi
+set -euxo pipefail
+
+# update version in const.py based on galaxy.yml
+VERSION=$(grep '^version: ' os_migrate/galaxy.yml | awk '{print $2}')
+sed -i -e "s/^OS_MIGRATE_VERSION = .*$/OS_MIGRATE_VERSION = '$VERSION'  # updated by build.sh/" \
+    os_migrate/plugins/module_utils/const.py
+
+ansible-galaxy collection build --force os_migrate
+LATEST=$(ls os_migrate-os_migrate*.tar.gz | grep -v latest | sort -V | tail -n1)
+ln -sf $LATEST os_migrate-os_migrate-latest.tar.gz


### PR DESCRIPTION
Initially i wanted to just load the collection manifest from const.py,
but it's not possible, more details at [1].

Our next best shot is probably to auto-update const.py constant
OS_MIGRATE_VERSION each time we build the collection, which is what
this commit implements.

[1] https://github.com/os-migrate/os-migrate/pull/28

Closes #12