### PR TITLE
Document reusable module_utils functions and network functions

### DIFF
--- a/os_migrate/plugins/module_utils/filesystem.py
+++ b/os_migrate/plugins/module_utils/filesystem.py
@@ -9,6 +9,12 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import seria
 
 
 def write_or_replace_resource(file_path, resource):
+    """Add (or replace if already present) a `resource` into a resource
+    file at `file_path`. If the resource is already present *and* its
+    serialization is up to date, the file will not be modified.
+
+    Returns: True if the file was modified, False otherwise
+    """
     if path.exists(file_path):
         file_struct = load_resources_file(file_path)
     else:
@@ -24,11 +30,18 @@ def write_or_replace_resource(file_path, resource):
 
 
 def load_resources_file(file_path):
+    """Load resources file at `file_path`.
+
+    Returns: Structure (dict) of the loaded file.
+    """
     with open(file_path, 'r') as f:
         file_struct = yaml.load(f)
     return file_struct
 
 
 def _write_resources_file(file_path, file_struct):
+    """Write `file_struct` resources file structure into a file at
+    `file_path`.
+    """
     with open(file_path, 'w') as f:
         f.write(yaml.dump(file_struct))

--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -11,6 +11,11 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils.serializatio
 
 
 def serialize_network(sdk_net, net_refs):
+    """Serialize OpenStack SDK network `sdk_net` into OS-Migrate
+    format. Use `net_refs` for id-to-name mappings.
+
+    Returns: Dict - OS-Migrate structure for Network
+    """
     expected_type = openstack.network.v2.network.Network
     if type(sdk_net) != expected_type:
         raise exc.UnexpectedResourceType(expected_type, type(sdk_net))
@@ -58,6 +63,12 @@ def serialize_network(sdk_net, net_refs):
 
 
 def network_sdk_params(ser_net, net_refs):
+    """Create OpenStack SDK parameters dict for creation or update of the
+    OS-Migrate Network serialization `ser_net`. Use `net_refs` for
+    name-to-id mappings.
+
+    Returns: Parameters to be fed into `openstack.network.v2.network.Network`
+    """
     res_type = ser_net.get(const.RES_TYPE, None)
     if res_type != const.RES_TYPE_NETWORK:
         raise exc.UnexpectedResourceType(const.RES_TYPE_NETWORK, res_type)
@@ -90,12 +101,26 @@ def network_sdk_params(ser_net, net_refs):
 
 
 def network_needs_update(sdk_net, net_refs, target_ser_net):
+    """Having OpenStack SDK network `sdk_net` and corresponding id-name
+    mappings `net_refs`, decide if the network needs to be updated to
+    reach state represented in OS-Migrate Network serialization
+    `target_ser_net`.
+
+    Returns: True if network needs to be updated, False otherwise
+    """
     current_params = serialize_network(sdk_net, net_refs)[const.RES_PARAMS]
     target_params = target_ser_net[const.RES_PARAMS]
     return current_params != target_params
 
 
 def network_refs_from_sdk(conn, sdk_net):
+    """Create a dict of name/id mappings for resources referenced from
+    OpenStack SDK Network `sdk_net`. Fetch any necessary information
+    from OpenStack SDK connection `conn`.
+
+    Returns: dict with names and IDs of resources referenced from
+    `sdk_net` (only those important for OS-Migrate)
+    """
     expected_type = openstack.network.v2.network.Network
     if type(sdk_net) != expected_type:
         raise exc.UnexpectedResourceType(expected_type, type(sdk_net))
@@ -111,6 +136,13 @@ def network_refs_from_sdk(conn, sdk_net):
 
 
 def network_refs_from_ser(conn, ser_net):
+    """Create a dict of name/id mappings for resources referenced from
+    OS-Migrage network serialization `sdk_net`. Fetch any necessary
+    information from OpenStack SDK connection `conn`.
+
+    Returns: dict with names and IDs of resources referenced from
+    `sdk_net` (only those important for OS-Migrate)
+    """
     if ser_net[const.RES_TYPE] != const.RES_TYPE_NETWORK:
         raise exc.UnexpectedResourceType(
             const.RES_TYPE_NETWORK, ser_net[const.RES_TYPE])

--- a/os_migrate/plugins/module_utils/reference.py
+++ b/os_migrate/plugins/module_utils/reference.py
@@ -3,18 +3,48 @@ __metaclass__ = type
 
 
 def qos_policy_name(conn, id_, required=True):
