### PR TITLE
Do not build container with Vagrant in CI

### DIFF
--- a/.github/workflows/functional-all.yml
+++ b/.github/workflows/functional-all.yml
@@ -95,7 +95,7 @@ jobs:
         openstack --os-cloud devstack-admin --os-region RegionOne router list
     - name: Make the container image to launch the tests
       run: |
-        make toolbox-build
+        NO_VAGRANT=1 make toolbox-build
     - name: Connect functional tests to devstack
       run: |
         cp /etc/openstack/clouds.yaml tests/func/clouds.yaml && \

--- a/.github/workflows/unit-all.yml
+++ b/.github/workflows/unit-all.yml
@@ -33,7 +33,7 @@ jobs:
         podman -v
     - name: Make the container image to launch the tests
       run: |
-        make toolbox-build
+        NO_VAGRANT=1 make toolbox-build
     - name: Run sanity and unit test
       run: |
         ./toolbox/run make test-fast

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test-unit: reinstall
 
 toolbox-build:
 	cd toolbox && \
-	podman build -t localhost/os_migrate_toolbox:latest . && \
+	podman build --build-arg NO_VAGRANT=$(NO_VAGRANT) -t localhost/os_migrate_toolbox:latest . && \
 	podman tag localhost/os_migrate_toolbox:latest localhost/os_migrate_toolbox:$$(date "+%Y_%m_%d")
 
 toolbox-clean:

--- a/toolbox/build/build.sh
+++ b/toolbox/build/build.sh
@@ -10,9 +10,11 @@ OS_MIGRATE_DIR=$(realpath "$DIR/../..")
 dnf clean all
 dnf -y update
 dnf -y install ansible gcc make python3-devel python3-openstackclient jq shyaml
-# This below packages are for vagrant-libvirt and take a lot of deps,
-# comment out if you run vagrant from host rather than from container.
-dnf -y install ansible libvirt-client rsync openssh-clients vagrant-libvirt
+# The below packages are for vagrant-libvirt and take a lot of deps,
+# build with `NO_VAGRANT=1 make toolbox-build` if Vagrant isn't required.
+if [ "${NO_VAGRANT:-}" != "1" ]; then
+    dnf -y install ansible libvirt-client rsync openssh-clients vagrant-libvirt
+fi
 dnf clean all
 
 


### PR DESCRIPTION
We don't need Vagrant in CI and it pulls a lot of deps, skipping its
installation in CI should speed up the jobs.

Closes #24 