### PR TITLE
Adding the export security groups

### DIFF
--- a/os_migrate/galaxy.yml
+++ b/os_migrate/galaxy.yml
@@ -18,6 +18,7 @@ readme: README.md
 # @nicks:irc/im.site#channel'
 authors:
 - Jiri Stransky <jistr@redhat.com>
+- Carlos Camacho <ccamacho@redhat.com>
 
 
 ### OPTIONAL but strongly recommended

--- a/os_migrate/playbooks/export_security_group_rules.yml
+++ b/os_migrate/playbooks/export_security_group_rules.yml
@@ -1,0 +1,3 @@
+- hosts: migrator
+  roles:
+    - os_migrate.os_migrate.export_security_group_rules

--- a/os_migrate/playbooks/export_security_groups.yml
+++ b/os_migrate/playbooks/export_security_groups.yml
@@ -1,0 +1,3 @@
+- hosts: migrator
+  roles:
+    - os_migrate.os_migrate.export_security_groups

--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -1,7 +1,11 @@
 OS_MIGRATE_VERSION = '0.1.0'  # updated by build.sh
 
+# Main serialization sections
 RES_PARAMS = 'params'
 RES_TYPE = 'type'
 RES_INFO = '_info'
 
+# Supported resource types
 RES_TYPE_NETWORK = 'openstack.network.Network'
+RES_TYPE_SECURITYGROUPRULE = 'openstack.network.SecurityGroupRule'
+RES_TYPE_SECURITYGROUP = 'openstack.network.SecurityGroup'

--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -157,3 +157,133 @@ def network_refs_from_ser(conn, ser_net):
         conn, ser_params['qos_policy_name'])
 
     return refs
+
+
+def serialize_security_group_rule(sdk_sec_rule):
+    """Serialize OpenStack SDK security group rule
+    `sdk_sec_rule` into OS-Migrate format.
+
+    Returns: Dict - OS-Migrate structure for Security group rule.
+    """
+    expected_type = openstack.network.v2.security_group_rule.SecurityGroupRule
+    if type(sdk_sec_rule) != expected_type:
+        raise exc.UnexpectedResourceType(expected_type, type(sdk_sec_rule))
+
+    resource = {}
+    params = {}
+    info = {}
+    sdk_params = {}
+
+    resource[const.RES_PARAMS] = params
+    resource[const.RES_INFO] = info
+    resource[const.RES_TYPE] = const.RES_TYPE_SECURITYGROUPRULE
+
+    params['tags'] = sorted(sdk_sec_rule['tags'])
+
+    # Decide which attrs are param and which are info
+    set_ser_params_same_name(info, sdk_sec_rule, [
+        'id',
+        'security_group_id',
+        'remote_group_id',
+        'project_id',
+        'created_at',
+        'updated_at',
+        'revision_number',
+    ])
+
+    # FIXME: missing remote_group_name and security_group_name
+    set_ser_params_same_name(params, sdk_sec_rule, [
+        'description',
+        'direction',
+        'port_range_max',
+        'port_range_min',
+        'protocol',
+        'remote_ip_prefix',
+    ])
+
+    return resource
+
+
+def serialize_security_group(sdk_sec):
+    """Serialize OpenStack SDK security group `sdk_sec`
+    into OS-Migrate format.
+
+    Returns: Dict - OS-Migrate structure for Security group.
+    """
+    expected_type = openstack.network.v2.security_group.SecurityGroup
+    if type(sdk_sec) != expected_type:
+        raise exc.UnexpectedResourceType(expected_type, type(sdk_sec))
+
+    resource = {}
+    params = {}
+    info = {}
+    sdk_params = {}
+
+    resource[const.RES_PARAMS] = params
+    resource[const.RES_INFO] = info
+    resource[const.RES_TYPE] = const.RES_TYPE_SECURITYGROUP
+    params['tags'] = sorted(sdk_sec['tags'])
+
+    # Decide which attrs are param and which are info
+    set_ser_params_same_name(info, sdk_sec, [
+        'id',
+        'project_id',
+        'created_at',
+        'updated_at',
+        'revision_number',
+    ])
+
+    set_ser_params_same_name(params, sdk_sec, [
+        'name',
+        'description',
+    ])
+
+    return resource
+
+
+def security_group_sdk_params(ser_sec):
+    """Create OpenStack SDK parameters dict for creation or update of the
+    OS-Migrate Security groups `ser_sec`.
+
+    Returns: Parameters to be fed into `openstack.network.v2.security_group.SecurityGroup`
+    """
+    res_type = ser_sec.get(const.RES_TYPE, None)
+    if res_type != const.RES_TYPE_SECURITYGROUP:
+        raise exc.UnexpectedResourceType(const.RES_TYPE_SECURITYGROUP, res_type)
+
+    ser_params = ser_sec[const.RES_PARAMS]
+    sdk_params = {}
+
+    set_sdk_params_same_name(ser_params, sdk_params, [
+        'description',
+        'name',
+    ])
+
+    return sdk_params
+
+
+def security_group_rule_sdk_params(ser_sec_rule):
+    """Create OpenStack SDK parameters dict for creation or update of the
+    OS-Migrate Security group rules `ser_sec_rule`.
+
+    Returns: Parameters to be fed into `openstack.network.v2.security_group_rule.SecurityGroupRule`
+    """
+    res_type = ser_sec_rule.get(const.RES_TYPE, None)
+    if res_type != const.RES_TYPE_SECURITYGROUPRULE:
+        raise exc.UnexpectedResourceType(const.RES_TYPE_SECURITYGROUPRULE, res_type)
+
+    ser_params = ser_sec_rule[const.RES_PARAMS]
+    sdk_params = {}
+
+    # FIXME: missing remote_group_id and security_group_id
+    set_sdk_params_same_name(ser_params, sdk_params, [
+        'description',
+        'direction',
+        'port_range_max',
+        'port_range_min',
+        'protocol',
+        'remote_ip_prefix',
+        'revision_number',
+    ])
+
+    return sdk_params

