### PR TITLE
Assert correct os_migrate_version when loading files

### DIFF
--- a/os_migrate/plugins/module_utils/exc.py
+++ b/os_migrate/plugins/module_utils/exc.py
@@ -1,6 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
+
 
 class UnexpectedResourceType(Exception):
     """Unexpected resource type."""
@@ -10,3 +12,13 @@ class UnexpectedResourceType(Exception):
     def __init__(self, expected_type, got_type):
         message = self.msg_format.format(expected_type, got_type)
         super(UnexpectedResourceType, self).__init__(message)
+
+
+class DataVersionMismatch(Exception):
+    """Data version does not match OS-Migrate version."""
+
+    msg_format = "Expected data with os_migrate_version '{}' but got '{}'."
+
+    def __init__(self, got_version):
+        message = self.msg_format.format(const.OS_MIGRATE_VERSION, got_version)
+        super(DataVersionMismatch, self).__init__(message)

--- a/os_migrate/plugins/module_utils/filesystem.py
+++ b/os_migrate/plugins/module_utils/filesystem.py
@@ -5,6 +5,7 @@ import yaml
 from os import path
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import serialization
 
 
@@ -36,6 +37,11 @@ def load_resources_file(file_path):
     """
     with open(file_path, 'r') as f:
         file_struct = yaml.load(f)
+
+    file_os_migrate_version = file_struct.get('os_migrate_version', None)
+    if file_os_migrate_version != const.OS_MIGRATE_VERSION:
+        raise exc.DataVersionMismatch(file_os_migrate_version)
+
     return file_struct
 
 


### PR DESCRIPTION
Currently we do not guarantee any backward/forward compatibility in
serialized files. Using different version of OS-Migrate between export
and import isn't supported. Should users get to a situation where
differing versions are needed between export and import, they will
have to investigate the risks and e.g. `sed` the version in files to
the expected one. We're defaulting to being defensive here.

I was thinking whether this could go into validations as one of the
validation errors, but in fact if the versions are different, we
cannot even guarantee that the validations will work correctly, so
let's be careful and just raise a clear exception right away.

Closes https://github.com/os-migrate/os-migrate/issues/20