### PR TITLE
Add validation of unique resource naming

### DIFF
--- a/os_migrate/playbooks/validate_data_dir.yml
+++ b/os_migrate/playbooks/validate_data_dir.yml
@@ -1,0 +1,3 @@
+- hosts: migrator
+  roles:
+    - os_migrate.os_migrate.validate_data_dir

--- a/os_migrate/plugins/module_utils/validation.py
+++ b/os_migrate/plugins/module_utils/validation.py
@@ -1,0 +1,48 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
+
+
+def get_errors_in_file_structs(file_structs):
+    """Validate a list of `file_structs` resources file
+    structures. Validates unique resource naming, in the future should
+    also validate internal format of resources.
+
+    Returns: A list of validation error messages. Empty if all is ok.
+    """
+    all_resources = []
+    for file_struct in file_structs:
+        all_resources.extend(file_struct['resources'])
+
+    errors = _resource_duplicate_name_errors(all_resources)
+    # TOOD: errors.extend(...) with additional checks for resource format
+    return errors
+
+
+def _resource_duplicate_name_errors(resources):
+    """Validate a `resources` list for duplicate naming.
+
+    Returns: A list of validation error messages. Empty if all is ok.
+    """
+    # Nested dict tracking count of resources per type per name.
+    # E.g. { 'some.resource.Type': { 'some-resource-name': 2 } }
+    type_name_counts = {}
+    for resource in resources:
+        r_type = resource.get('type', None)
+        r_name = resource.get('params', {}).get('name', None)
+        if r_type and r_name:
+            type_subdict = type_name_counts.setdefault(r_type, {})
+            count = type_subdict.get(r_name, 0)
+            type_subdict[r_name] = count + 1
+
+    errors = []
+
+    for type_, type_subdict in type_name_counts.items():
+        for name, count in type_subdict.items():
+            if count > 1:
+                errors.append(
+                    "Resource duplication: {0} resources of type '{1}' and "
+                    "name '{2}'.".format(count, type_, name))
+
+    return errors

