### PR TITLE
Implement generic idempotence checker

### DIFF
--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -6,6 +6,7 @@ import openstack
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import reference
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import serialization
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils.serialization \
     import set_sdk_params_same_name, set_ser_params_same_name
 
@@ -108,9 +109,8 @@ def network_needs_update(sdk_net, net_refs, target_ser_net):
 
     Returns: True if network needs to be updated, False otherwise
     """
-    current_params = serialize_network(sdk_net, net_refs)[const.RES_PARAMS]
-    target_params = target_ser_net[const.RES_PARAMS]
-    return current_params != target_params
+    current_ser_net = serialize_network(sdk_net, net_refs)
+    return serialization.resource_needs_update(current_ser_net, target_ser_net)
 
 
 def network_refs_from_sdk(conn, sdk_net):

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -26,6 +26,39 @@ def minimal_resource_file_struct():
     }
 
 
+def resource_with_nested():
+    return {
+        const.RES_TYPE: 'openstack.WithNested',
+        const.RES_PARAMS: {
+            'name': 'with-nested',
+            'description': 'resource with nested resources',
+            'subresources': [
+                {
+                    const.RES_TYPE: 'openstack.Nested',
+                    const.RES_PARAMS: {
+                        'name': 'nested-1',
+                    },
+                    const.RES_INFO: {
+                        'nested-detail': 'not important',
+                    },
+                },
+                {
+                    const.RES_TYPE: 'openstack.Nested',
+                    const.RES_PARAMS: {
+                        'name': 'nested-2',
+                    },
+                    const.RES_INFO: {
+                        'nested-detail': 'also not important',
+                    },
+                },
+            ],
+        },
+        const.RES_INFO: {
+            'detail': 'not important for import and idempotence',
+        },
+    }
+
+
 def sdk_network():
     return openstack.network.v2.network.Network(
         availability_zone_hints=['nova', 'zone2'],

--- a/os_migrate/tests/unit/test_serialization.py
+++ b/os_migrate/tests/unit/test_serialization.py
@@ -4,7 +4,10 @@ __metaclass__ = type
 import unittest
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import const
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
     import serialization
+from ansible_collections.os_migrate.os_migrate.tests.unit import fixtures
 
 
 class TestSerialization(unittest.TestCase):
@@ -86,6 +89,50 @@ class TestSerialization(unittest.TestCase):
             },
         ])
 
+    def test_resource_needs_update_minimal(self):
+        current = fixtures.minimal_resource()
+        target = fixtures.minimal_resource()
+
+        self.assertFalse(serialization.resource_needs_update(current, target))
+
+        target[const.RES_INFO]['detail'] = 'updated detail'
+        self.assertFalse(serialization.resource_needs_update(current, target))
+
+        target[const.RES_PARAMS]['description'] = 'updated description'
+        self.assertTrue(serialization.resource_needs_update(current, target))
+
+    def test_resource_needs_update_nested(self):
+        current = fixtures.resource_with_nested()
+        target = fixtures.resource_with_nested()
+
+        self.assertFalse(serialization.resource_needs_update(current, target))
+
+        target[const.RES_INFO]['detail'] = 'updated detail'
+        self.assertFalse(serialization.resource_needs_update(current, target))
+
+        target[const.RES_PARAMS]['description'] = 'updated description'
+        self.assertTrue(serialization.resource_needs_update(current, target))
+
+        # reset
+        current = fixtures.resource_with_nested()
+        target = fixtures.resource_with_nested()
+
+        target[const.RES_PARAMS]['subresources'][0][const.RES_INFO]['nested-detail'] \
+            = 'updated detail'
+        self.assertFalse(serialization.resource_needs_update(current, target))
+
+        target[const.RES_PARAMS]['subresources'][0][const.RES_PARAMS]['name'] \
+            = 'updated-name'
+        self.assertTrue(serialization.resource_needs_update(current, target))
+
+        # reset
+        current = fixtures.resource_with_nested()
+        target = fixtures.resource_with_nested()
+
+        target[const.RES_PARAMS]['subresources'][0][const.RES_TYPE] \
+            = 'openstack.UpdatedType'
+        self.assertTrue(serialization.resource_needs_update(current, target))
+
     def test_set_sdk_param(self):
         ser_params = {'a': 'b', 'c': 'd', 'e': 'f'}
         sdk_params = {'g': 'h'}
@@ -113,3 +160,28 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises(KeyError):
             serialization.set_ser_params_same_name(
                 ser_params, sdk_params, ['a', 'e', 'z'])
+
+    def test_trim_info(self):
+        resource = fixtures.resource_with_nested()
+        trimmed = serialization._trim_info(resource)
+        self.assertEqual(trimmed, {
+            const.RES_TYPE: 'openstack.WithNested',
+            const.RES_PARAMS: {
+                'name': 'with-nested',
+                'description': 'resource with nested resources',
+                'subresources': [
+                    {
+                        const.RES_TYPE: 'openstack.Nested',
+                        const.RES_PARAMS: {
+                            'name': 'nested-1',
+                        },
+                    },
+                    {
+                        const.RES_TYPE: 'openstack.Nested',
+                        const.RES_PARAMS: {
+                            'name': 'nested-2',
+                        },
+                    },
+                ],
+            },
+        })


### PR DESCRIPTION
The resource_needs_update function should be generically usable on all
our resources to check whether some resource is in target state or
needs update (= idempotence checks). It is right away plugged into the
check method for Network.