### PR TITLE
Import idempotence

### DIFF
--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -76,3 +76,9 @@ def network_sdk_params(serialized):
     ])
 
     return sdk_params
+
+
+def network_needs_update(sdk_network, target_serialized_state):
+    current_params = serialize_network(sdk_network)['params']
+    target_params = target_serialized_state['params']
+    return current_params != target_params

--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import openstack
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils.serialization \
@@ -8,6 +9,10 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils.serializatio
 
 
 def serialize_network(network):
+    expected_type = openstack.network.v2.network.Network
+    if type(network) != expected_type:
+        raise exc.UnexpectedResourceType(expected_type, type(network))
+
     resource = {}
     params = {}
     info = {}

--- a/os_migrate/plugins/modules/import_network.py
+++ b/os_migrate/plugins/modules/import_network.py
@@ -69,9 +69,13 @@ def run_module():
 
     conn = openstack.connect(cloud=module.params['cloud'])
     net_params = network.network_sdk_params(module.params['data'])
-    if conn.network.find_network(net_params['name']):
-        conn.network.update_network(net_params['name'], **net_params)
-        result['changed'] = True
+    existing_network = conn.network.find_network(net_params['name'])
+    if existing_network:
+        if network.network_needs_update(
+                existing_network, module.params['data']):
+            conn.network.update_network(net_params['name'], **net_params)
+            result['changed'] = True
+        # else: pass -- nothing to update
     else:
         conn.network.create_network(**net_params)
         result['changed'] = True

--- a/os_migrate/tests/unit/test_network.py
+++ b/os_migrate/tests/unit/test_network.py
@@ -65,3 +65,15 @@ class TestNetwork(unittest.TestCase):
         # disallowed params when creating a network
         self.assertNotIn('availability_zones', sdk_params)
         self.assertNotIn('revision_number', sdk_params)
+
+    def test_network_needs_update(self):
+        sdk_net = fixtures.sdk_network()
+        serialized = network.serialize_network(sdk_net)
+
+        self.assertFalse(network.network_needs_update(sdk_net, serialized))
+
+        serialized['info']['id'] = 'different id'
+        self.assertFalse(network.network_needs_update(sdk_net, serialized))
+
+        serialized['params']['description'] = 'updated description'
+        self.assertTrue(network.network_needs_update(sdk_net, serialized))

--- a/tests/func/idempotence/network.yml
+++ b/tests/func/idempotence/network.yml
@@ -1,3 +1,42 @@
+### IMPORT IDEMPOTENCE ###
+
+# Testing import idempotency first, because until
+# https://github.com/os-migrate/os-migrate/issues/22 is implemented,
+# the export is only fully idempotent w/r/t osm_net, not the other
+# networks. For import idempotency test, we still want to use the
+# "hacked" resource YAML from:
+# https://github.com/os-migrate/os-migrate/pull/23/commits/eae2ec721336b18f5119df80fb82343bce306746#diff-4118187bf0e50204179ea9267d71c2a6R20-R21
+- name: look up osm_net dst cloud
+  os_networks_info:
+    cloud: "{{ os_migrate_dst_cloud }}"
+    filters:
+      name: osm_net
+  register: network_import_idem_before
+
+- include_role:
+    name: os_migrate.os_migrate.import_networks
+
+- name: look up osm_net in dst cloud again
+  os_networks_info:
+    cloud: "{{ os_migrate_dst_cloud }}"
+    filters:
+      name: osm_net
+  register: network_import_idem_after
+
+- name: ensure updated_at for osm_net did not change
+  assert:
+    that:
+      - network_import_idem_before['openstack_networks'][0].updated_at != None
+      - "network_import_idem_before['openstack_networks'][0]['updated_at'] \
+         == network_import_idem_after['openstack_networks'][0]['updated_at']"
+    fail_msg: |
+      network_import_idem_before updated_at:
+      {{ network_import_idem_before['openstack_networks'][0].updated_at }}
+      network_import_idem_after updated_at:
+      {{ network_import_idem_after['openstack_networks'][0].updated_at }}
+
+### EXPORT IDEMPOTENCE ###
+
 - include_role:
     name: os_migrate.os_migrate.export_networks
 


### PR DESCRIPTION
Depends on PRs #23, #27, #31 

For idempotence of imports we largely have all the pieces, all that
needs to be done is to serialize the existing network into our format
and compare if the resulting 'params' are the same as the ones
provided to the import_network module.

Crucial is looking at 'params' only and not 'info', as 'params'
contain the important network parameters that are meant to be
migrated, while 'info' contains non-migratable info, e.g. the
network's UUID.