### PR TITLE
Adapt conventions based on Security Groups discussion

### DIFF
--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -1,1 +1,7 @@
 OS_MIGRATE_VERSION = '0.1.0'  # updated by build.sh
+
+RES_PARAMS = 'params'
+RES_TYPE = 'type'
+RES_INFO = '_info'
+
+RES_TYPE_NETWORK = 'openstack.network.Network'

--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -3,6 +3,7 @@ __metaclass__ = type
 
 import openstack
 
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import reference
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils.serialization \
@@ -17,9 +18,9 @@ def serialize_network(sdk_net, net_refs):
     resource = {}
     params = {}
     info = {}
-    resource['params'] = params
-    resource['info'] = info
-    resource['type'] = 'openstack.network'
+    resource[const.RES_PARAMS] = params
+    resource[const.RES_INFO] = info
+    resource[const.RES_TYPE] = const.RES_TYPE_NETWORK
 
     params['availability_zone_hints'] = sorted(sdk_net['availability_zone_hints'])
     set_ser_params_same_name(params, sdk_net, [
@@ -57,11 +58,11 @@ def serialize_network(sdk_net, net_refs):
 
 
 def network_sdk_params(ser_net, net_refs):
-    res_type = ser_net.get('type', None)
-    if res_type != 'openstack.network':
-        raise exc.UnexpectedResourceType('openstack.network', res_type)
+    res_type = ser_net.get(const.RES_TYPE, None)
+    if res_type != const.RES_TYPE_NETWORK:
+        raise exc.UnexpectedResourceType(const.RES_TYPE_NETWORK, res_type)
 
-    ser_params = ser_net['params']
+    ser_params = ser_net[const.RES_PARAMS]
     sdk_params = {}
 
     set_sdk_params_same_name(ser_params, sdk_params, [
@@ -89,8 +90,8 @@ def network_sdk_params(ser_net, net_refs):
 
 
 def network_needs_update(sdk_net, net_refs, target_ser_net):
-    current_params = serialize_network(sdk_net, net_refs)['params']
-    target_params = target_ser_net['params']
+    current_params = serialize_network(sdk_net, net_refs)[const.RES_PARAMS]
+    target_params = target_ser_net[const.RES_PARAMS]
     return current_params != target_params
 
 
@@ -110,9 +111,10 @@ def network_refs_from_sdk(conn, sdk_net):
 
 
 def network_refs_from_ser(conn, ser_net):
-    if ser_net['type'] != 'openstack.network':
-        raise exc.UnexpectedResourceType('openstack.network', ser_net['type'])
-    ser_params = ser_net['params']
+    if ser_net[const.RES_TYPE] != const.RES_TYPE_NETWORK:
+        raise exc.UnexpectedResourceType(
+            const.RES_TYPE_NETWORK, ser_net[const.RES_TYPE])
+    ser_params = ser_net[const.RES_PARAMS]
     refs = {}
 
     # when creating refs from serialized Network, we copy names and

--- a/os_migrate/plugins/module_utils/serialization.py
+++ b/os_migrate/plugins/module_utils/serialization.py
@@ -27,14 +27,15 @@ def add_or_replace_resource(resources, resource):
 
 
 def is_same_resource(res1, res2):
-    if res1.get('type', '__undefined1__') != res2.get('type', '__undefined2__'):
+    if res1.get(const.RES_TYPE, '__undefined1__') != res2.get(
+            const.RES_TYPE, '__undefined2__'):
         return False
 
     # We can add special cases if something else than ['type'] &&
     # ['params']['name'] should be the deciding factors for sameness,
     # but it's not necessary for now.
-    return (res1.get('params', {}).get('name', '__undefined1__') ==
-            res2.get('params', {}).get('name', '__undefined1__'))
+    return (res1.get(const.RES_PARAMS, {}).get('name', '__undefined1__') ==
+            res2.get(const.RES_PARAMS, {}).get('name', '__undefined1__'))
 
 
 def set_sdk_param(ser_params, ser_key, sdk_params, sdk_key):

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -8,10 +8,13 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 
 def minimal_resource():
     return {
-        'type': 'openstack.minimal',
-        'params': {
+        const.RES_TYPE: 'openstack.Minimal',
+        const.RES_PARAMS: {
             'name': 'minimal',
             'description': 'minimal resource',
+        },
+        const.RES_INFO: {
+            'detail': 'not important for import and idempotence',
         },
     }
 
@@ -66,7 +69,7 @@ def network_refs():
 
 def serialized_network():
     return {
-        'params': {
+        const.RES_PARAMS: {
             'availability_zone_hints': ['nova', 'zone2'],
             'description': 'test network',
             'dns_domain': 'example.org',
@@ -85,7 +88,7 @@ def serialized_network():
             'qos_policy_name': 'test-qos-policy',
             'segments': [],
         },
-        'info': {
+        const.RES_INFO: {
             'availability_zones': ['nova', 'zone3'],
             'created_at': '2020-01-06T15:50:55Z',
             'project_id': 'uuid-test-project',
@@ -95,5 +98,5 @@ def serialized_network():
             'qos_policy_id': 'uuid-test-qos-policy',
             'updated_at': '2020-01-06T15:51:00Z',
         },
-        'type': 'openstack.network',
+        const.RES_TYPE: 'openstack.network.Network',
     }

--- a/os_migrate/tests/unit/test_filesystem.py
+++ b/os_migrate/tests/unit/test_filesystem.py
@@ -20,7 +20,7 @@ class TestFilesystem(unittest.TestCase):
 
             file_struct = filesystem.load_resources_file(file_path)
             resource = file_struct['resources'][0]
-            self.assertEqual(resource['type'], 'openstack.minimal')
+            self.assertEqual(resource['type'], 'openstack.Minimal')
             self.assertEqual(resource['params']['name'], 'minimal')
             self.assertEqual(
                 resource['params']['description'], 'minimal resource')
@@ -43,11 +43,11 @@ class TestFilesystem(unittest.TestCase):
             file_struct = filesystem.load_resources_file(file_path)
             resource0 = file_struct['resources'][0]
             resource1 = file_struct['resources'][1]
-            self.assertEqual(resource0['type'], 'openstack.minimal')
+            self.assertEqual(resource0['type'], 'openstack.Minimal')
             self.assertEqual(resource0['params']['name'], 'minimal')
             self.assertEqual(
                 resource0['params']['description'], 'minimal resource')
-            self.assertEqual(resource1['type'], 'openstack.minimal')
+            self.assertEqual(resource1['type'], 'openstack.Minimal')
             self.assertEqual(resource1['params']['name'], 'minimal2')
             self.assertEqual(
                 resource1['params']['description'], 'minimal two')

--- a/os_migrate/tests/unit/test_network.py
+++ b/os_migrate/tests/unit/test_network.py
@@ -15,9 +15,9 @@ class TestNetwork(unittest.TestCase):
         net_refs = fixtures.network_refs()
         serialized = network.serialize_network(net, net_refs)
         s_params = serialized['params']
-        s_info = serialized['info']
+        s_info = serialized['_info']
 
-        self.assertEqual(serialized['type'], 'openstack.network')
+        self.assertEqual(serialized['type'], 'openstack.network.Network')
         self.assertEqual(s_params['availability_zone_hints'], ['nova', 'zone2'])
         self.assertEqual(s_params['description'], 'test network')
         self.assertEqual(s_params['dns_domain'], 'example.org')
@@ -77,7 +77,7 @@ class TestNetwork(unittest.TestCase):
         self.assertFalse(network.network_needs_update(
             sdk_net, net_refs, serialized))
 
-        serialized['info']['id'] = 'different id'
+        serialized['_info']['id'] = 'different id'
         self.assertFalse(network.network_needs_update(
             sdk_net, net_refs, serialized))
 

--- a/os_migrate/tests/unit/test_serialization.py
+++ b/os_migrate/tests/unit/test_serialization.py
@@ -17,71 +17,71 @@ class TestSerialization(unittest.TestCase):
     def test_add_or_replace_resource(self):
         resources = [
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'one', 'description': 'one'},
             },
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'two', 'description': 'two'},
             },
         ]
 
         # append at the end
         self.assertTrue(serialization.add_or_replace_resource(resources, {
-            'type': 'openstack.network',
+            'type': 'openstack.network.Network',
             'params': {'name': 'three', 'description': 'three'},
         }))
         self.assertEqual(resources, [
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'one', 'description': 'one'},
             },
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'two', 'description': 'two'},
             },
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'three', 'description': 'three'},
             },
         ])
 
         # replace existing
         self.assertTrue(serialization.add_or_replace_resource(resources, {
-            'type': 'openstack.network',
+            'type': 'openstack.network.Network',
             'params': {'name': 'two', 'description': 'two updated'},
         }))
         self.assertEqual(resources, [
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'one', 'description': 'one'},
             },
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'two', 'description': 'two updated'},
             },
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'three', 'description': 'three'},
             },
         ])
 
         # same replacement again - should return False, nothing changed
         self.assertFalse(serialization.add_or_replace_resource(resources, {
-            'type': 'openstack.network',
+            'type': 'openstack.network.Network',
             'params': {'name': 'two', 'description': 'two updated'},
         }))
         self.assertEqual(resources, [
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'one', 'description': 'one'},
             },
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'two', 'description': 'two updated'},
             },
             {
-                'type': 'openstack.network',
+                'type': 'openstack.network.Network',
                 'params': {'name': 'three', 'description': 'three'},
             },
         ])


### PR DESCRIPTION
Work on Security Groups spawned a discussion about some
conventions. This patch performs following adaptation:

* Use '_info' instead of 'info' for resource properties which are
  irrelevant for importing and idempotence checks. This should further
  reduce a chance of conflict with some real property and allow us to
  ignore any '_info' *also in nested dicts* when importing / checking
  idempotence.

* Better namespacing for Network type
  serialization. 'openstack.network.Network' rather than
  'openstack.network'.