### PR TITLE
Fix Subnet Update

### DIFF
--- a/os_migrate/plugins/module_utils/subnet.py
+++ b/os_migrate/plugins/module_utils/subnet.py
@@ -53,6 +53,13 @@ class Subnet(resource.Resource):
         'subnet_pool_id',
     ]
 
+    @classmethod
+    def from_sdk(cls, conn, sdk_resource):
+        obj = super(Subnet, cls).from_sdk(conn, sdk_resource)
+        obj._sort_param('allocation_pools')
+        obj._sort_param('dns_nameservers')
+        return obj
+
     @staticmethod
     def _create_sdk_res(conn, sdk_params):
         return conn.network.create_subnet(**sdk_params)

--- a/os_migrate/tests/unit/test_subnet.py
+++ b/os_migrate/tests/unit/test_subnet.py
@@ -26,7 +26,8 @@ def sdk_subnet():
         created_at='2020-02-21T17:34:54Z',
         revision_number=0,
         segment_id='uuid-test-segment',
-        subnet_pool_id='uuid-test-subnet-pool'
+        subnet_pool_id='uuid-test-subnet-pool',
+        dns_nameservers=[],
     )
 
 
@@ -102,7 +103,7 @@ class TestSubnet(unittest.TestCase):
                          [{'start': '10.10.10.2', 'end': '10.10.10.254'}])
         self.assertEqual(params['cidr'], '10.10.10.0/24')
         self.assertEqual(params['description'], 'test-subnet')
-        self.assertEqual(params['dns_nameservers'], None)
+        self.assertEqual(params['dns_nameservers'], [])
         self.assertEqual(params['gateway_ip'], '10.10.10.1')
         self.assertEqual(params['host_routes'], None)
         self.assertEqual(params['ip_version'], 4)


### PR DESCRIPTION
During the idempotency testing, the subnet update calls to the API
failed for ip_version and network_id.  These parameters are accepted
for the create, but not the update.  Sorting the allocation_pools and
dns_nameservers migtigated the condistion that caused this error.