### PR TITLE
Resource class

### DIFF
--- a/os_migrate/plugins/module_utils/filesystem.py
+++ b/os_migrate/plugins/module_utils/filesystem.py
@@ -6,6 +6,7 @@ from os import path
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.resource import Resource
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import serialization
 
 

--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -3,54 +3,18 @@ __metaclass__ = type
 
 import openstack
 
-from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
-from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
-from ansible_collections.os_migrate.os_migrate.plugins.module_utils import reference
-from ansible_collections.os_migrate.os_migrate.plugins.module_utils import serialization
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import const, exc, reference, resource, serialization
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils.serialization \
     import set_sdk_params_same_name, set_ser_params_same_name
 
 
-def serialize_network(sdk_net, net_refs):
-    """Serialize OpenStack SDK network `sdk_net` into OS-Migrate
-    format. Use `net_refs` for id-to-name mappings.
+class Network(resource.Resource):
 
-    Returns: Dict - OS-Migrate structure for Network
-    """
-    expected_type = openstack.network.v2.network.Network
-    if type(sdk_net) != expected_type:
-        raise exc.UnexpectedResourceType(expected_type, type(sdk_net))
+    resource_type = const.RES_TYPE_NETWORK
+    sdk_class = openstack.network.v2.network.Network
 
-    resource = {}
-    params = {}
-    info = {}
-    resource[const.RES_PARAMS] = params
-    resource[const.RES_INFO] = info
-    resource[const.RES_TYPE] = const.RES_TYPE_NETWORK
-
-    params['availability_zone_hints'] = sorted(sdk_net['availability_zone_hints'])
-    set_ser_params_same_name(params, sdk_net, [
-        'description',
-        'dns_domain',
-        'is_admin_state_up',
-        'is_default',
-        'is_port_security_enabled',
-        'is_router_external',
-        'is_shared',
-        'is_vlan_transparent',
-        'mtu',
-        'name',
-        'provider_network_type',
-        'provider_physical_network',
-        'provider_segmentation_id',
-        'segments',
-    ])
-    set_ser_params_same_name(params, net_refs, [
-        'qos_policy_name',
-    ])
-
-    info['subnet_ids'] = sorted(sdk_net['subnet_ids'])
-    set_ser_params_same_name(info, sdk_net, [
+    info_from_sdk = [
         'availability_zones',
         'created_at',
         'id',
@@ -58,27 +22,10 @@ def serialize_network(sdk_net, net_refs):
         'qos_policy_id',
         'revision_number',
         'status',
+        'subnet_ids',
         'updated_at',
-    ])
-
-    return resource
-
-
-def network_sdk_params(ser_net, net_refs):
-    """Create OpenStack SDK parameters dict for creation or update of the
-    OS-Migrate Network serialization `ser_net`. Use `net_refs` for
-    name-to-id mappings.
-
-    Returns: Parameters to be fed into `openstack.network.v2.network.Network`
-    """
-    res_type = ser_net.get(const.RES_TYPE, None)
-    if res_type != const.RES_TYPE_NETWORK:
-        raise exc.UnexpectedResourceType(const.RES_TYPE_NETWORK, res_type)
-
-    ser_params = ser_net[const.RES_PARAMS]
-    sdk_params = {}
-
-    set_sdk_params_same_name(ser_params, sdk_params, [
+    ]
+    params_from_sdk = [
         'availability_zone_hints',
         'description',
         'dns_domain',
@@ -94,24 +41,48 @@ def network_sdk_params(ser_net, net_refs):
         'provider_physical_network',
         'provider_segmentation_id',
         'segments',
-    ])
-    set_sdk_params_same_name(net_refs, sdk_params, [
+    ]
+    params_from_refs = [
+        'qos_policy_name',
+    ]
+    sdk_params_from_refs = [
         'qos_policy_id',
-    ])
+    ]
 
-    return sdk_params
+    @classmethod
+    def from_sdk(cls, conn, sdk_resource):
+        obj = super(Network, cls).from_sdk(conn, sdk_resource)
+        obj._sort_param('availability_zone_hints')
+        obj._sort_info('subnet_ids')
+        return obj
 
