### PR TITLE
Idea: Some OOP refactoring

### DIFF
--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -1,3 +1,8 @@
+from __future__ import (absolute_import, division, print_function)
+from enum import Enum
+__metaclass__ = type
+
+
 OS_MIGRATE_VERSION = '0.1.0'  # updated by build.sh
 
 # Main serialization sections
@@ -10,3 +15,21 @@ RES_TYPE_NETWORK = 'openstack.network.Network'
 RES_TYPE_SECURITYGROUPRULE = 'openstack.network.SecurityGroupRule'
 RES_TYPE_SECURITYGROUP = 'openstack.network.SecurityGroup'
 RES_TYPE_SUBNET = 'openstack.subnet.Subnet'
+
+
+# NOTE: OOP
+# enums to replace the const values above.  Still provides . access to values
+# but easier to read IMO.  The tradeoff that I see is when you want access to
+# the string value under the type, you have to call .value
+# const.RES_TYPE_NETWORK vs ResourceType.NETWORK
+class ResourceType(Enum):
+    NETWORK = 'openstack.network.Network'
+    SECURITY_GROUP_RULE = 'openstack.network.SecurityGroupRule'
+    SECURITY_GROUP = 'openstack.network.SecurityGroup'
+    SUBNET = 'openstack.subnet.Subnet'
+
+
+class Sections(Enum):
+    PARAMS = 'params'
+    TYPE = 'type'
+    INFO = '_info'

--- a/os_migrate/plugins/module_utils/subnet.py
+++ b/os_migrate/plugins/module_utils/subnet.py
@@ -3,32 +3,16 @@ __metaclass__ = type
 
 import openstack
 
-from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
-from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.const \
+    import ResourceType
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils.serialization \
-    import set_sdk_params_same_name, set_ser_params_same_name
+    import Resource
 
 
-def serialize_subnet(sdk_subnet):
-    """Serialize OpenStack SDK network `sdk_net` into OS-Migrate
-    format. Use `net_refs` for id-to-name mappings.
-
-    Returns: Dict - OS-Migrate structure for Network
-    """
+class SubnetResource(Resource):
     expected_type = openstack.network.v2.subnet.Subnet
-    if type(sdk_subnet) != expected_type:
-        raise exc.UnexpectedResourceType(expected_type, type(sdk_subnet))
-
-    resource = {}
-    params = {}
-    info = {}
-    resource[const.RES_PARAMS] = params
-    resource[const.RES_INFO] = info
-    resource[const.RES_TYPE] = const.RES_TYPE_SUBNET
-
-    # FIXME: We will need to eventually add network_name, subnet_pool_name
-    # and segment_name into params.  See issue #88.
-    set_ser_params_same_name(params, sdk_subnet, [
+    serialized_type = ResourceType.SUBNET
+    parameters = [
         'allocation_pools',
         'cidr',
         'description',
@@ -43,9 +27,8 @@ def serialize_subnet(sdk_subnet):
         'service_types',
         'tags',
         'use_default_subnet_pool'
-    ])
-
-    set_ser_params_same_name(info, sdk_subnet, [
+    ]
+    information = [
         'created_at',
         'id',
         'network_id',
@@ -55,6 +38,4 @@ def serialize_subnet(sdk_subnet):
         'segment_id',
         'subnet_pool_id',
         'updated_at',
-    ])
-
-    return resource
+    ]

--- a/os_migrate/plugins/modules/export_network.py
+++ b/os_migrate/plugins/modules/export_network.py
@@ -79,7 +79,7 @@ def run_module():
     conn = openstack.connect(cloud=module.params['cloud'])
     sdk_net = conn.network.find_network(module.params['name'], ignore_missing=False)
     net_refs = network.network_refs_from_sdk(conn, sdk_net)
-    ser_net = network.serialize_network(sdk_net, net_refs)
+    ser_net = network.NetworkResource(content=sdk_net, external_content=net_refs).serialize()
 
     result['changed'] = filesystem.write_or_replace_resource(
         module.params['path'], ser_net)

