### PR TITLE
Allow skipping func test cleanup only after testing

### DIFF
--- a/doc/devel/dev-env-setup.md
+++ b/doc/devel/dev-env-setup.md
@@ -130,3 +130,8 @@ To run functional tests for just the resource you're working on, run
 e.g.:
 
     ./toolbox/run bash -c "FUNC_TEST_ARGS='--tags test_network,test_subnet' make test-func"
+
+To explore imported resoruces, skip the after-test cleanup of
+resources, e.g.:
+
+    ./toolbox/run bash -c "FUNC_TEST_ARGS='--tags test_network --skip_tags test_clean_after' make test-func"

--- a/tests/func/test_all.yml
+++ b/tests/func/test_all.yml
@@ -9,10 +9,18 @@
   hosts: migrator
   tasks:
     - import_tasks: global/prep.yml
-    - import_tasks: clean/all.yml
+    - include_tasks: clean/all.yml
+      args:
+        apply:
+          tags: test_clean_before
+      tags: always
     - import_tasks: seed/all.yml
     - import_tasks: run/all.yml
     - import_tasks: idempotence/all.yml
-    - import_tasks: clean/all.yml
+    - include_tasks: clean/all.yml
+      args:
+        apply:
+          tags: test_clean_after
+      tags: always
   tags:
     - test_migration


### PR DESCRIPTION
Previously it was possible to skip cleanup via `--skip-tags
test_clean`, but that would affect cleanup both before and after
testing. It is now possible to skip the cleanup only after testing,
with `--skip-tags test_clean_after`.