### PR TITLE
Do not lint YAML files in ./tests/func/tmpdata

### DIFF
--- a/scripts/linters.sh
+++ b/scripts/linters.sh
@@ -18,13 +18,27 @@ set -euxo pipefail
 #
 # Flake
 # TODO: Have the Ansible and YAML lint fixed first
-flake8 --exclude releasenotes,.tox --ignore E125,E251,E402,H405,W503,W504,E501
+flake8 \
+    --exclude releasenotes,.tox \
+    --ignore E125,E251,E402,H405,W503,W504,E501
 
 # Bash hate
-find ./ -not -wholename ".tox/*" -and -not -wholename "*.test/*" -and -name "*.sh" -print0 | xargs -0 bashate -v --ignore E006
+find ./ \
+     -not -wholename ".tox/*" \
+     -and -not -wholename "*.test/*" \
+     -and -name "*.sh" -print0 \
+    | xargs -0 bashate -v --ignore E006
 
 #Yaml lint
-find ./ -not -wholename ".tox/*" -and -name "*.yml"  -print0 | xargs -0 -I {} yamllint -d '{extends: default, rules: {truthy: disable, document-start: disable}}' {}
+find ./ \
+     -not -wholename ".tox/*" \
+     -and -not -wholename "./tests/func/tmpdata/*" \
+     -and -name "*.yml"  -print0 \
+    | xargs -0 -I {} yamllint -d '{extends: default, rules: {truthy: disable, document-start: disable}}' {}
 
 # Ansible lint
-find ./ -not -wholename ".tox/*" -and -name "*.yml" -print0 | xargs -0 ansible-lint
+find ./ \
+     -not -wholename ".tox/*" \
+     -and -not -wholename "./tests/func/tmpdata/*" \
+     -and -name "*.yml" -print0 \
+    | xargs -0 ansible-lint


### PR DESCRIPTION
These resource files are generated in tests via YAML dumper and they
don't pass the lint check on indentation :).

Also reformat the linters.sh file to make the commands a bit easier to
read.