### PR TITLE
Correct $HOME ownership in vagrant-run and vagrant-shell

### DIFF
--- a/toolbox/vagrant-run
+++ b/toolbox/vagrant-run
@@ -11,7 +11,7 @@ fi
 DIR=$(dirname $(realpath $0))
 OS_MIGRATE_DIR=$(realpath "$DIR/..")
 if [ -t 1 ]; then
-    CONTAINER_TTY="${CONTAINER_TTY:--ti}"
+    CONTAINER_TTY="${CONTAINER_TTY:--ai}"
 else
     CONTAINER_TTY="${CONTAINER_TTY:-}"
 fi
@@ -37,16 +37,15 @@ IDX=0
 while sudo podman inspect os_migrate_vagrant_$IDX &> /dev/null; do
     ((IDX++))
 done || true
+CONTAINER_NAME=os_migrate_vagrant_shell_$IDX
 
 mkdir -p $HOME/.vagrant.d
 mkdir -p $HOME/.cache/libvirt
 mkdir -p $HOME/.config/libvirt
 mkdir -p $HOME/.local/share/libvirt/vagrant
 
-sudo podman run \
-    --name os_migrate_vagrant_shell_$IDX \
-    --detach-keys='ctrl-^' \
-    $CONTAINER_TTY \
+sudo podman create \
+    --name $CONTAINER_NAME \
     --rm \
     --net host \
     --pid host \
@@ -83,3 +82,18 @@ sudo podman run \
     ${OS_MIGRATE_VAGRANT_TOOLBOX_ARGS:-} \
     localhost/os_migrate_toolbox \
     "$@"
+
+CONTAINER_FS=$(sudo podman mount $CONTAINER_NAME)
+if [ -z "$CONTAINER_FS" ]; then
+    echo "ERROR: Empty container filesystem root path, cannot initialize the container."
+    exit 1
+fi
+sudo mkdir -p "${CONTAINER_FS}${HOME}/.cache"
+sudo mkdir -p "${CONTAINER_FS}${HOME}/.config"
+sudo mkdir -p "${CONTAINER_FS}${HOME}/.local/share"
+sudo mkdir -p "${CONTAINER_FS}${OS_MIGRATE_DIR}"
+sudo chown -R "$USER:" "${CONTAINER_FS}${HOME}"
+
+sudo podman start $CONTAINER_NAME \
+    --detach-keys='ctrl-^' \
+    $CONTAINER_TTY


### PR DESCRIPTION
I was considering several options how to solve the issue of incorrect
$HOME ownership in containers:

* Give the user sudo rights to do the chown in entrypoint. Bad mainly
  because we don't know which user we'll run as when creating the
  container image, and for sudo to work in a container we also need to
  mount in /etc/shadow (even when using NOPASSWD sudo).

* Launch the container as root, perform chown in its entrypoint, and
  then `su` to another user (we'd pass it in via env variable) to run
  the real command. Better than previous but reimplementing the
  `--user` argument of `podman run` via an env variable and custom
  entrypoint still feels somewhat suboptimal, especially if Vagrant is
  not the only use case for the os_migrate_toolbox image.

* First create the container without starting it, tweak the
  container's filesystem as needed via `podman mount`, and then start
  the container. This feels like the cleanest option and it's the one
  implemented in this commit.

The last option feels the cleanest and it's the one implemented in
this commit.

Closes #61.