### PR TITLE
Do not ls, use always current version as latest

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,5 +12,4 @@ sed -i -e "s/^OS_MIGRATE_VERSION = .*$/OS_MIGRATE_VERSION = '$VERSION'  # update
 
 ansible-galaxy collection build os_migrate -v --force --output-path releases/
 cd releases
-LATEST=$(ls os_migrate-os_migrate*.tar.gz | grep -v latest | sort -V | tail -n1)
-ln -sf $LATEST os_migrate-os_migrate-latest.tar.gz
+ln -sf os_migrate-os_migrate-$VERSION.tar.gz os_migrate-os_migrate-latest.tar.gz


### PR DESCRIPTION
This might hit us in our dev envs, we should push a fix for this asap.

Closes: #156 