### PR TITLE
Make sure toolbox container RPMs are up-to-date when building

### DIFF
--- a/toolbox/build/build.sh
+++ b/toolbox/build/build.sh
@@ -8,6 +8,7 @@ OS_MIGRATE_DIR=$(realpath "$DIR/../..")
 ### PACKAGES ###
 
 dnf clean all
+dnf -y update
 dnf -y install ansible gcc make python3-devel python3-openstackclient jq shyaml
 # This below packages are for vagrant-libvirt and take a lot of deps,
 # comment out if you run vagrant from host rather than from container.


### PR DESCRIPTION
We install a bunch of (latest) RPMs but until now we didn't update the
others. This could result in a mixture of RPMs that has never been
tested together in Fedora. Let's update packages before installing
additional ones.