### PR TITLE
Including matching id by name for the security group name on rules param section

### DIFF
--- a/os_migrate/plugins/module_utils/reference.py
+++ b/os_migrate/plugins/module_utils/reference.py
@@ -14,6 +14,18 @@ def qos_policy_name(conn, id_, required=True):
     return _fetch_name(conn.network.find_qos_policy, id_, required)
 
 
+def security_group_name(conn, id_, required=True):
+    """Fetch name of the Security Group identified by ID `id_`. Use OpenStack SDK
+    connection `conn` to fetch the info. If `required`, ensure the
+    fetch is successful.
+
+    Returns: the name, or None if not found and not `required`
+
+    Raises: openstack's ResourceNotFound when `required` but not found
+    """
+    return _fetch_name(conn.network.find_security_group, id_, required)
+
+
 def qos_policy_id(conn, name, required=True):
     """Fetch ID of QoS Policy identified by name `name`. Use OpenStack SDK
     connection `conn` to fetch the info. If `required`, ensure the

--- a/os_migrate/plugins/modules/export_security_group_rules.py
+++ b/os_migrate/plugins/modules/export_security_group_rules.py
@@ -85,7 +85,8 @@ def run_module():
         # We check that serialize_security_group_rule receives
         # a openstack.network.v2.security_group_rule.SecurityGroupRule
         sec_rule_obj = openstack.network.v2.security_group_rule.SecurityGroupRule(**rule)
-        ser_sec = network.serialize_security_group_rule(sec_rule_obj)
+        sec_refs = network.security_group_rule_refs_from_sdk(conn, sec_rule_obj)
+        ser_sec = network.serialize_security_group_rule(sec_rule_obj, sec_refs)
 
     result['changed'] = filesystem.write_or_replace_resource(
         module.params['path'], ser_sec)

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -105,6 +105,13 @@ def network_refs():
     }
 
 
+def security_group_rule_refs():
+    return {
+        'security_group_name': 'default',
+        'remote_group_name': 'default',
+    }
+
+
 def serialized_network():
     return {
         const.RES_PARAMS: {
@@ -175,7 +182,9 @@ def sdk_security_group_rule():
     return openstack.network.v2.security_group_rule.SecurityGroupRule(
         id='uuid',
         security_group_id='uuid-sec-group',
+        security_group_name='default',
         remote_group_id='uuid-group',
+        remote_group_name='default',
         project_id='uuid-project',
         created_at='2020-01-30T14:49:06Z',
         updated_at='2020-01-30T14:49:06Z',

--- a/os_migrate/tests/unit/test_security_group_rule.py
+++ b/os_migrate/tests/unit/test_security_group_rule.py
@@ -12,11 +12,14 @@ class TestSecurityGroupRule(unittest.TestCase):
 
     def test_serialize_security_group_rule(self):
         sec = fixtures.sdk_security_group_rule()
-        serialized = network.serialize_security_group_rule(sec)
+        sec_refs = fixtures.security_group_rule_refs()
+        serialized = network.serialize_security_group_rule(sec, sec_refs)
         s_params = serialized['params']
         s_info = serialized['_info']
 
         self.assertEqual(serialized['type'], 'openstack.network.SecurityGroupRule')
+        self.assertEqual(s_params['security_group_name'], 'default')
+        self.assertEqual(s_params['remote_group_name'], 'default')
         self.assertEqual(s_params['description'], 'null')
         self.assertEqual(s_params['direction'], 'ingress')
         self.assertEqual(s_params['port_range_max'], 100)


### PR DESCRIPTION
This commit adds the parameter security_group_name
to the params section.

Closes: #79