--- a/os_migrate/plugins/modules/export_security_group.py
+++ b/os_migrate/plugins/modules/export_security_group.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: os_migrate.os_migrate.export_security_group
+
+short_description: Export OpenStack security group
+
+version_added: "2.9"
+
+description:
+  - "Export an OpenStack security group definition into an OS-Migrate YAML"
+
+options:
+  cloud:
+    description:
+      - Named cloud to operate against.
+    required: true
+  path:
+    description:
+      - Resources YAML file to where security groups will be serialized.
+      - In case the resource file already exists, it must match the
+        os-migrate version.
+      - In case the resource of same type and name exists in the file,
+        it will be replaced.
+    required: true
+  name:
+    description:
+      - Name of the security group. OS-Migrate requires unique resource names.
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Export security groups into /opt/os-migrate/security_groups.yml
+  os_migrate.os_migrate.export_security_groups:
+    cloud: source_cloud
+    path: /opt/os-migrate/security_groups.yml
+    name: mysecgroup
+'''
+
+RETURN = '''
+'''
+
+import openstack
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import filesystem
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import network
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import serialization
+
+
+def run_module():
+    module_args = dict(
+        cloud=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+    )
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        # TODO: Consider check mode. We'd fetch the resource and check
+        # if the file representation matches it.
+        # supports_check_mode=True,
+    )
+
+    conn = openstack.connect(cloud=module.params['cloud'])
+    sdk_sec = conn.get_security_group(module.params['name'])
+
+    ser_sec = network.serialize_security_group(sdk_sec)
+
+    result['changed'] = filesystem.write_or_replace_resource(
+        module.params['path'], ser_sec)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/export_security_group_rules.py
+++ b/os_migrate/plugins/modules/export_security_group_rules.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: os_migrate.os_migrate.export_security_group_rules
+
+short_description: Export OpenStack security group rules
+
+version_added: "2.9"
+
+description:
+  - "Export an OpenStack security group rules definition into an OS-Migrate YAML"
+
+options:
+  cloud:
+    description:
+      - Named cloud to operate against.
+    required: true
+  path:
+    description:
+      - Resources YAML file to where security groups will be serialized.
+      - In case the resource file already exists, it must match the
+        os-migrate version.
+      - In case the resource of same type and name exists in the file,
+        it will be replaced.
+    required: true
+  name:
+    description:
+      - Name of the security group. OS-Migrate requires unique resource names.
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Export security groups into /opt/os-migrate/security_groups.yml
+  os_migrate.os_migrate.export_security_group_rules:
+    cloud: source_cloud
+    path: /opt/os-migrate/security_groups.yml
+    name: mysecgroup
+'''
+
+RETURN = '''
+'''
+
+import openstack
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import filesystem
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import network
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import serialization
+
+
+def run_module():
+    module_args = dict(
+        cloud=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+    )
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        # TODO: Consider check mode. We'd fetch the resource and check
+        # if the file representation matches it.
+        # supports_check_mode=True,
+    )
+
+    conn = openstack.connect(cloud=module.params['cloud'])
+    sdk_sec = conn.get_security_group(module.params['name'])
+
+    for rule in sdk_sec['security_group_rules']:
+        # In this particular case we are creating a SecurityGroupRule
+        # object parsed from the rule dictionary.
+        # We check that serialize_security_group_rule receives
+        # a openstack.network.v2.security_group_rule.SecurityGroupRule
+        sec_rule_obj = openstack.network.v2.security_group_rule.SecurityGroupRule(**rule)
+        ser_sec = network.serialize_security_group_rule(sec_rule_obj)
+
+    result['changed'] = filesystem.write_or_replace_resource(
+        module.params['path'], ser_sec)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/os_security_group_rules_info.py
+++ b/os_migrate/plugins/modules/os_security_group_rules_info.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: os_migrate.os_migrate.os_security_group_rules_info
+
+short_description: Get security group rules info
+
+version_added: "2.9"
+
+description:
+  - "List security group rules information"
+
+options:
+  cloud:
+    description:
+      - Named cloud to operate against.
+    required: true
+  path:
+    description:
+      - Resources YAML file to where security groups will be serialized.
+      - In case the resource file already exists, it must match the
+        os-migrate version.
+      - In case the resource of same type and name exists in the file,
+        it will be replaced.
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Export security group rules into /opt/os-migrate/security_group_rules.yml
+  os_security_group_rules_info:
+    auth:
+      auth_url: https://identity.example.com
+      username: user
+      password: password
+      project_name: someproject
+    name:  secgroup
+'''
+
+RETURN = '''
+openstack_security_group_rules:
+    description: has all the openstack information about the securty group rules
+    returned: always, but can be null
+    type: complex
+    contains:
+        id:
+            description: Unique UUID.
+            returned: success
+            type: str
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_cloud_from_module
+
+
+def main():
+
+    argument_spec = openstack_full_argument_spec(
+        name=dict(required=False, default=None),
+        filters=dict(required=False, type='dict', default=None)
+    )
+    module = AnsibleModule(argument_spec)
+    sdk, cloud = openstack_cloud_from_module(module)
+    try:
+        security_group = cloud.list_security_groups(module.params['name'])
+
+        # We need to get the security rules from the security group we queried
+        security_group_rules = security_group['']
+        module.exit_json(changed=False, openstack_security_group_rules=security_group_rules)
+
+    except sdk.exceptions.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/os_security_groups_info.py
+++ b/os_migrate/plugins/modules/os_security_groups_info.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: os_migrate.os_migrate.os_security_groups_info
+
+short_description: Get security groups info
+
+version_added: "2.9"
+
+description:
+  - "List security groups information"
+
+options:
+  cloud:
+    description:
+      - Named cloud to operate against.
+    required: true
+  path:
+    description:
+      - Resources YAML file to where security groups will be serialized.
+      - In case the resource file already exists, it must match the
+        os-migrate version.
+      - In case the resource of same type and name exists in the file,
+        it will be replaced.
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Export security groups into /opt/os-migrate/security_groups.yml
+  os_security_groups_info:
+    auth:
+      auth_url: https://identity.example.com
+      username: user
+      password: password
+      project_name: someproject
+    name:  secgroup
+'''
+
+RETURN = '''
+openstack_security_groups:
+    description: has all the openstack information about the securty groups
+    returned: always, but can be null
+    type: complex
+    contains:
+        id:
+            description: Unique UUID.
+            returned: success
+            type: str
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_cloud_from_module
+
+
+def main():
+
+    argument_spec = openstack_full_argument_spec(
+        name=dict(required=False, default=None),
+        filters=dict(required=False, type='dict', default=None)
+    )
+    module = AnsibleModule(argument_spec)
+    sdk, cloud = openstack_cloud_from_module(module)
+    try:
+        security_groups = cloud.list_security_groups(module.params['name'])
+        module.exit_json(changed=False, openstack_security_groups=security_groups)
+
+    except sdk.exceptions.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/roles/export_security_group_rules/defaults/main.yml
+++ b/os_migrate/roles/export_security_group_rules/defaults/main.yml
@@ -1,0 +1,2 @@
+export_security_groups_name_filter:
+  - regex: .*

