### PR TITLE
 Default implementation for Resource.create_or_update

### DIFF
--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -56,18 +56,13 @@ class Network(resource.Resource):
         obj._sort_info('subnet_ids')
         return obj
 
-    def create_or_update(self, conn):
-        refs = self._refs_from_ser(conn)
-        sdk_params = self._to_sdk_params(refs)
-        existing = conn.network.find_network(sdk_params['name'])
-        if existing:
-            if self._needs_update(Network.from_sdk(conn, existing)):
-                conn.network.update_network(sdk_params['name'], **sdk_params)
-                return True
-        else:
-            conn.network.create_network(**sdk_params)
-            return True
-        return False  # no change done
+    @staticmethod
+    def _create_sdk_res(conn, sdk_params):
+        return conn.network.create_network(**sdk_params)
+
+    @staticmethod
+    def _find_sdk_res(conn, name_or_id):
+        return conn.network.find_network(name_or_id)
 
     @staticmethod
     def _refs_from_sdk(conn, sdk_res):
@@ -83,6 +78,10 @@ class Network(resource.Resource):
         refs['qos_policy_id'] = reference.qos_policy_id(
             conn, self.params()['qos_policy_name'])
         return refs
+
+    @staticmethod
+    def _update_sdk_res(conn, name_or_id, sdk_params):
+        return conn.network.update_network(name_or_id, **sdk_params)
 
 
 def security_group_needs_update(sdk_sec, target_ser_sec):

--- a/os_migrate/tests/unit/test_resource.py
+++ b/os_migrate/tests/unit/test_resource.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import unittest
+from unittest import mock
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
@@ -14,10 +15,18 @@ class FakeResource(resource.Resource):
     sdk_class = dict
 
     info_from_sdk = ['info1', 'info2']
-    params_from_sdk = ['param1', 'param2']
+    params_from_sdk = ['name', 'param1']
     info_from_refs = ['param3id', 'param4id']
     params_from_refs = ['param3name', 'param4name']
     sdk_params_from_refs = ['param3id', 'param4id']
+
+    @staticmethod
+    def _create_sdk_res(conn, sdk_params):
+        return valid_fakeresource_sdk()
+
+    @staticmethod
+    def _find_sdk_res(conn, name_or_id):
+        return valid_fakeresource_sdk()
 
     def _refs_from_ser(self, conn):
         return {
@@ -36,11 +45,15 @@ class FakeResource(resource.Resource):
             'param4id': 'param4idval',
         }
 
+    @staticmethod
+    def _update_sdk_res(conn, name_or_id, sdk_params):
+        return valid_fakeresource_sdk()
+
 
 def valid_fakeresource_sdk():
     return {
+        'name': 'nameval',
         'param1': 'param1val',
-        'param2': 'param2val',
         'param3id': 'param3idval',
         'param4id': 'param4idval',
         'info1': 'info1val',
@@ -50,8 +63,8 @@ def valid_fakeresource_sdk():
 
 def valid_fakeresource_sdk_creation_params():
     return {
+        'name': 'nameval',
         'param1': 'param1val',
-        'param2': 'param2val',
         'param3id': 'param3idval',
         'param4id': 'param4idval',
     }
@@ -61,8 +74,8 @@ def valid_fakeresource_data():
     return {
         'type': 'some.FakeResource',
         'params': {
+            'name': 'nameval',
             'param1': 'param1val',
-            'param2': 'param2val',
             'param3name': 'param3nameval',
             'param4name': 'param4nameval',
         },
@@ -108,3 +121,34 @@ class TestResource(unittest.TestCase):
         self.assertFalse(res1._needs_update(res2))
         res2.params()['param1'] = 'changed'
         self.assertTrue(res1._needs_update(res2))
+
+    def test_create_and_update_all_ok(self):
+        res = FakeResource.from_data(valid_fakeresource_data())
+        # _find_sdk_res returns up-to-date resource
+        res._create_sdk_res = mock.Mock()
+        res._update_sdk_res = mock.Mock()
+        self.assertFalse(res.create_or_update(None))
+        res._create_sdk_res.assert_not_called()
+        res._update_sdk_res.assert_not_called()
+
+    def test_create_and_update_needs_update(self):
+        res = FakeResource.from_data(valid_fakeresource_data())
+        stale = valid_fakeresource_sdk()
+        stale['param1'] = 'stale'
+        # _find_sdk_res returns stale resource
+        res._find_sdk_res = mock.Mock(return_value=stale)
+        res._create_sdk_res = mock.Mock()
+        res._update_sdk_res = mock.Mock()
+        self.assertTrue(res.create_or_update(None))
+        res._create_sdk_res.assert_not_called()
+        res._update_sdk_res.assert_called_once()
+
+    def test_create_and_update_needs_create(self):
+        res = FakeResource.from_data(valid_fakeresource_data())
+        # _find_sdk_res returns None - not found
+        res._find_sdk_res = mock.Mock(return_value=None)
+        res._create_sdk_res = mock.Mock()
+        res._update_sdk_res = mock.Mock()
+        self.assertTrue(res.create_or_update(None))
+        res._create_sdk_res.assert_called_once()
+        res._update_sdk_res.assert_not_called()


### PR DESCRIPTION
By extracting the find/create/update calls for the underlying SDK
object, we can provide a default implementation for the
create_or_update method on Resource. Subclasses can either provide the
find/create/update mini-methods and reuse the create_or_update logic,
or override the create_or_update method fully.