### PR TITLE
Fix checker of resource sameness, add tests for it

### DIFF
--- a/os_migrate/plugins/module_utils/serialization.py
+++ b/os_migrate/plugins/module_utils/serialization.py
@@ -48,7 +48,7 @@ def is_same_resource(res1, res2):
     # ['params']['name'] should be the deciding factors for sameness,
     # but it's not necessary for now.
     return (res1.get(const.RES_PARAMS, {}).get('name', '__undefined1__') ==
-            res2.get(const.RES_PARAMS, {}).get('name', '__undefined1__'))
+            res2.get(const.RES_PARAMS, {}).get('name', '__undefined2__'))
 
 
 def resource_needs_update(current, target):

--- a/os_migrate/tests/unit/test_serialization.py
+++ b/os_migrate/tests/unit/test_serialization.py
@@ -133,6 +133,36 @@ class TestSerialization(unittest.TestCase):
             = 'openstack.UpdatedType'
         self.assertTrue(serialization.resource_needs_update(current, target))
 
+    def test_is_same_resource(self):
+        r1 = fixtures.minimal_resource()
+        r2 = fixtures.minimal_resource()
+        self.assertTrue(serialization.is_same_resource(r1, r2))
+
+        r2['params']['description'] = 'different description'
+        self.assertTrue(serialization.is_same_resource(r1, r2))
+
+        r2['params']['name'] = 'different-name'
+        self.assertFalse(serialization.is_same_resource(r1, r2))
+
+        # reset to sameness
+        r1 = fixtures.minimal_resource()
+        r2 = fixtures.minimal_resource()
+
+        r2['type'] = 'different.type'
+        self.assertFalse(serialization.is_same_resource(r1, r2))
+
+        del r1['type']
+        del r2['type']
+        self.assertFalse(serialization.is_same_resource(r1, r2))
+
+        # reset to sameness
+        r1 = fixtures.minimal_resource()
+        r2 = fixtures.minimal_resource()
+
+        del r1['params']['name']
+        del r2['params']['name']
+        self.assertFalse(serialization.is_same_resource(r1, r2))
+
     def test_set_sdk_param(self):
         ser_params = {'a': 'b', 'c': 'd', 'e': 'f'}
         sdk_params = {'g': 'h'}


### PR DESCRIPTION
When two resources have the same type but their names are undefined,
we should not consider them the same. This is now the case after a
copypasta typo is fixed, and tests are added to verify correct
behavior.