### PR TITLE
Fixes Subnet Update

### DIFF
--- a/os_migrate/plugins/module_utils/resource.py
+++ b/os_migrate/plugins/module_utils/resource.py
@@ -190,8 +190,8 @@ class Resource():
         existing = self._find_sdk_res(conn, sdk_params['name'])
         if existing:
             if self._needs_update(self.from_sdk(conn, existing)):
-                update_params = self._remove_readonly_params(sdk_params)
-                self._update_sdk_res(conn, update_params['name'], update_params)
+                self._remove_readonly_params(sdk_params)
+                self._update_sdk_res(conn, sdk_params['name'], sdk_params)
                 return True
         else:
             self._create_sdk_res(conn, sdk_params)
@@ -257,7 +257,6 @@ class Resource():
         for name in self.readonly_sdk_params:
             if name in sdk_params:
                 sdk_params.pop(name)
-        return sdk_params
 
     # Used when creating params for SDK calls, should be overriden in
     # majority of child classes.

--- a/os_migrate/tests/unit/test_resource.py
+++ b/os_migrate/tests/unit/test_resource.py
@@ -128,8 +128,8 @@ class TestResource(unittest.TestCase):
 
     def test_remove_readonly_param(self):
         res1 = FakeResource.from_data(valid_fakeresource_data())
-        sdk_params = res1._remove_readonly_params(valid_fakeresource_data())
-        self.assertFalse('readonly_param' in sdk_params)
+        res1._remove_readonly_params(res1.params())
+        self.assertFalse('readonly_param' in res1.params())
 
     def test_create_and_update_all_ok(self):
         res = FakeResource.from_data(valid_fakeresource_data())


### PR DESCRIPTION
Intermittently, the subnet import functional tests fail for ip_version
or network_id attributes.  This patch removes the ip_version and
network_id from the update args.

closes #140