--- a/os_migrate/roles/export_security_group_rules/tasks/main.yml
+++ b/os_migrate/roles/export_security_group_rules/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: scan available security groups
+  os_migrate.os_migrate.os_security_groups_info:
+    cloud: "{{ os_migrate_src_cloud }}"
+  register: src_security_groups_info
+
+- name: filter names of security_groups to export
+  set_fact:
+    export_security_groups_names: "{{ src_security_groups_info.openstack_security_groups | json_query('[*].name') | sort | os_migrate.os_migrate.stringfilter(export_security_groups_name_filter) }}"
+
+# In this case we will export all the security groups
+# rules for all the security groups filtered before
+- name: export security group rules
+  os_migrate.os_migrate.export_security_group_rules:
+    cloud: "{{ os_migrate_src_cloud }}"
+    path: "{{ os_migrate_data_dir }}/security_group_rules.yml"
+    name: "{{ item }}"
+  loop: "{{ export_security_groups_names }}"

--- a/os_migrate/roles/export_security_groups/defaults/main.yml
+++ b/os_migrate/roles/export_security_groups/defaults/main.yml
@@ -1,0 +1,2 @@
+export_security_groups_name_filter:
+  - regex: .*

--- a/os_migrate/roles/export_security_groups/tasks/main.yml
+++ b/os_migrate/roles/export_security_groups/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: scan available security groups
+  os_migrate.os_migrate.os_security_groups_info:
+    cloud: "{{ os_migrate_src_cloud }}"
+  register: src_security_groups_info
+
+- name: filter names of security_groups to export
+  set_fact:
+    export_security_groups_names: "{{ src_security_groups_info.openstack_security_groups | json_query('[*].name') | sort | os_migrate.os_migrate.stringfilter(export_security_groups_name_filter) }}"
+
+- name: export security groups
+  os_migrate.os_migrate.export_security_group:
+    cloud: "{{ os_migrate_src_cloud }}"
+    path: "{{ os_migrate_data_dir }}/security_groups.yml"
+    name: "{{ item }}"
+  loop: "{{ export_security_groups_names }}"

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -138,3 +138,75 @@ def serialized_network():
         },
         const.RES_TYPE: 'openstack.network.Network',
     }