+    def create_or_update(self, conn):
+        refs = self._refs_from_ser(conn)
+        sdk_params = self._to_sdk_params(refs)
+        existing = conn.network.find_network(sdk_params['name'])
+        if existing:
+            if self._needs_update(Network.from_sdk(conn, existing)):
+                conn.network.update_network(sdk_params['name'], **sdk_params)
+                return True
+        else:
+            conn.network.create_network(**sdk_params)
+            return True
+        return False  # no change done
 
-def network_needs_update(sdk_net, net_refs, target_ser_net):
-    """Having OpenStack SDK network `sdk_net` and corresponding id-name
-    mappings `net_refs`, decide if the network needs to be updated to
-    reach state represented in OS-Migrate Network serialization
-    `target_ser_net`.
+    @staticmethod
+    def _refs_from_sdk(conn, sdk_res):
+        refs = {}
+        refs['qos_policy_id'] = sdk_res['qos_policy_id']
+        refs['qos_policy_name'] = reference.qos_policy_name(
+            conn, sdk_res['qos_policy_id'])
+        return refs
 
-    Returns: True if network needs to be updated, False otherwise
-    """
-    current_ser_net = serialize_network(sdk_net, net_refs)
-    return serialization.resource_needs_update(current_ser_net, target_ser_net)
+    def _refs_from_ser(self, conn):
+        refs = {}
+        refs['qos_policy_name'] = self.params()['qos_policy_name']
+        refs['qos_policy_id'] = reference.qos_policy_id(
+            conn, self.params()['qos_policy_name'])
+        return refs
 
 
 def security_group_needs_update(sdk_sec, target_ser_sec):
