### PR TITLE
Use tags in functional tests instead of separate playbooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-FUNC_TEST_PLAYBOOK ?= all
+FUNC_TEST_ARGS ?=
 
 
 # ANSIBLE COLLECTION
@@ -52,7 +52,7 @@ test-func: reinstall
 		-e os_migrate_src_cloud=testsrc \
 		-e os_migrate_dst_cloud=testdst \
 		-e os_migrate_data_dir=$(ROOT_DIR)/tests/func/tmpdata \
-		test_$(FUNC_TEST_PLAYBOOK).yml
+		$(FUNC_TEST_ARGS) test_all.yml
 
 test-fast: test-sanity test-unit
 

--- a/tests/func/clean/all.yml
+++ b/tests/func/clean/all.yml
@@ -1,1 +1,5 @@
-- import_tasks: network.yml
+- include_tasks:
+    file: network.yml
+    apply:
+      tags:
+        - test_network

--- a/tests/func/global/prep.yml
+++ b/tests/func/global/prep.yml
@@ -3,8 +3,14 @@
   file:
     path: "{{ os_migrate_data_dir }}"
     state: absent
+  tags:
+    - always
+    - test_prep
 
 - name: create os_migrate_data_dir
   file:
     path: "{{ os_migrate_data_dir }}"
     state: directory
+  tags:
+    - always
+    - test_prep

--- a/tests/func/idempotence/all.yml
+++ b/tests/func/idempotence/all.yml
@@ -1,1 +1,5 @@
-- import_tasks: network.yml
+- include_tasks:
+    file: network.yml
+    apply:
+      tags:
+        - test_network

--- a/tests/func/run/all.yml
+++ b/tests/func/run/all.yml
@@ -1,1 +1,5 @@
-- import_tasks: network.yml
+- include_tasks:
+    file: network.yml
+    apply:
+      tags:
+        - test_network

--- a/tests/func/seed/all.yml
+++ b/tests/func/seed/all.yml
@@ -1,1 +1,5 @@
-- import_tasks: network.yml
+- include_tasks:
+    file: network.yml
+    apply:
+      tags:
+        - test_network

--- a/tests/func/test_network.yml
+++ b/tests/func/test_network.yml
@@ -1,9 +1,0 @@
-- name: Migration
-  hosts: migrator
-  tasks:
-    - import_tasks: global/prep.yml
-    - import_tasks: clean/network.yml
-    - import_tasks: seed/network.yml
-    - import_tasks: run/network.yml
-    - import_tasks: idempotence/network.yml
-    - import_tasks: clean/network.yml


### PR DESCRIPTION
To run subset of functional tests, the current pattern was to create a
full playbook which would only include the desired parts.

An alternative pattern might be to use --skip-tags or --tags with the
test_all.yml playbook. This might allow better mix-and-match execution
for particular test environments and developer scenarios.

Due to env vars not being automatically passed into the toolbox
container, currently there are two ways to test this approach e.g. by
skipping the network tests:

    ./toolbox/shell
    FUNC_TEST_ARGS='--skip-tags test_network' make test-func

and

    ./toolbox/run bash -c "FUNC_TEST_ARGS='--skip-tags test_network' make test-func"

The 2nd case perhaps deserves some improvement (list of env vars we
want to detect and pass into toolbox container automatically?) but
that's beyond the scope of this commit.