--- a/os_migrate/plugins/modules/validate_resource_files.py
+++ b/os_migrate/plugins/modules/validate_resource_files.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: os_migrate.os_migrate.validate_resource_files
+
+short_description: Import OpenStack network
+
+version_added: "2.9"
+
+description:
+  - "Validate OS-Migrate YAML resource files."
+  - "Unique resource naming is validated across all files provided."
+
+options:
+  paths:
+    description:
+      - Resources YAML files to read.
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Read resources from /opt/os-migrate/networks.yml
+  os_migrate.os_migrate.validate_resource_files:
+    paths:
+      - /opt/os-migrate/networks.yml
+      - /opt/os-migrate/security_groups.yml
+      - /opt/os-migrate/security_group_rules.yml
+      - /opt/os-migrate/subnets.yml
+  register: validation_results
+
+- name: Debug-print validation results
+  debug:
+    var: validation_results
+'''
+
+RETURN = '''
+ok:
+    description: Whether validation passed without errors
+    returned: always
+    type: boolean
+resources:
+    description: Errors found
+    returned: always but can be empty
+    type: list of str
+'''
+
+import openstack
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import filesystem
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import validation
+
+
+def run_module():
+    module_args = dict(
+        paths=dict(type='list', required=True),
+    )
+
+    result = dict(
+        # This module doesn't change anything.
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        # Module doesn't change anything, we can let it run as-is in
+        # check mode.
+        supports_check_mode=True,
+    )
+
+    file_structs = []
+    for path in module.params['paths']:
+        file_structs.append(filesystem.load_resources_file(path))
+    errors = validation.get_errors_in_file_structs(file_structs)
+
+    result['ok'] = len(errors) == 0
+    result['errors'] = errors
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/roles/import_networks/defaults/main.yml
+++ b/os_migrate/roles/import_networks/defaults/main.yml
@@ -1,0 +1,1 @@
+import_networks_validate_file: true

--- a/os_migrate/roles/import_networks/tasks/main.yml
+++ b/os_migrate/roles/import_networks/tasks/main.yml
@@ -1,3 +1,15 @@
+- name: validate loaded resources
+  os_migrate.os_migrate.validate_resource_files:
+    paths:
+      - "{{ os_migrate_data_dir }}/networks.yml"
+  register: networks_file_validation
+  when: import_networks_validate_file
+
+- name: stop when errors found
+  fail:
+    msg: "{{ networks_file_validation.errors|join(' ') }}"
+  when: not networks_file_validation.ok
+
 - name: read networks resource file
   os_migrate.os_migrate.read_resources:
     path: "{{ os_migrate_data_dir }}/networks.yml"

--- a/os_migrate/roles/validate_data_dir/tasks/main.yml
+++ b/os_migrate/roles/validate_data_dir/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: list resource files
+  find:
+    paths:
+      - "{{ os_migrate_data_dir }}"
+    patterns:
+      - "*.yml"
+  register: resource_files_result
+
+- fail:
+    msg: No resource files found.
+  when: resource_files_result.files | count < 1
+
+- name: validate resource files
+  os_migrate.os_migrate.validate_resource_files:
+    paths: "{{ resource_files_result.files | map(attribute='path') | list }}"
+  register: validate_data_dir_result
+
+- name: stop if errors found
+  fail:
+    msg: "{{ validate_data_dir_result.errors | join(' ') }}"
+  when: not validate_data_dir_result.ok

--- a/os_migrate/tests/unit/test_validation.py
+++ b/os_migrate/tests/unit/test_validation.py
@@ -1,0 +1,37 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import const
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import validation
+from ansible_collections.os_migrate.os_migrate.tests.unit import fixtures
+
+
+class TestValidation(unittest.TestCase):
+
+    def test_get_errors_in_file_structs_duplication_single(self):
+        file_struct = fixtures.minimal_resource_file_struct()
+        self.assertEqual([], validation.get_errors_in_file_structs(
+            [file_struct]))
+
+        resources = file_struct['resources']
+        minimal2 = fixtures.minimal_resource()
+        minimal2[const.RES_INFO]['id'] = 'uuid-minimal-2'
+        resources.append(minimal2)
+        self.assertEqual(
+            ["Resource duplication: 2 resources of type 'openstack.Minimal' "
+             "and name 'minimal'."],
+            validation.get_errors_in_file_structs([file_struct]))
+
+    def test_get_errors_in_file_structs_duplication_multi(self):
+        file_struct1 = fixtures.minimal_resource_file_struct()
+        file_struct2 = fixtures.minimal_resource_file_struct()
+
+        self.assertEqual(
+            ["Resource duplication: 2 resources of type 'openstack.Minimal' "
+             "and name 'minimal'."],
+            validation.get_errors_in_file_structs(
+                [file_struct1, file_struct2]))

--- a/tests/func/data/validate_data_dir/invalid/networks-duplicate.yml
+++ b/tests/func/data/validate_data_dir/invalid/networks-duplicate.yml
@@ -1,0 +1,30 @@
+os_migrate_version: 0.1.0
+resources:
+- _info:
+    availability_zones: []
+    created_at: '2020-02-17T16:02:56Z'
+    id: ee2f0425-d87f-4173-90e5-b8993665a033
+    project_id: fc4098dfdf564598812a2a73c49c46df
+    qos_policy_id: null
+    revision_number: 1
+    status: ACTIVE
+    subnet_ids: []
+    updated_at: '2020-02-17T16:02:56Z'
+  params:
+    availability_zone_hints: []
+    description: osm_net test network
+    dns_domain: null
+    is_admin_state_up: true
+    is_default: null
+    is_port_security_enabled: true
+    is_router_external: false
+    is_shared: false
+    is_vlan_transparent: null
+    mtu: 1450
+    name: osm_net
+    provider_network_type: null
+    provider_physical_network: null
+    provider_segmentation_id: null
+    qos_policy_name: null
+    segments: null
+  type: openstack.network.Network

--- a/tests/func/data/validate_data_dir/invalid/networks.yml
+++ b/tests/func/data/validate_data_dir/invalid/networks.yml
@@ -1,0 +1,30 @@
+os_migrate_version: 0.1.0
+resources:
+- _info:
+    availability_zones: []
+    created_at: '2020-02-17T16:02:56Z'
+    id: ee2f0425-d87f-4173-90e5-b8993665a033
+    project_id: fc4098dfdf564598812a2a73c49c46df
+    qos_policy_id: null
+    revision_number: 1
+    status: ACTIVE
+    subnet_ids: []
+    updated_at: '2020-02-17T16:02:56Z'
+  params:
+    availability_zone_hints: []
+    description: osm_net test network
+    dns_domain: null
+    is_admin_state_up: true
+    is_default: null
+    is_port_security_enabled: true
+    is_router_external: false
+    is_shared: false
+    is_vlan_transparent: null
+    mtu: 1450
+    name: osm_net
+    provider_network_type: null
+    provider_physical_network: null
+    provider_segmentation_id: null
+    qos_policy_name: null
+    segments: null
+  type: openstack.network.Network

--- a/tests/func/data/validate_data_dir/valid/networks.yml
+++ b/tests/func/data/validate_data_dir/valid/networks.yml
@@ -1,0 +1,30 @@
+os_migrate_version: 0.1.0
+resources:
+- _info:
+    availability_zones: []
+    created_at: '2020-02-17T16:02:56Z'
+    id: ee2f0425-d87f-4173-90e5-b8993665a033
+    project_id: fc4098dfdf564598812a2a73c49c46df
+    qos_policy_id: null
+    revision_number: 1
+    status: ACTIVE
+    subnet_ids: []
+    updated_at: '2020-02-17T16:02:56Z'
+  params:
+    availability_zone_hints: []
+    description: osm_net test network
+    dns_domain: null
+    is_admin_state_up: true
+    is_default: null
+    is_port_security_enabled: true
+    is_router_external: false
+    is_shared: false
+    is_vlan_transparent: null
+    mtu: 1450
+    name: osm_net
+    provider_network_type: null
+    provider_physical_network: null
+    provider_segmentation_id: null
+    qos_policy_name: null
+    segments: null
+  type: openstack.network.Network

--- a/tests/func/independent/all.yml
+++ b/tests/func/independent/all.yml
@@ -1,0 +1,5 @@
+- include_tasks:
+    file: validate_data_dir.yml
+    apply:
+      tags:
+        - test_validate_data_dir

--- a/tests/func/independent/validate_data_dir.yml
+++ b/tests/func/independent/validate_data_dir.yml
@@ -1,0 +1,32 @@
+- name: validate valid dir
+  shell: |
+    OS_MIGRATE="$HOME/.ansible/collections/ansible_collections/os_migrate/os_migrate"
+    OS_MIGRATE_DATA="{{playbook_dir}}/data/validate_data_dir/valid"
+    ansible-playbook -v \
+        -i $OS_MIGRATE/localhost_inventory.yml \
+        -e "os_migrate_data_dir=$OS_MIGRATE_DATA" \
+        $OS_MIGRATE/playbooks/validate_data_dir.yml
+
+- name: validate invalid dir
+  shell: |
+    OS_MIGRATE="$HOME/.ansible/collections/ansible_collections/os_migrate/os_migrate"
+    OS_MIGRATE_DATA="{{playbook_dir}}/data/validate_data_dir/invalid"
+    ansible-playbook -v \
+        -i $OS_MIGRATE/localhost_inventory.yml \
+        -e "os_migrate_data_dir=$OS_MIGRATE_DATA" \
+        $OS_MIGRATE/playbooks/validate_data_dir.yml
+  failed_when: false
+  register: validate_data_dir_invalid_result
+
+- name: assert invalid dir validation failed
+  fail:
+    msg: |
+      =======
+      STDOUT:
+      =======
+      {{ validate_data_dir_invalid_result.stdout }}
+      =======
+      STDERR:
+      =======
+      {{ validate_data_dir_invalid_result.stderr }}
+  when: validate_data_dir_invalid_result.rc == 0

--- a/tests/func/test_all.yml
+++ b/tests/func/test_all.yml
@@ -1,4 +1,11 @@
-- name: Migration
+- name: Independent tests
+  hosts: migrator
+  tasks:
+    - import_tasks: independent/all.yml
+  tags:
+    - test_independent
+
+- name: Migration tests
   hosts: migrator
   tasks:
     - import_tasks: global/prep.yml
@@ -7,3 +14,5 @@
     - import_tasks: run/all.yml
     - import_tasks: idempotence/all.yml
     - import_tasks: clean/all.yml
+  tags:
+    - test_migration


### PR DESCRIPTION
This adds validation of resource files. Unique resource naming in
ensured per resource type. Multiple resource files can be fed into the
validation, so if someone had a resource file setup where resources of
the same type are spread across multiple files, the names would still
get validated properly.

Validation can currently be executed in 2 ways:

* After loading resources, before importing them (can be disabled by a
  boolean flag).

* Independently on all resources in a directory via validate_data_dir
  playbook.

Closes #58 .