@@ -124,28 +95,6 @@ def security_group_needs_update(sdk_sec, target_ser_sec):
     """
     current_ser_sec = serialize_security_group(sdk_sec)
     return serialization.resource_needs_update(current_ser_sec, target_ser_sec)
-
-
-def network_refs_from_sdk(conn, sdk_net):
-    """Create a dict of name/id mappings for resources referenced from
-    OpenStack SDK Network `sdk_net`. Fetch any necessary information
-    from OpenStack SDK connection `conn`.
-
-    Returns: dict with names and IDs of resources referenced from
-    `sdk_net` (only those important for OS-Migrate)
-    """
-    expected_type = openstack.network.v2.network.Network
-    if type(sdk_net) != expected_type:
-        raise exc.UnexpectedResourceType(expected_type, type(sdk_net))
-    refs = {}
-
-    # when creating refs from SDK Network object, we copy IDs and
-    # query the cloud for names
-    refs['qos_policy_id'] = sdk_net['qos_policy_id']
-    refs['qos_policy_name'] = reference.qos_policy_name(
-        conn, sdk_net['qos_policy_id'])
-
-    return refs
 
 
 def security_group_rule_refs_from_sdk(conn, sdk_rule):
@@ -167,29 +116,6 @@ def security_group_rule_refs_from_sdk(conn, sdk_rule):
         conn, sdk_rule['security_group_id'])
     refs['remote_group_name'] = reference.security_group_name(
         conn, sdk_rule['remote_group_id'])
-
-    return refs
-
-
-def network_refs_from_ser(conn, ser_net):
-    """Create a dict of name/id mappings for resources referenced from
-    OS-Migrage network serialization `sdk_net`. Fetch any necessary
-    information from OpenStack SDK connection `conn`.
-
-    Returns: dict with names and IDs of resources referenced from
-    `sdk_net` (only those important for OS-Migrate)
-    """
-    if ser_net[const.RES_TYPE] != const.RES_TYPE_NETWORK:
-        raise exc.UnexpectedResourceType(
-            const.RES_TYPE_NETWORK, ser_net[const.RES_TYPE])
-    ser_params = ser_net[const.RES_PARAMS]
-    refs = {}
-
-    # when creating refs from serialized Network, we copy names and
-    # query the cloud for IDs
-    refs['qos_policy_name'] = ser_params['qos_policy_name']
-    refs['qos_policy_id'] = reference.qos_policy_id(
-        conn, ser_params['qos_policy_name'])
 
     return refs
 

--- a/os_migrate/plugins/module_utils/resource.py
+++ b/os_migrate/plugins/module_utils/resource.py
@@ -1,0 +1,237 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import const, exc
+
+
+class Resource():
+
+    resource_type = 'UNDEFINED'
+    sdk_class = 'UNDEFINED'
+
+    info_from_sdk = []
+    info_from_refs = []
+    params_from_sdk = []
+    params_from_refs = []
+    sdk_params_from_refs = []
+
+    # ===== PUBLIC CLASS/STATIC METHODS (alphabetic sort) =====
+
+    # This constructor should work OOTB in all cases, shouldn't be
+    # overriden in child classes.
+    @classmethod
+    def from_data(cls, data):
+        """Returns: a new Resource instance with internal data set from `data`
+        parameter.
+        """
+        res_type = data.get('type', None)
+        if res_type != cls.resource_type:
+            raise exc.UnexpectedResourceType(cls.resource_type, res_type)
+
+        obj = cls()
+        # Barring resource type errors, we allow Resource subclass
+        # construction with invalid data so that we don't break on
+        # loading a data file, but we explicitly fail with full list
+        # of errors (rather than a single exception) when all
+        # resources are validated with is_data_valid() and/or
+        # data_errors().
+        obj.data = data
+        # Just in case the data didn't contain those keys (invalid
+        # data), set to empty defaults so that all other methods can
+        # rely on these existing rather than calling dict.get().
+        obj.data.setdefault(const.RES_PARAMS, {})
+        obj.data.setdefault(const.RES_INFO, {})
+        return obj
+
+    # Meant to be extended in child classes, but can be overriden
+    # completely.
+    @classmethod
+    def from_sdk(cls, conn, sdk_resource):
+        """Returns: a new Resource instance intitalized from `sdk_resource`,
+        using `conn` OpenStack SDK connection to fetch any additional
+        information.
+        """
+        if not isinstance(sdk_resource, cls.sdk_class):
+            raise exc.UnexpectedResourceType(
+                cls.sdk_class, sdk_resource.__class__)
+
+        obj = cls()
+        obj._data_from_sdk_and_refs(
+            sdk_resource, cls._refs_from_sdk(conn, sdk_resource))
+        obj.data['type'] = cls.resource_type
+        return obj
+
+    # === PRIVATE CLASS/STATIC METHODS (alphabetic sort) ===
+
+    # Used when creating Resource from SDK object, should be overriden
+    # in majority of child classes.
+    @staticmethod
+    def _refs_from_sdk(conn, sdk_res):
+        """Create a dictionary of references from OpenStack SDK resource
+        instance `sdk_res` and OpenStack SDK connection `conn`. Get
+        IDs from `sdk_res` and fetch names from `conn`.
+
+        Returns: dict with names and ids
+        """
+        return {}
+
+    # Not meant to be overriden in majority of subclasses.
+    @classmethod
+    def _set_sdk_params_same_name(cls, ser_params, sdk_params, param_names):
+        """Copy values from `ser_params` into `sdk_params` for all keys in
+        `param_names` (list of strings), only for values in `ser_params`
+        which aren't None.
+        """
+        for p_name in param_names:
+            cls._set_sdk_param(ser_params, p_name, sdk_params, p_name)
+
+    # Not meant to be overriden in majority of subclasses.
+    @staticmethod
+    def _set_sdk_param(ser_params, ser_key, sdk_params, sdk_key):
+        """Assign value from `ser_key` in `ser_params` dict as value for
+        `sdk_key` in `sdk_params`, but only if it isn't None.
+        """
+        if ser_params.get(ser_key, None) is not None:
+            sdk_params[sdk_key] = ser_params[ser_key]
+
+    # Not meant to be overriden in majority of subclasses.
+    @staticmethod
+    def _set_ser_params_same_name(ser_params, sdk_params, param_names):
+        """Copy values from `sdk_params` to `ser_params` for keys listed in
+        `param_names` (list of strings).
+        """
+        for p_name in param_names:
+            ser_params[p_name] = sdk_params[p_name]
+
+    # ===== PUBLIC INSTANCE METHODS (alphabetic sort) =====
+
+    # Meant to be reused in child classes, but can be overriden
+    # completely.
+    def create_or_update(self, conn):
+        """Create the resource `self` in the target OpenStack cloud connection
+        `conn`, or update it if it already exists but needs to be
+        updated, or do nothing if it already matches desired state.
+
+        Returns: True if any change was made, False otherwise
+        """
+        # TODO: It would be nice to provide a default implementation
+        # here, we'll have to do some dynamic method lookup though,
+        # because we need to reference methods under conn (runtime
+        # object), so AFAICT we cannot simply point to something
+        # static in OpenStack SDK.
+        return False
+
+    def info(self):
+        return self.data[const.RES_INFO]
+
+    def params(self):
+        return self.data[const.RES_PARAMS]
+
+    def params_and_info(self):
+        return (self.params(), self.info())
+
+    def type(self):
+        return self.data[const.RES_TYPE]
+
+    # TODO add validation
+    # def is_data_valid(self):
+    # def data_errors(self):
+    # def are_prerequisites_met(self, conn):
+
+    # === PRIVATE INSTANCE METHODS (alphabetic sort) ===
+
+    # This method should only be called by when creating subclasses
+    # and Resource should not be instantiated directly, not sure if we
+    # have a way to enforce that in Python.
+    def __init__(self):
+        self.data = {
+            const.RES_TYPE: None,
+            const.RES_PARAMS: {},
+            const.RES_INFO: {},
+        }
+
+    # Not meant to be overriden in majority of subclasses.
+    def _data_from_sdk_and_refs(self, sdk_res, refs):
+        """Fill `self` internal params and info structures with values from
+        `sdk_res` and `refs`.
+        """
+        params, info = self.params_and_info()
+        self._set_ser_params_same_name(params, sdk_res, self.params_from_sdk)
+        self._set_ser_params_same_name(params, refs, self.params_from_refs)
+        self._set_ser_params_same_name(info, sdk_res, self.info_from_sdk)
+        self._set_ser_params_same_name(info, refs, self.info_from_refs)
+
+    # Not meant to be overriden in majority of subclasses.
+    def _needs_update(self, target):
+        """Check if `target` resource needs to be updated to match the state
+        defined in `self`.
+
+        Returns: True if `target` needs to be updated, False otherwise
+        """
+        return self._data_without_info() != target._data_without_info()
+
+    # Used when creating params for SDK calls, should be overriden in
+    # majority of child classes.
+    def _refs_from_ser(self, conn):
+        """Create a dictionary of references of `self` using OpenStack SDK
+        connection `conn` to fetch any necessary info. Get names from
+        `self` and fetch IDs from `conn`.
+
+        Returns: dict with names and ids
+        """
+        return {}
+
+    # Not meant to be overriden in majority of subclasses.
+    def _sdk_params_from_params_and_refs(self, sdk_params, refs):
+        """Fill `sdk_params` with values from `self` internal parameters and
+        from `refs`.
+        """
+        # we could move these methods from serialization.py to private
+        # under Resource
+        self._set_sdk_params_same_name(self.params(), sdk_params, self.params_from_sdk)
+        self._set_sdk_params_same_name(refs, sdk_params, self.sdk_params_from_refs)
+
+    # Not meant to be overriden in majority of subclasses.
+    def _sort_param(self, param_name):
+        """Sort internal param `param_name`."""
+        self.params()[param_name] = sorted(self.params()[param_name])
+
+    # Not meant to be overriden in majority of subclasses.
+    def _sort_info(self, info_name):
+        """Sort internal info `info_name`."""
+        self.info()[info_name] = sorted(self.info()[info_name])
+
+    # Not meant to be overriden in majority of subclasses.
+    def _to_sdk_params(self, refs):
+        """Returns: dict - `self` formatted as creation/update params for
+        OpenStack SDK API call.
+        """
+        sdk_params = {}
+        self._sdk_params_from_params_and_refs(sdk_params, refs)
+        return sdk_params
+
+    # Not meant to be overriden in majority of subclasses.
+    def _data_without_info(self):
+        """Returns: serialized `self.data` with all the '_info' keys removed,
+        even from nested resources. The original `self.data` structure
+        is untouched, but the returned structure does reuse data
+        contents to save memory (it is not a deep copy).
+        """
+        def _recursive_trim(obj):
+            if isinstance(obj, dict):
+                result_dict = {}
+                for k, v in obj.items():
+                    if k == const.RES_INFO:
+                        continue
+                    result_dict[k] = _recursive_trim(v)
+                return result_dict
+            elif isinstance(obj, list):
+                result_list = []
+                for item in obj:
+                    result_list.append(_recursive_trim(item))
+                return result_list
+            else:
+                return obj
+
+        return _recursive_trim(self.data)

--- a/os_migrate/plugins/module_utils/serialization.py
+++ b/os_migrate/plugins/module_utils/serialization.py
@@ -1,6 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.resource \
+    import Resource
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 
 
@@ -14,13 +16,21 @@ def new_resources_file_struct():
     return data
 
 
-def add_or_replace_resource(resources, resource):
+def add_or_replace_resource(resources, resource_or_data):
     """Add a `resource` into `resources` struct, or replace it if already
     present (check via is_same_resource). Edits `resources` in place.
 
     Returns: True if something changed in resources structure, False
     otherwise
     """
+    # TODO: remove this compatibility handler when everything is a
+    # Resource, rename parameter from `resource_or_data` back to
+    # `resource`
+    if isinstance(resource_or_data, Resource):
+        resource = resource_or_data.data
+    else:
+        resource = resource_or_data
+
     for i, r in enumerate(resources):
         if is_same_resource(r, resource):
             if r == resource:
@@ -34,6 +44,7 @@ def add_or_replace_resource(resources, resource):
     return True
 
 
+# TODO: move sameness check into Resource when everything is a Resource
 def is_same_resource(res1, res2):
     """Check whether two `res1` and `res2` dicts represent the same
     resource. Type and id are checked.
