### PR TITLE
Allow exporting non-uniquely named resource sets

### DIFF
--- a/os_migrate/plugins/filter/stringfilter.py
+++ b/os_migrate/plugins/filter/stringfilter.py
@@ -7,11 +7,16 @@ import re
 from ansible import errors
 
 
-def stringfilter(strings, queries):
-    """Filter a `strings` list of strigs according to a list of
-    `queries`. Values from `strings` are kept if they match at least
-    one query. The original `strings` list is untouched but the result
-    list uses the same data (not a deep copy).
+def stringfilter(items, queries, attribute=None):
+    """Filter a `items` list according to a list of `queries`. Values from
+    `items` are kept if they match at least one query. The original
+    `items` list is untouched but the result list uses the same data
+    (not a deep copy).
+
+    If `attribute` is None, it is assumed that `items` is a list of
+    strings to be filtered directly. If `attribute` is provided, it is
+    assumed that `items` is a list of dicts, and `queries` will tested
+    against value under `attribute` key in each dict.
 
     `queries` is a list where each item can be:
 
@@ -22,21 +27,44 @@ def stringfilter(strings, queries):
 
     Returns: a list - subset of `strings` where each item matched one
     or more `queries`
+
     """
     result = []
-    for s in strings:
-        for q in queries:
-            if isinstance(q, str):
-                if q == s:
-                    result.append(s)
+    for item in items:
+        if attribute is not None:
+            if not isinstance(item, dict):
+                raise errors.AnsibleFilterError(
+                    "stringfilter: 'attribute' parameter provided "
+                    "but list item is not dict: {0}".format(pformat(item))
+                )
+            if attribute not in item:
+                raise errors.AnsibleFilterError(
+                    "stringfilter: 'attribute' is {0} "
+                    "but it was not found in list item: {1}"
+                    .format(pformat(attribute), pformat(item))
+                )
+            string = item[attribute]
+        else:
+            if not isinstance(item, str):
+                raise errors.AnsibleFilterError(
+                    "stringfilter: list item is not string: {0}"
+                    .format(pformat(item))
+                )
+            string = item
+
+        for query in queries:
+            if isinstance(query, str):
+                if query == string:
+                    result.append(item)
                     break
-            elif isinstance(q, dict) and q.get('regex'):
-                if re.search(q['regex'], s):
-                    result.append(s)
+            elif isinstance(query, dict) and query.get('regex'):
+                if re.search(query['regex'], string):
+                    result.append(item)
                     break
             else:
                 raise errors.AnsibleFilterError(
-                    "stringfilter: unrecognized query: {0}".format(pformat(q))
+                    "stringfilter: unrecognized query: {0}"
+                    .format(pformat(query))
                 )
     return result
 

--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -53,6 +53,7 @@ def serialize_network(sdk_net, net_refs):
     set_ser_params_same_name(info, sdk_net, [
         'availability_zones',
         'created_at',
+        'id',
         'project_id',
         'qos_policy_id',
         'revision_number',

--- a/os_migrate/plugins/module_utils/serialization.py
+++ b/os_migrate/plugins/module_utils/serialization.py
@@ -48,7 +48,7 @@ def is_same_resource(res1, res2):
     # ['params']['name'] should be the deciding factors for sameness,
     # but it's not necessary for now.
     return (res1.get(const.RES_PARAMS, {}).get('name', '__undefined1__') ==
-            res2.get(const.RES_PARAMS, {}).get('name', '__undefined1__'))
+            res2.get(const.RES_PARAMS, {}).get('name', '__undefined2__'))
 
 
 def resource_needs_update(current, target):

--- a/os_migrate/plugins/module_utils/serialization.py
+++ b/os_migrate/plugins/module_utils/serialization.py
@@ -36,19 +36,22 @@ def add_or_replace_resource(resources, resource):
 
 def is_same_resource(res1, res2):
     """Check whether two `res1` and `res2` dicts represent the same
