### PR TITLE
OOP sec group

### DIFF
--- a/os_migrate/plugins/modules/export_security_group.py
+++ b/os_migrate/plugins/modules/export_security_group.py
@@ -78,7 +78,7 @@ def run_module():
     conn = openstack.connect(cloud=module.params['cloud'])
     sdk_sec = conn.network.find_security_group(module.params['name'], ignoring_missing=False)
 
-    ser_sec = security_group.serialize_security_group(sdk_sec)
+    ser_sec = security_group.SecurityGroup.from_sdk(conn, sdk_sec)
 
     result['changed'] = filesystem.write_or_replace_resource(
         module.params['path'], ser_sec)

--- a/os_migrate/plugins/modules/import_security_group.py
+++ b/os_migrate/plugins/modules/import_security_group.py
@@ -64,17 +64,8 @@ def run_module():
     )
 
     conn = openstack.connect(cloud=module.params['cloud'])
-    ser_sec = module.params['data']
-    sec_params = security_group.security_group_sdk_params(ser_sec)
-    existing_secgroup = conn.network.find_security_group(sec_params['name'])
-    if existing_secgroup:
-        if security_group.security_group_needs_update(existing_secgroup, ser_sec):
-            conn.network.update_security_group(sec_params['name'], **sec_params)
-            result['changed'] = True
-        # else: pass -- nothing to update
-    else:
-        conn.network.create_security_group(**sec_params)
-        result['changed'] = True
+    ser_sec = security_group.SecurityGroup.from_data(module.params['data'])
+    result['changed'] = ser_sec.create_or_update(conn)
 
     module.exit_json(**result)
 

--- a/os_migrate/tests/unit/fixtures.py
+++ b/os_migrate/tests/unit/fixtures.py
@@ -71,37 +71,6 @@ def security_group_rule_refs():
     }
 
 
-def sdk_security_group():
-    return openstack.network.v2.security_group.SecurityGroup(
-        description='Default security group',
-        name='default',
-        id='uuid',
-        project_id='uuid-project',
-        created_at='2020-01-30T14:49:06Z',
-        updated_at='2020-01-30T14:49:06Z',
-        tenant_id='uuid-tenant',
-        revision_number='1',
-    )
-
-
-def serialized_security_group():
-    return {
-        const.RES_PARAMS: {
-            'description': 'Default security group',
-            'name': 'default',
-        },
-        const.RES_INFO: {
-            'id': 'uuid',
-            'project_id': 'uuid-project',
-            'created_at': '2020-01-30T14:49:06Z',
-            'updated_at': '2020-01-30T14:49:06Z',
-            'tenant_id': 'uuid-tenant',
-            'revision_number': '0',
-        },
-        const.RES_TYPE: 'openstack.network.SecurityGroup',
-    }
-
-
 def sdk_security_group_rule():
     return openstack.network.v2.security_group_rule.SecurityGroupRule(
         id='uuid',

--- a/os_migrate/tests/unit/test_security_group.py
+++ b/os_migrate/tests/unit/test_security_group.py
@@ -1,47 +1,80 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import openstack
 import unittest
 
-from ansible_collections.os_migrate.os_migrate.tests.unit import fixtures
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
-    import security_group
+    import const, security_group
+
+
+def sdk_security_group():
+    return openstack.network.v2.security_group.SecurityGroup(
+        description='Default security group',
+        name='default',
+        id='uuid',
+        project_id='uuid-project',
+        created_at='2020-01-30T14:49:06Z',
+        updated_at='2020-01-30T14:49:06Z',
+        tenant_id='uuid-tenant',
+        revision_number='1',
+    )
+
+
+def serialized_security_group():
+    return {
+        const.RES_PARAMS: {
+            'description': 'Default security group',
+            'name': 'default',
+        },
+        const.RES_INFO: {
+            'id': 'uuid',
+            'project_id': 'uuid-project',
+            'created_at': '2020-01-30T14:49:06Z',
+            'updated_at': '2020-01-30T14:49:06Z',
+            'tenant_id': 'uuid-tenant',
+            'revision_number': '0',
+        },
+        const.RES_TYPE: 'openstack.network.SecurityGroup',
+    }
+
+
+def security_group_refs():
+    return {
+        'project_id': 'uuid-test-project',
+    }
+
+
+# "Disconnected" variant of SecurityGroup resource where we make sure not to
+# make requests using `conn`.
+class SecurityGroup(security_group.SecurityGroup):
+
+    def _refs_from_ser(self, conn):
+        return security_group_refs()
+
+    @staticmethod
+    def _refs_from_sdk(conn, sdk_res):
+        return security_group_refs()
 
 
 class TestSecurityGroup(unittest.TestCase):
 
     def test_serialize_security_group(self):
-        sec = fixtures.sdk_security_group()
-        serialized = security_group.serialize_security_group(sec)
-        s_params = serialized['params']
-        s_info = serialized['_info']
+        sec = sdk_security_group()
+        serialized = SecurityGroup.from_sdk(None, sec)
+        params, info = serialized.params_and_info()
 
-        self.assertEqual(serialized['type'], 'openstack.network.SecurityGroup')
-        self.assertEqual(s_params['description'], 'Default security group')
-        self.assertEqual(s_params['name'], 'default')
-        self.assertEqual(s_params['tags'], [])
+        self.assertEqual(serialized.type(), 'openstack.network.SecurityGroup')
+        self.assertEqual(params['description'], 'Default security group')
+        self.assertEqual(params['name'], 'default')
 
-        self.assertEqual(s_info['created_at'], '2020-01-30T14:49:06Z')
-        self.assertEqual(s_info['project_id'], 'uuid-project')
-        self.assertEqual(s_info['updated_at'], '2020-01-30T14:49:06Z')
+        self.assertEqual(info['created_at'], '2020-01-30T14:49:06Z')
+        self.assertEqual(info['project_id'], 'uuid-project')
+        self.assertEqual(info['updated_at'], '2020-01-30T14:49:06Z')
 
     def test_security_group_sdk_params(self):
-        ser_sec = fixtures.serialized_security_group()
-        sdk_params = security_group.security_group_sdk_params(ser_sec)
+        ser_sec = SecurityGroup.from_data(serialized_security_group())
+        refs = ser_sec._refs_from_ser(None)  # conn=None
+        sdk_params = ser_sec._to_sdk_params(refs)
 
         self.assertEqual(sdk_params['description'], 'Default security group')
-
-    def test_security_group_needs_update(self):
-        sdk_sec = fixtures.sdk_security_group()
-        serialized = security_group.serialize_security_group(sdk_sec)
-
-        self.assertFalse(security_group.security_group_needs_update(
-            sdk_sec, serialized))
-
-        serialized['_info']['id'] = 'different id'
-        self.assertFalse(security_group.security_group_needs_update(
-            sdk_sec, serialized))
-
-        serialized['params']['description'] = 'updated description'
-        self.assertTrue(security_group.security_group_needs_update(
-            sdk_sec, serialized))


### PR DESCRIPTION
This is the second part of the OOP refactor, by doing the split first the complexity of the change is reduced a lot.