@@ -54,6 +65,7 @@ def is_same_resource(res1, res2):
             res2.get(const.RES_INFO, {}).get('id', '__undefined2__'))
 
 
+# TODO: Remove when everything is a Resource
 def resource_needs_update(current, target):
     """Having two serialized resources, `current` and `target`, check if
     the `current` resource is already in `target` state or if it needs
@@ -68,6 +80,7 @@ def resource_needs_update(current, target):
     return current_trimmed != target_trimmed
 
 
+# TODO: Remove when everything is a Resource
 def set_sdk_param(ser_params, ser_key, sdk_params, sdk_key):
     """Assign value from `ser_key` in `ser_params` dict as value for
     `sdk_key` in `sdk_params`, but only if it isn't None.
@@ -76,6 +89,7 @@ def set_sdk_param(ser_params, ser_key, sdk_params, sdk_key):
         sdk_params[sdk_key] = ser_params[ser_key]
 
 
+# TODO: Remove when everything is a Resource
 def set_sdk_params_same_name(ser_params, sdk_params, param_names):
     """Copy values from `ser_params` into `sdk_params` for all keys in
     `param_names` (list of strings), only for values in `ser_params`
@@ -85,6 +99,7 @@ def set_sdk_params_same_name(ser_params, sdk_params, param_names):
         set_sdk_param(ser_params, p_name, sdk_params, p_name)
 
 
+# TODO: Remove when everything is a Resource
 def set_ser_params_same_name(ser_params, sdk_params, param_names):
     """Copy values from `sdk_params` to `ser_params` for keys listed in
     `param_names` (list of strings).