--- a/os_migrate/plugins/modules/export_subnet.py
+++ b/os_migrate/plugins/modules/export_subnet.py
@@ -77,7 +77,9 @@ def run_module():
 
     conn = openstack.connect(cloud=module.params['cloud'])
     sdk_subnet = conn.network.find_subnet(module.params['name'], ignore_missing=False)
-    ser_subnet = subnet.serialize_subnet(sdk_subnet)
+    ser_subnet = subnet.SubnetResource(content=sdk_subnet).serialize()
+
+    # ser_subnet = subnet.serialize_subnet(sdk_subnet)
 
     result['changed'] = filesystem.write_or_replace_resource(
         module.params['path'], ser_subnet)

--- a/os_migrate/tests/unit/test_network.py
+++ b/os_migrate/tests/unit/test_network.py
@@ -3,6 +3,8 @@ __metaclass__ = type
 
 import unittest
 
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.const \
+    import ResourceType
 from ansible_collections.os_migrate.os_migrate.tests.unit import fixtures
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
     import network
@@ -13,11 +15,17 @@ class TestNetwork(unittest.TestCase):
     def test_serialize_network(self):
         net = fixtures.sdk_network()
         net_refs = fixtures.network_refs()
-        serialized = network.serialize_network(net, net_refs)
+        serialized = network.NetworkResource(
+            content=net,
+            external_content=net_refs
+        ).serialize()
         s_params = serialized['params']
         s_info = serialized['_info']
 
-        self.assertEqual(serialized['type'], 'openstack.network.Network')
+        print(net_refs)
+        print(s_info)
+
+        self.assertEqual(serialized['type'], ResourceType.NETWORK)
         self.assertEqual(s_params['availability_zone_hints'], ['nova', 'zone2'])
         self.assertEqual(s_params['description'], 'test network')
         self.assertEqual(s_params['dns_domain'], 'example.org')
@@ -73,7 +81,10 @@ class TestNetwork(unittest.TestCase):
     def test_network_needs_update(self):
         sdk_net = fixtures.sdk_network()
         net_refs = fixtures.network_refs()
-        serialized = network.serialize_network(sdk_net, net_refs)
+        serialized = network.NetworkResource(
+            content=sdk_net,
+            external_content=net_refs
+        ).serialize()
 
         self.assertFalse(network.network_needs_update(
             sdk_net, net_refs, serialized))

--- a/os_migrate/tests/unit/test_subnet.py
+++ b/os_migrate/tests/unit/test_subnet.py
@@ -4,6 +4,8 @@ __metaclass__ = type
 import unittest
 
 from ansible_collections.os_migrate.os_migrate.tests.unit import fixtures
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.const \
+    import ResourceType
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
     import subnet
 
@@ -12,11 +14,11 @@ class TestSubnet(unittest.TestCase):
 
     def test_serialize_subnet(self):
         subnet_data = fixtures.sdk_subnet()
-        serialized = subnet.serialize_subnet(subnet_data)
-        s_params = serialized['params']
-        s_info = serialized['_info']
+        ser_subnet = subnet.SubnetResource(content=subnet_data).serialize()
+        s_params = ser_subnet['params']
+        s_info = ser_subnet['_info']
 
-        self.assertEqual(serialized['type'], 'openstack.subnet.Subnet')
+        self.assertEqual(ser_subnet['type'], ResourceType.SUBNET)
         self.assertEqual(s_params['allocation_pools'],
                          [{'start': '10.10.10.2', 'end': '10.10.10.254'}])
         self.assertEqual(s_params['cidr'], '10.10.10.0/24')


### PR DESCRIPTION
The purpose of this patch was to demonstrate an area I think OOP
could be saving us time in creating resources.  I focused solely
on the export for now and only the non-nested resources.  I thought
it prudent to just do enough of a patch to get the point across, but
not too much in case we just throw it away.

IMO the main savings is reducing the amount of boilerplate to create
an export.  The SubnetResource and NetworkResource classes illustrate
how a little bit of OOP can help us just focus on adding enough code
to describe the types, info and parameters and not need to add the rest.