+    """Fetch name of QoS Policy identified by ID `id_`. Use OpenStack SDK
+    connection `conn` to fetch the info. If `required`, ensure the
+    fetch is successful.
+
+    Returns: the name, or None if not found and not `required`
+
+    Raises: openstack's ResourceNotFound when `required` but not found
+    """
     return _fetch_name(conn.network.find_qos_policy, id_, required)
 
 
 def qos_policy_id(conn, name, required=True):
+    """Fetch ID of QoS Policy identified by name `name`. Use OpenStack SDK
+    connection `conn` to fetch the info. If `required`, ensure the
+    fetch is successful.
+
+    Returns: the ID, or None if not found and not `required`
+
+    Raises: openstack's ResourceNotFound when `required` but not found
+    """
     return _fetch_id(conn.network.find_qos_policy, name, required)
 
 
 def _fetch_name(get_method, id_, required=True):
+    """Use `get_method` to fetch an OpenStack SDK resource by `id_` and
+    return its name. If `required`, ensure the fetch is successful.
+
+    Returns: the ID, or None if not found and not `required`
+
+    Raises: openstack's ResourceNotFound when `required` but not found
+    """
     if id_ is not None:
         return get_method(id_, ignore_missing=not required)['name']
 
 
 def _fetch_id(get_method, name, required=True):
+    """Use `get_method` to fetch an OpenStack SDK resource by `name` and
+    return its ID. If `required`, ensure the fetch is successful.
+
+    Returns: the ID, or None if not found and not `required`
+
+    Raises: openstack's ResourceNotFound when `required` but not found
+    """
     if name is not None:
         return get_method(name, ignore_missing=not required)['id']

--- a/os_migrate/plugins/module_utils/serialization.py
+++ b/os_migrate/plugins/module_utils/serialization.py
@@ -5,14 +5,22 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 
 
 def new_resources_file_struct():
+    """Create an empty resources file data structure into which resources
+    can be added.
+    """
     data = {}
     data['os_migrate_version'] = const.OS_MIGRATE_VERSION
     data['resources'] = []
     return data
 
 
-# Edits resources_file_struct in place. Returns bool whether something changed.
 def add_or_replace_resource(resources, resource):
+    """Add a `resource` into `resources` struct, or replace it if already
+    present (check via is_same_resource). Edits `resources` in place.
+
+    Returns: True if something changed in resources structure, False
+    otherwise
+    """
     for i, r in enumerate(resources):
         if is_same_resource(r, resource):
             if r == resource:
@@ -27,6 +35,11 @@ def add_or_replace_resource(resources, resource):
 
 
 def is_same_resource(res1, res2):
+    """Check whether two `res1` and `res2` dicts represent the same
+    resource. Type and name are deciding factors.
+
+    Returns: True if same, False otherwise
+    """
     if res1.get(const.RES_TYPE, '__undefined1__') != res2.get(
             const.RES_TYPE, '__undefined2__'):
         return False
@@ -39,15 +52,25 @@ def is_same_resource(res1, res2):
 
 
 def set_sdk_param(ser_params, ser_key, sdk_params, sdk_key):
+    """Assign value from `ser_key` in `ser_params` dict as value for
+    `sdk_key` in `sdk_params`, but only if it isn't None.
+    """
     if ser_params.get(ser_key, None) is not None:
         sdk_params[sdk_key] = ser_params[ser_key]
 
 
 def set_sdk_params_same_name(ser_params, sdk_params, param_names):
+    """Copy values from `ser_params` into `sdk_params` for all keys in
+    `param_names` (list of strings), only for values in `ser_params`
+    which aren't None.
+    """
     for p_name in param_names:
         set_sdk_param(ser_params, p_name, sdk_params, p_name)
 
 
 def set_ser_params_same_name(ser_params, sdk_params, param_names):
+    """Copy values from `sdk_params` to `ser_params` for keys listed in
+    `param_names` (list of strings).
+    """
     for p_name in param_names:
         ser_params[p_name] = sdk_params[p_name]


### PR DESCRIPTION
Documents what our functions (especially the reusable ones that are
intended to be shared) should do.

Since Pydoc is a free-form format, i went for very simple way of
describing the functions, trying to maximize the information provided
per characters typed and limit rigid boilerplate. This should help us
be diligent about documenting the functions by making documentation
not much pain to write :).