@@ -93,6 +108,7 @@ def set_ser_params_same_name(ser_params, sdk_params, param_names):
         ser_params[p_name] = sdk_params[p_name]
 
 
+# TODO: Remove when everything is a Resource
 def _trim_info(resource):
     """Returns: serialized `resource` with all the '_info' keys removed,
     even from nested resources. The original `resource` structure is

--- a/os_migrate/plugins/modules/export_network.py
+++ b/os_migrate/plugins/modules/export_network.py
@@ -78,11 +78,10 @@ def run_module():
 
     conn = openstack.connect(cloud=module.params['cloud'])
     sdk_net = conn.network.find_network(module.params['name'], ignore_missing=False)
-    net_refs = network.network_refs_from_sdk(conn, sdk_net)
-    ser_net = network.serialize_network(sdk_net, net_refs)
+    net = network.Network.from_sdk(conn, sdk_net)
 
     result['changed'] = filesystem.write_or_replace_resource(
-        module.params['path'], ser_net)
+        module.params['path'], net)
 
     module.exit_json(**result)
 

--- a/os_migrate/plugins/modules/import_network.py
+++ b/os_migrate/plugins/modules/import_network.py
@@ -68,18 +68,8 @@ def run_module():
     )
 
     conn = openstack.connect(cloud=module.params['cloud'])
-    ser_net = module.params['data']
-    net_refs = network.network_refs_from_ser(conn, ser_net)
-    net_params = network.network_sdk_params(ser_net, net_refs)
-    existing_net = conn.network.find_network(net_params['name'])
-    if existing_net:
-        if network.network_needs_update(existing_net, net_refs, ser_net):
-            conn.network.update_network(net_params['name'], **net_params)
-            result['changed'] = True
-        # else: pass -- nothing to update
-    else:
-        conn.network.create_network(**net_params)
-        result['changed'] = True
+    net = network.Network.from_data(module.params['data'])
+    result['changed'] = net.create_or_update(conn)
 
     module.exit_json(**result)
 

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -63,48 +63,6 @@ def resource_with_nested():
     }
 
 
-def sdk_network():
-    return openstack.network.v2.network.Network(
-        availability_zone_hints=['nova', 'zone2'],
-        availability_zones=['nova', 'zone3'],
-        created_at='2020-01-06T15:50:55Z',
-        description='test network',
-        dns_domain='example.org',
-        id='uuid-test-net',
-        ipv4_address_scope_id=None,
-        ipv6_address_scope_id=None,
-        is_admin_state_up=True,
-        is_default=False,
-        is_port_security_enabled=True,
-        is_router_external=False,
-        is_shared=False,
-        mtu=1400,
-        name='test-net',
-        project_id='uuid-test-project',
-        provider_network_type='vxlan',
-        provider_physical_network='physnet',
-        provider_segmentation_id='456',
-        qos_policy_id='uuid-test-qos-policy',
-        revision_number=3,
-        segments=[],
-        status='ACTIVE',
-        subnet_ids=['uuid-test-subnet1', 'uuid-test-subnet2'],
-        updated_at='2020-01-06T15:51:00Z',
-        is_vlan_transparent=False,
-    )
-
-
-def network_refs():
-    return {
-        'project_id': 'uuid-test-project',
-        'project_name': 'test-project',
-        'qos_policy_id': 'uuid-test-qos-policy',
-        'qos_policy_name': 'test-qos-policy',
-        'subnet_ids': ['uuid-test-subnet1', 'uuid-test-subnet2'],
-        'subnet_names': ['test-subnet1', 'test-subnet2'],
-    }
-
-
 def sdk_router():
     return openstack.network.v2.router.Router(
         availability_zone_hints=['nova', 'zone2'],
@@ -163,41 +121,6 @@ def security_group_rule_refs():
     return {
         'security_group_name': 'default',
         'remote_group_name': 'default',
-    }
-
-
-def serialized_network():
-    return {
-        const.RES_PARAMS: {
-            'availability_zone_hints': ['nova', 'zone2'],
-            'description': 'test network',
-            'dns_domain': 'example.org',
-            'is_admin_state_up': True,
-            'is_default': False,
-            'is_port_security_enabled': True,
-            'is_router_external': False,
-            'is_shared': False,
-            'is_vlan_transparent': False,
-            'mtu': 1400,
-            'name': 'test-net',
-            'project_name': 'test-project',
-            'provider_network_type': 'vxlan',
-            'provider_physical_network': 'physnet',
-            'provider_segmentation_id': '456',
-            'qos_policy_name': 'test-qos-policy',
-            'segments': [],
-        },
-        const.RES_INFO: {
-            'availability_zones': ['nova', 'zone3'],
-            'created_at': '2020-01-06T15:50:55Z',
-            'project_id': 'uuid-test-project',
-            'revision_number': 3,
-            'status': 'ACTIVE',
-            'subnet_ids': ['uuid-test-subnet1', 'uuid-test-subnet2'],
-            'qos_policy_id': 'uuid-test-qos-policy',
-            'updated_at': '2020-01-06T15:51:00Z',
-        },
-        const.RES_TYPE: 'openstack.network.Network',
     }
 
 

--- a/os_migrate/tests/unit/test_resource.py
+++ b/os_migrate/tests/unit/test_resource.py
@@ -1,0 +1,110 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import resource
+
+
+class FakeResource(resource.Resource):
+
+    resource_type = 'some.FakeResource'
+    sdk_class = dict
+
+    info_from_sdk = ['info1', 'info2']
+    params_from_sdk = ['param1', 'param2']
+    info_from_refs = ['param3id', 'param4id']
+    params_from_refs = ['param3name', 'param4name']
+    sdk_params_from_refs = ['param3id', 'param4id']
+
+    def _refs_from_ser(self, conn):
+        return {
+            'param3name': 'param3nameval',
+            'param4name': 'param4nameval',
+            'param3id': 'param3idval',
+            'param4id': 'param4idval',
+        }
+
+    @staticmethod
+    def _refs_from_sdk(conn, sdk_res):
+        return {
+            'param3name': 'param3nameval',
+            'param4name': 'param4nameval',
+            'param3id': 'param3idval',
+            'param4id': 'param4idval',
+        }
+
+
+def valid_fakeresource_sdk():
+    return {
+        'param1': 'param1val',
+        'param2': 'param2val',
+        'param3id': 'param3idval',
+        'param4id': 'param4idval',
+        'info1': 'info1val',
+        'info2': 'info2val',
+    }
+
+
+def valid_fakeresource_sdk_creation_params():
+    return {
+        'param1': 'param1val',
+        'param2': 'param2val',
+        'param3id': 'param3idval',
+        'param4id': 'param4idval',
+    }
+
+
+def valid_fakeresource_data():
+    return {
+        'type': 'some.FakeResource',
+        'params': {
+            'param1': 'param1val',
+            'param2': 'param2val',
+            'param3name': 'param3nameval',
+            'param4name': 'param4nameval',
+        },
+        '_info': {
+            'info1': 'info1val',
+            'info2': 'info2val',
+            'param3id': 'param3idval',
+            'param4id': 'param4idval',
+        },
+    }
+
+
+class TestResource(unittest.TestCase):
+
+    def test_from_data(self):
+        data = valid_fakeresource_data()
+        res = FakeResource.from_data(data)
+        self.assertEqual(res.data, data)
+
+    def test_from_data_invalid(self):
+        data = valid_fakeresource_data()
+        data['type'] = 'some.InvalidType'
+        with self.assertRaises(exc.UnexpectedResourceType):
+            res = FakeResource.from_data(data)
+
+    def test_from_sdk(self):
+        sdk = valid_fakeresource_sdk()
+        # conn=None because the fake _refs_from_* methods don't need it
+        res = FakeResource.from_sdk(None, sdk)
+        self.assertEqual(res.data, valid_fakeresource_data())
+
+    def test_to_sdk_params(self):
+        res = FakeResource.from_data(valid_fakeresource_data())
+        # conn=None because the fake _refs_from_* methods don't need it
+        refs = res._refs_from_ser(None)
+        sdk_params = res._to_sdk_params(refs)
+        self.assertEqual(sdk_params, valid_fakeresource_sdk_creation_params())
+
+    def test_needs_update(self):
+        res1 = FakeResource.from_data(valid_fakeresource_data())
+        res2 = FakeResource.from_data(valid_fakeresource_data())
+        res2.info()['info1'] = 'changed'
+        self.assertFalse(res1._needs_update(res2))
+        res2.params()['param1'] = 'changed'
+        self.assertTrue(res1._needs_update(res2))


### PR DESCRIPTION
We created a Resource class as the base class for all our exported
resources. It improves the DRYness of our overall code and is suitable
for both export and import. It uses method composition internally so
that it can be easily "disconnected from network" for purposes of unit
testing.

The common interfaces are now backwards compatible, e.g. the
add_or_replace method for exporting resources now accepts both direct
resource data or an instance of Resource.

Co-Authored-By: Ryan Brady <rbrady@redhat.com>

Closes: #83 