-    resource. Type and name are deciding factors.
+    resource. Type and id are checked.
 
     Returns: True if same, False otherwise
     """
+    # UUID should be enough of a check but just in case we get back to
+    # checking by name in the future, let's keep the type check as
+    # well, it doesn't hurt.
     if res1.get(const.RES_TYPE, '__undefined1__') != res2.get(
             const.RES_TYPE, '__undefined2__'):
         return False
 
     # We can add special cases if something else than ['type'] &&
-    # ['params']['name'] should be the deciding factors for sameness,
+    # ['_info']['id'] should be the deciding factors for sameness,
     # but it's not necessary for now.
-    return (res1.get(const.RES_PARAMS, {}).get('name', '__undefined1__') ==
-            res2.get(const.RES_PARAMS, {}).get('name', '__undefined2__'))
+    return (res1.get(const.RES_INFO, {}).get('id', '__undefined1__') ==
+            res2.get(const.RES_INFO, {}).get('id', '__undefined2__'))
 
 
 def resource_needs_update(current, target):

--- a/os_migrate/plugins/modules/export_network.py
+++ b/os_migrate/plugins/modules/export_network.py
@@ -35,7 +35,7 @@ options:
     required: true
   name:
     description:
-      - Name of the network to export. OS-Migrate requires unique resource names.
+      - Name (or ID) of a Network to export.
     required: true
 '''
 

--- a/os_migrate/roles/export_networks/tasks/main.yml
+++ b/os_migrate/roles/export_networks/tasks/main.yml
@@ -3,13 +3,23 @@
     cloud: "{{ os_migrate_src_cloud }}"
   register: src_networks_info
 
+- name: create id-name pairs of networks to export
+  set_fact:
+    export_networks_ids_names: "{{ (
+      src_networks_info.openstack_networks
+        | json_query('[*].{name: name, id: id}')
+        | sort(attribute='id') ) }}"
+
 - name: filter names of networks to export
   set_fact:
-    export_networks_names: "{{ src_networks_info.openstack_networks | json_query('[*].name') | sort | os_migrate.os_migrate.stringfilter(export_networks_name_filter) }}"
+    export_networks_ids_names: "{{ (
+      export_networks_ids_names
+        | os_migrate.os_migrate.stringfilter(export_networks_name_filter,
+                                             attribute='name') ) }}"
 
-- name: export networks
+- name: export network
   os_migrate.os_migrate.export_network:
     cloud: "{{ os_migrate_src_cloud }}"
     path: "{{ os_migrate_data_dir }}/networks.yml"
-    name: "{{ item }}"
-  loop: "{{ export_networks_names }}"
+    name: "{{ item['id'] }}"
+  loop: "{{ export_networks_ids_names }}"

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -14,6 +14,7 @@ def minimal_resource():
             'description': 'minimal resource',
         },
         const.RES_INFO: {
+            'id': 'id-minimal',
             'detail': 'not important for import and idempotence',
         },
     }
@@ -39,6 +40,7 @@ def resource_with_nested():
                         'name': 'nested-1',
                     },
                     const.RES_INFO: {
+                        'id': 'id-nested-1',
                         'nested-detail': 'not important',
                     },
                 },
@@ -48,12 +50,14 @@ def resource_with_nested():
                         'name': 'nested-2',
                     },
                     const.RES_INFO: {
+                        'id': 'id-nested-2',
                         'nested-detail': 'also not important',
                     },
                 },
             ],
         },
         const.RES_INFO: {
+            'id': 'id-with-nested',
             'detail': 'not important for import and idempotence',
         },
     }
@@ -66,6 +70,7 @@ def sdk_network():
         created_at='2020-01-06T15:50:55Z',
         description='test network',
         dns_domain='example.org',
+        id='uuid-test-net',
         ipv4_address_scope_id=None,
         ipv6_address_scope_id=None,
         is_admin_state_up=True,

--- a/os_migrate/tests/unit/test_filesystem.py
+++ b/os_migrate/tests/unit/test_filesystem.py
@@ -34,6 +34,7 @@ class TestFilesystem(unittest.TestCase):
             minimal2 = fixtures.minimal_resource()
             minimal2['params']['name'] = 'minimal2'
             minimal2['params']['description'] = 'minimal two'
+            minimal2['_info']['id'] = 'id-minimal2'
             self.assertTrue(
                 filesystem.write_or_replace_resource(file_path, minimal2))
             # repeated replacement should report no changes - return False
@@ -45,9 +46,11 @@ class TestFilesystem(unittest.TestCase):
             resource1 = file_struct['resources'][1]
             self.assertEqual(resource0['type'], 'openstack.Minimal')
             self.assertEqual(resource0['params']['name'], 'minimal')
+            self.assertEqual(resource0['_info']['id'], 'id-minimal')
             self.assertEqual(
                 resource0['params']['description'], 'minimal resource')
             self.assertEqual(resource1['type'], 'openstack.Minimal')
             self.assertEqual(resource1['params']['name'], 'minimal2')
+            self.assertEqual(resource1['_info']['id'], 'id-minimal2')
             self.assertEqual(
                 resource1['params']['description'], 'minimal two')

--- a/os_migrate/tests/unit/test_network.py
+++ b/os_migrate/tests/unit/test_network.py
@@ -37,6 +37,7 @@ class TestNetwork(unittest.TestCase):
 
         self.assertEqual(s_info['availability_zones'], ['nova', 'zone3'])
         self.assertEqual(s_info['created_at'], '2020-01-06T15:50:55Z')
+        self.assertEqual(s_info['id'], 'uuid-test-net')
         self.assertEqual(s_info['project_id'], 'uuid-test-project')
         self.assertEqual(s_info['revision_number'], 3)
         self.assertEqual(s_info['status'], 'ACTIVE')

--- a/os_migrate/tests/unit/test_serialization.py
+++ b/os_migrate/tests/unit/test_serialization.py
@@ -133,6 +133,36 @@ class TestSerialization(unittest.TestCase):
             = 'openstack.UpdatedType'
         self.assertTrue(serialization.resource_needs_update(current, target))
 
+    def test_is_same_resource(self):
+        r1 = fixtures.minimal_resource()
+        r2 = fixtures.minimal_resource()
+        self.assertTrue(serialization.is_same_resource(r1, r2))
+
+        r2['params']['description'] = 'different description'
+        self.assertTrue(serialization.is_same_resource(r1, r2))
+
+        r2['params']['name'] = 'different-name'
+        self.assertFalse(serialization.is_same_resource(r1, r2))
+
+        # reset to sameness
+        r1 = fixtures.minimal_resource()
+        r2 = fixtures.minimal_resource()
+
+        r2['type'] = 'different.type'
+        self.assertFalse(serialization.is_same_resource(r1, r2))
+
+        del r1['type']
+        del r2['type']
+        self.assertFalse(serialization.is_same_resource(r1, r2))
+
+        # reset to sameness
+        r1 = fixtures.minimal_resource()
+        r2 = fixtures.minimal_resource()
+
+        del r1['params']['name']
+        del r2['params']['name']
+        self.assertFalse(serialization.is_same_resource(r1, r2))
+
     def test_set_sdk_param(self):
         ser_params = {'a': 'b', 'c': 'd', 'e': 'f'}
         sdk_params = {'g': 'h'}

--- a/os_migrate/tests/unit/test_serialization.py
+++ b/os_migrate/tests/unit/test_serialization.py
@@ -22,10 +22,12 @@ class TestSerialization(unittest.TestCase):
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'one', 'description': 'one'},
+                '_info': {'id': 'id-one'},
             },
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'two', 'description': 'two'},
+                '_info': {'id': 'id-two'},
             },
         ]
 
@@ -33,19 +35,23 @@ class TestSerialization(unittest.TestCase):
         self.assertTrue(serialization.add_or_replace_resource(resources, {
             'type': 'openstack.network.Network',
             'params': {'name': 'three', 'description': 'three'},
+            '_info': {'id': 'id-three'},
         }))
         self.assertEqual(resources, [
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'one', 'description': 'one'},
+                '_info': {'id': 'id-one'},
             },
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'two', 'description': 'two'},
+                '_info': {'id': 'id-two'},
             },
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'three', 'description': 'three'},
+                '_info': {'id': 'id-three'},
             },
         ])
 
@@ -53,19 +59,23 @@ class TestSerialization(unittest.TestCase):
         self.assertTrue(serialization.add_or_replace_resource(resources, {
             'type': 'openstack.network.Network',
             'params': {'name': 'two', 'description': 'two updated'},
+            '_info': {'id': 'id-two'},
         }))
         self.assertEqual(resources, [
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'one', 'description': 'one'},
+                '_info': {'id': 'id-one'},
             },
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'two', 'description': 'two updated'},
+                '_info': {'id': 'id-two'},
             },
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'three', 'description': 'three'},
+                '_info': {'id': 'id-three'},
             },
         ])
 
@@ -73,19 +83,23 @@ class TestSerialization(unittest.TestCase):
         self.assertFalse(serialization.add_or_replace_resource(resources, {
             'type': 'openstack.network.Network',
             'params': {'name': 'two', 'description': 'two updated'},
+            '_info': {'id': 'id-two'},
         }))
         self.assertEqual(resources, [
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'one', 'description': 'one'},
+                '_info': {'id': 'id-one'},
             },
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'two', 'description': 'two updated'},
+                '_info': {'id': 'id-two'},
             },
             {
                 'type': 'openstack.network.Network',
                 'params': {'name': 'three', 'description': 'three'},
+                '_info': {'id': 'id-three'},
             },
         ])
 
@@ -142,7 +156,9 @@ class TestSerialization(unittest.TestCase):
         self.assertTrue(serialization.is_same_resource(r1, r2))
 
         r2['params']['name'] = 'different-name'
-        self.assertFalse(serialization.is_same_resource(r1, r2))
+        self.assertTrue(serialization.is_same_resource(r1, r2))
+
+        r2['_info']['id'] = 'different-id'
 
         # reset to sameness
         r1 = fixtures.minimal_resource()
@@ -159,8 +175,8 @@ class TestSerialization(unittest.TestCase):
         r1 = fixtures.minimal_resource()
         r2 = fixtures.minimal_resource()
 
-        del r1['params']['name']
-        del r2['params']['name']
+        del r1['_info']['id']
+        del r2['_info']['id']
         self.assertFalse(serialization.is_same_resource(r1, r2))
 
     def test_set_sdk_param(self):

--- a/os_migrate/tests/unit/test_stringfilter.py
+++ b/os_migrate/tests/unit/test_stringfilter.py
@@ -11,7 +11,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.filter.stringfilter \
 
 class TestStringfilter(unittest.TestCase):
 
-    def test_stringfilter(self):
+    def test_stringfilter_strings(self):
         strings = [
             'one',
             'two',
@@ -57,3 +57,58 @@ class TestStringfilter(unittest.TestCase):
 
         with self.assertRaises(ansible.errors.AnsibleFilterError):
             stringfilter(strings, [{'regexp': 'one'}])
+
+    def test_stringfilter_dicts(self):
+        items = [
+            {'a': 'one', 'b': 'another one'},
+            {'a': 'two', 'b': 'another two'},
+            {'a': 'three', 'b': 'another three'},
+            {'a': 'prefixed-one', 'b': 'another prefixed-one'},
+            {'a': 'prefixed-two', 'b': 'another prefixed-two'},
+            {'a': 'prefixed-three', 'b': 'another prefixed-three'},
+            {'a': 'one-suffixed', 'b': 'another one-suffixed'},
+            {'a': 'two-suffixed', 'b': 'another two-suffixed'},
+            {'a': 'three-suffixed', 'b': 'another three-suffixed'},
+        ]
+
+        self.assertEqual(
+            stringfilter(items, ['one', 'prefixed'], attribute='a'),
+            [{'a': 'one', 'b': 'another one'}],
+        )
+
+        self.assertEqual(
+            stringfilter(items, ['one', {'regex': '^prefixed'}], attribute='a'),
+            [
+                {'a': 'one', 'b': 'another one'},
+                {'a': 'prefixed-one', 'b': 'another prefixed-one'},
+                {'a': 'prefixed-two', 'b': 'another prefixed-two'},
+                {'a': 'prefixed-three', 'b': 'another prefixed-three'},
+            ],
+        )
+
+        self.assertEqual(
+            stringfilter(items, [{'regex': 'xed$'}], attribute='a'),
+            [
+                {'a': 'one-suffixed', 'b': 'another one-suffixed'},
+                {'a': 'two-suffixed', 'b': 'another two-suffixed'},
+                {'a': 'three-suffixed', 'b': 'another three-suffixed'},
+            ],
+        )
+
+        self.assertEqual(
+            stringfilter(items, [{'regex': 'one'}], attribute='a'),
+            [
+                {'a': 'one', 'b': 'another one'},
+                {'a': 'prefixed-one', 'b': 'another prefixed-one'},
+                {'a': 'one-suffixed', 'b': 'another one-suffixed'},
+            ],
+        )
+
+        self.assertEqual(
+            stringfilter(items, [], attribute='a'),
+            [],
+        )
+
+        # no 'attribute' provided but iterating over dicts
+        with self.assertRaises(ansible.errors.AnsibleFilterError):
+            stringfilter(items, [{'regexp': 'one'}])


### PR DESCRIPTION
This change is fueled by work on validations. We have essentially 2
options there:

* Export all resources including ones with empty name and duplicate
  names. Then run validatiton on the exported files. This requires
  that resources are iterated over for export by ID and not by name.

  This is nicer because the files can be perhaps edited by hand to
  amend the naming on destination cloud without forcing name changes
  on source cloud. Validation can be re-ran arbitrarily on the files
  to iterate forward.

* Validate the state in the source cloud to verify whether export can
  be ran, and change the state in the source cloud until unique naming
  is achieved. Then run export.

  This is less nice because amendments of the source cloud are
  necessary before an export can be performed.

To achieve the former (nicer) option, we need to start iterating
by ID on export.