### PR TITLE
Update Vagrant-Devstack setup to Fedora 30

### DIFF
--- a/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
@@ -7,12 +7,6 @@
   become: true
   become_user: stack
 
-- name: hack devstack until we switch to Fedora 30 or CentOS 8
-  lineinfile:
-    path: /home/stack/devstack/lib/nova
-    regexp: sudo dnf copr enable -y iwienand/iscsi-initiator-utils
-    state: absent
-
 - name: write devstack config
   template:
     src: local.conf.j2

--- a/toolbox/vagrant/vagrant-config.yml
+++ b/toolbox/vagrant/vagrant-config.yml
@@ -1,6 +1,6 @@
 libvirt:
-  # vagrant box add --name fedora29 https://download.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-29-1.2.x86_64.vagrant-libvirt.box
-  box: fedora29
+  # vagrant box add --name fedora30 https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-30-1.2.x86_64.vagrant-libvirt.box
+  box: fedora30
   default_prefix: os_migrate
   private_net_name: os_migrate
   storage_pool_name: vagrant

--- a/toolbox/vagrant/vagrant-up
+++ b/toolbox/vagrant/vagrant-up
@@ -5,8 +5,8 @@ set -euxo pipefail
 if ! virsh pool-list | grep vagrant &> /dev/null; then
     virsh pool-create-as vagrant dir --target $HOME/.local/share/libvirt/vagrant
 fi
-if ! vagrant box list | grep fedora29 &> /dev/null; then
-    vagrant box add --name fedora29 https://download.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-29-1.2.x86_64.vagrant-libvirt.box
+if ! vagrant box list | grep fedora30 &> /dev/null; then
+    vagrant box add --name fedora30 https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-30-1.2.x86_64.vagrant-libvirt.box
 fi
 
 vagrant up


### PR DESCRIPTION
Fedora 29 is no longer supported.

Closes https://github.com/os-migrate/os-migrate/issues/74
Closes https://github.com/os-migrate/os-migrate/issues/65