### PR TITLE
registry.fedoraproject.org consistently fails on pulling images

### DIFF
--- a/toolbox/Dockerfile
+++ b/toolbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:31
+FROM docker.io/library/fedora:31
 ADD build /build
 RUN bash /build/build.sh
 WORKDIR /root/os_migrate


### PR DESCRIPTION
We had several CI issues related to errors when pulling the
container image from registry.fedoraproject.org

Maybe we wont hit this anymore if we use Docker Hub.
Also, the image shuold be exactly the same.