### PR TITLE
Make sure releasing is done from toolbox container

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,6 +23,12 @@ while (( "$#" )); do
     esac
 done
 
+if [ ! -e /.os-migrate-toolbox ]; then
+    echo "Error: This script must be run from an os-migrate-toolbox container" >&2
+    echo "to ensure having all dependencies available and in expected versions." >&2
+    exit 1
+fi
+
 #
 # Initial variables
 #


### PR DESCRIPTION
E.g. if shyaml is missing, the releasing will fail with a weird
error. In toolbox, we have all the releasing dependencies.