+
+
+def sdk_security_group():
+    return openstack.network.v2.security_group.SecurityGroup(
+        description='Default security group',
+        name='default',
+        id='uuid',
+        project_id='uuid-project',
+        created_at='2020-01-30T14:49:06Z',
+        updated_at='2020-01-30T14:49:06Z',
+        tenant_id='uuid-tenant',
+        revision_number='1',
+    )
+
+
+def serialized_security_group():
+    return {
+        const.RES_PARAMS: {
+            'description': 'Default security group',
+            'name': 'default',
+        },
+        const.RES_INFO: {
+            'id': 'uuid',
+            'project_id': 'uuid-project',
+            'created_at': '2020-01-30T14:49:06Z',
+            'updated_at': '2020-01-30T14:49:06Z',
+            'tenant_id': 'uuid-tenant',
+            'revision_number': '0',
+        },
+        const.RES_TYPE: 'openstack.network.SecurityGroup',
+    }
+
+
+def sdk_security_group_rule():
+    return openstack.network.v2.security_group_rule.SecurityGroupRule(
+        id='uuid',
+        security_group_id='uuid-sec-group',
+        remote_group_id='uuid-group',
+        project_id='uuid-project',
+        created_at='2020-01-30T14:49:06Z',
+        updated_at='2020-01-30T14:49:06Z',
+        revision_number='0',
+        description='null',
+        direction='ingress',
+        port_range_max='100',
+        port_range_min='10',
+        protocol='null',
+        remote_ip_prefix='null',
+    )
+
+
+def serialized_security_group_rule():
+    return {
+        const.RES_PARAMS: {
+            'description': 'null',
+            'direction': 'ingress',
+            'port_range_max': '100',
+            'port_range_min': '10',
+            'protocol': 'null',
+            'remote_ip_prefix': 'null',
+        },
+        const.RES_INFO: {
+            'id': 'uuid',
+            'security_group_id': 'uuid-sec-group',
+            'remote_group_id': 'uuid-group',
+            'project_id': 'uuid-project',
+            'created_at': '2020-01-30T14:49:06Z',
+            'updated_at': '2020-01-30T14:49:06Z',
+            'revision_number': '0',
+        },
+        const.RES_TYPE: 'openstack.network.SecurityGroupRule',
+    }

