### PR TITLE
Allow running functional tests more individually

### DIFF
--- a/tests/func/clean/all.yml
+++ b/tests/func/clean/all.yml
@@ -3,27 +3,42 @@
     apply:
       tags:
         - test_router
+        - test_clean
+  tags:
+    - always
 
 - include_tasks:
     file: subnet.yml
     apply:
       tags:
         - test_subnet
+        - test_clean
+  tags:
+    - always
 
 - include_tasks:
     file: network.yml
     apply:
       tags:
         - test_network
+        - test_clean
+  tags:
+    - always
 
 - include_tasks:
     file: security_group_rule.yml
     apply:
       tags:
         - test_security_group_rule
+        - test_clean
+  tags:
+    - always
 
 - include_tasks:
     file: security_group.yml
     apply:
       tags:
         - test_security_group
+        - test_clean
+  tags:
+    - always

--- a/tests/func/idempotence/all.yml
+++ b/tests/func/idempotence/all.yml
@@ -3,3 +3,4 @@
     apply:
       tags:
         - test_network
+  tags: always

--- a/tests/func/run/all.yml
+++ b/tests/func/run/all.yml
@@ -3,27 +3,32 @@
     apply:
       tags:
         - test_network
+  tags: always
 
 - include_tasks:
     file: subnet.yml
     apply:
       tags:
         - test_subnet
+  tags: always
 
 - include_tasks:
     file: security_group.yml
     apply:
       tags:
         - test_security_group
+  tags: always
 
 - include_tasks:
     file: security_group_rule.yml
     apply:
       tags:
         - test_security_group_rule
+  tags: always
 
 - include_tasks:
     file: router.yml
     apply:
       tags:
         - test_router
+  tags: always

--- a/tests/func/seed/all.yml
+++ b/tests/func/seed/all.yml
@@ -3,27 +3,32 @@
     apply:
       tags:
         - test_network
+  tags: always
 
 - include_tasks:
     file: subnet.yml
     apply:
       tags:
         - test_subnet
+  tags: always
 
 - include_tasks:
     file: security_group.yml
     apply:
       tags:
         - test_security_group
+  tags: always
 
 - include_tasks:
     file: security_group_rule.yml
     apply:
       tags:
         - test_security_group_rule
+  tags: always
 
 - include_tasks:
     file: router.yml
     apply:
       tags:
         - test_router
+  tags: always


### PR DESCRIPTION
Now one can run this to run only Network tests for example:

./toolbox/run bash -c "FUNC_TEST_ARGS='--tags test_network' make test-func"

or Network + Subnet tests:

./toolbox/run bash -c "FUNC_TEST_ARGS='--tags test_network,test_subnet' make test-func"

Special new use case is:

./toolbox/run bash -c "FUNC_TEST_ARGS='--tags test_clean' make test-func"

which will only clean up the test data from the named clouds.