### PR TITLE
Save ether_type for security group rules

### DIFF
--- a/os_migrate/plugins/module_utils/security_group_rule.py
+++ b/os_migrate/plugins/module_utils/security_group_rule.py
@@ -24,6 +24,7 @@ class SecurityGroupRule(resource.Resource):
     params_from_sdk = [
         'description',
         'direction',
+        'ether_type',
         'port_range_max',
         'port_range_min',
         'protocol',

--- a/os_migrate/tests/unit/test_security_group_rule.py
+++ b/os_migrate/tests/unit/test_security_group_rule.py
@@ -28,6 +28,7 @@ def sdk_security_group_rule():
         revision_number='0',
         description='null',
         direction='ingress',
+        ether_type='IPv4',
         port_range_max='100',
         port_range_min='10',
         protocol='null',
@@ -40,6 +41,7 @@ def serialized_security_group_rule():
         const.RES_PARAMS: {
             'description': 'null',
             'direction': 'ingress',
+            'ether_type': 'IPv4',
             'port_range_max': '100',
             'port_range_min': '10',
             'protocol': 'null',
@@ -82,6 +84,7 @@ class TestSecurityGroupRule(unittest.TestCase):
         self.assertEqual(params['remote_group_name'], 'default')
         self.assertEqual(params['description'], 'null')
         self.assertEqual(params['direction'], 'ingress')
+        self.assertEqual(params['ether_type'], 'IPv4')
         self.assertEqual(params['port_range_max'], 100)
         self.assertEqual(params['port_range_min'], 10)
         self.assertEqual(params['protocol'], 'null')
@@ -103,6 +106,7 @@ class TestSecurityGroupRule(unittest.TestCase):
 
         self.assertEqual(sdk_params['description'], 'null')
         self.assertEqual(sdk_params['direction'], 'ingress')
+        self.assertEqual(sdk_params['ether_type'], 'IPv4')
         self.assertEqual(sdk_params['port_range_max'], '100')
         self.assertEqual(sdk_params['port_range_min'], '10')
         self.assertEqual(sdk_params['protocol'], 'null')


### PR DESCRIPTION
This is a fundamental property of the rule, specifies whether the rule
applies to IPv4 or IPv6 traffic.