### PR TITLE
Fixes CI

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -71,7 +71,7 @@ jobs:
           --health-timeout=5s
           --health-retries=3
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ os_migrate-os_migrate-latest.tar.gz:
 
 # TESTS
 
-test-lint:
+test-lint: reinstall
 	set -euo pipefail; \
 	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
 		source /root/venv/bin/activate; \


### PR DESCRIPTION
The CI started failing today when attempting to run the checkout
source step.  I started researching online and found there is a
race condition issue with the actions/checkout@v1[1].  This patch
changes the checkout action to use @v2 which supposedly addresses
this issue.

[1] https://github.com/actions/checkout/issues/23