--- a/os_migrate/tests/unit/test_security_group.py
+++ b/os_migrate/tests/unit/test_security_group.py
@@ -1,0 +1,32 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.os_migrate.os_migrate.tests.unit import fixtures
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import network
+
+
+class TestSecurityGroup(unittest.TestCase):
+
+    def test_serialize_security_group(self):
+        sec = fixtures.sdk_security_group()
+        serialized = network.serialize_security_group(sec)
+        s_params = serialized['params']
+        s_info = serialized['_info']
+
+        self.assertEqual(serialized['type'], 'openstack.network.SecurityGroup')
+        self.assertEqual(s_params['description'], 'Default security group')
+        self.assertEqual(s_params['name'], 'default')
+        self.assertEqual(s_params['tags'], [])
+
+        self.assertEqual(s_info['created_at'], '2020-01-30T14:49:06Z')
+        self.assertEqual(s_info['project_id'], 'uuid-project')
+        self.assertEqual(s_info['updated_at'], '2020-01-30T14:49:06Z')
+
+    def test_security_group_sdk_params(self):
+        ser_sec = fixtures.serialized_security_group()
+        sdk_params = network.security_group_sdk_params(ser_sec)
+
+        self.assertEqual(sdk_params['description'], 'Default security group')

--- a/os_migrate/tests/unit/test_security_group_rule.py
+++ b/os_migrate/tests/unit/test_security_group_rule.py
@@ -1,0 +1,45 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.os_migrate.os_migrate.tests.unit import fixtures
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import network
+
+
+class TestSecurityGroupRule(unittest.TestCase):
+
+    def test_serialize_security_group_rule(self):
+        sec = fixtures.sdk_security_group_rule()
+        serialized = network.serialize_security_group_rule(sec)
+        s_params = serialized['params']
+        s_info = serialized['_info']
+
+        self.assertEqual(serialized['type'], 'openstack.network.SecurityGroupRule')
+        self.assertEqual(s_params['description'], 'null')
+        self.assertEqual(s_params['direction'], 'ingress')
+        self.assertEqual(s_params['port_range_max'], 100)
+        self.assertEqual(s_params['port_range_min'], 10)
+        self.assertEqual(s_params['protocol'], 'null')
+        self.assertEqual(s_params['remote_ip_prefix'], 'null')
+        self.assertEqual(s_params['tags'], [])
+
+        self.assertEqual(s_info['created_at'], '2020-01-30T14:49:06Z')
+        self.assertEqual(s_info['id'], 'uuid')
+        self.assertEqual(s_info['project_id'], 'uuid-project')
+        self.assertEqual(s_info['remote_group_id'], 'uuid-group')
+        self.assertEqual(s_info['security_group_id'], 'uuid-sec-group')
+        self.assertEqual(s_info['updated_at'], '2020-01-30T14:49:06Z')
+        self.assertEqual(s_info['revision_number'], 0)
+
+    def test_security_group_rule_sdk_params(self):
+        ser_sec = fixtures.serialized_security_group_rule()
+        sdk_params = network.security_group_rule_sdk_params(ser_sec)
+
+        self.assertEqual(sdk_params['description'], 'null')
+        self.assertEqual(sdk_params['direction'], 'ingress')
+        self.assertEqual(sdk_params['port_range_max'], '100')
+        self.assertEqual(sdk_params['port_range_min'], '10')
+        self.assertEqual(sdk_params['protocol'], 'null')
+        self.assertEqual(sdk_params['remote_ip_prefix'], 'null')


### PR DESCRIPTION
This patch exports the current deployed security groups into
the yaml os-migrate format.