### PR TITLE
Fix subnet import idempotence

### DIFF
--- a/os_migrate/plugins/module_utils/resource.py
+++ b/os_migrate/plugins/module_utils/resource.py
@@ -132,6 +132,17 @@ class Resource():
         for p_name in param_names:
             ser_params[p_name] = sdk_params[p_name]
 
+    # Not meant to be overriden in majority of subclasses.
+    @staticmethod
+    def _sort_dicts(list_of_dicts, by_keys):
+        """Sort `list_of_dicts` by dict keys in `by_keys`."""
+        def keyfn(dct):
+            dct_compound_key = []
+            for by_key in by_keys:
+                dct_compound_key.append(dct[by_key])
+            return dct_compound_key
+        return sorted(list_of_dicts, key=keyfn)
+
     # Must be overriden in child class if `create_or_update` isn't
     # overriden.
     @classmethod
@@ -245,14 +256,20 @@ class Resource():
         self._set_sdk_params_same_name(refs, sdk_params, self.sdk_params_from_refs)
 
     # Not meant to be overriden in majority of subclasses.
-    def _sort_param(self, param_name):
-        """Sort internal param `param_name`."""
-        self.params()[param_name] = sorted(self.params()[param_name])
+    def _sort_info(self, info_name, by_keys=None):
+        """Sort internal info `info_name`."""
+        if by_keys:
+            self.info()[info_name] = self._sort_dicts(self.info()[info_name], by_keys)
+        else:
+            self.info()[info_name] = sorted(self.info()[info_name])
 
     # Not meant to be overriden in majority of subclasses.
-    def _sort_info(self, info_name):
-        """Sort internal info `info_name`."""
-        self.info()[info_name] = sorted(self.info()[info_name])
+    def _sort_param(self, param_name, by_keys=None):
+        """Sort internal param `param_name`."""
+        if by_keys:
+            self.params()[param_name] = self._sort_dicts(self.params()[param_name], by_keys)
+        else:
+            self.params()[param_name] = sorted(self.params()[param_name])
 
     # Not meant to be overriden in majority of subclasses.
     def _to_sdk_params(self, refs):

--- a/os_migrate/plugins/module_utils/subnet.py
+++ b/os_migrate/plugins/module_utils/subnet.py
@@ -58,6 +58,7 @@ class Subnet(resource.Resource):
         obj = super(Subnet, cls).from_sdk(conn, sdk_resource)
         obj._sort_param('allocation_pools')
         obj._sort_param('dns_nameservers')
+        obj._sort_param('host_routes', by_keys=['destination', 'nexthop'])
         return obj
 
     @staticmethod

--- a/os_migrate/tests/unit/test_subnet.py
+++ b/os_migrate/tests/unit/test_subnet.py
@@ -17,6 +17,9 @@ def sdk_subnet():
         ip_version=4,
         enable_dhcp=True,
         gateway_ip='10.10.10.1',
+        host_routes=[
+            {'destination': '0.0.0.0/0', 'nexthop': '12.34.56.78'},
+        ],
         cidr='10.10.10.0/24',
         allocation_pools=[{
             'start': '10.10.10.2',
@@ -40,7 +43,9 @@ def serialized_subnet():
             'description': 'test-subnet',
             'dns_nameservers': None,
             'gateway_ip': '10.10.10.1',
-            'host_routes': None,
+            'host_routes': [
+                {'destination': '0.0.0.0/0', 'nexthop': '12.34.56.78'},
+            ],
             'ip_version': 4,
             'ipv6_address_mode': None,
             'ipv6_ra_mode': None,
@@ -105,7 +110,8 @@ class TestSubnet(unittest.TestCase):
         self.assertEqual(params['description'], 'test-subnet')
         self.assertEqual(params['dns_nameservers'], [])
         self.assertEqual(params['gateway_ip'], '10.10.10.1')
-        self.assertEqual(params['host_routes'], None)
+        self.assertEqual(params['host_routes'],
+                         [{'destination': '0.0.0.0/0', 'nexthop': '12.34.56.78'}])
         self.assertEqual(params['ip_version'], 4)
         self.assertEqual(params['ipv6_address_mode'], None)
         self.assertEqual(params['ipv6_ra_mode'], None)


### PR DESCRIPTION
The last param that must be sorted for import idempotence to work is
'host_routes'. It's a list of dicts so it needs a list of keys to look
at in each dict. The list-of-dicts sorting is implemented in Resource
class to be reusable.

Closes #140 