### PR TITLE
Adds additional user docs

### DIFF
--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -30,53 +30,8 @@ It is recommended to install releases from Ansible Galaxy.
 ansible-galaxy collection install os_migrate.os_migrate
 ```
 
-**Note: We haven't released to Ansible Galaxy yet. Until we do, the
-above command will not work.**
-
 Alternatively, you can [install from source](install-from-source.md).
 
-
-Clouds.yaml
------------
-
-OS-Migrate uses "named clouds" from `clouds.yml` file as the source of
-OpenStack authentication credentials. The file should be created at
-`$HOME/.config/openstack/clouds.yml`. Assuming we'll be migrating
-content from a named cloud (tenant) we call `src` to one we call
-`dst`, the `clouds.yml` file may look similar to:
-
-```yaml
-clouds:
-  src:
-    auth:
-      auth_url: http://192.168.122.11/identity
-      password: srcpassword
-      project_domain_id: default
-      project_name: src_project
-      user_domain_id: default
-      username: src_user
-    identity_api_version: '3'
-    region_name: RegionOne
-    volume_api_version: '3'
-  dst:
-    auth:
-      auth_url: http://192.168.122.11/identity
-      password: dstpassword
-      project_domain_id: default
-      project_name: dst_project
-      user_domain_id: default
-      username: dst_user
-    identity_api_version: '3'
-    region_name: RegionOne
-    volume_api_version: '3'
-```
-
-*Note: Due to a possible bug in some versions of Ansible or OpenStack
-SDK, it seemed that the cloud names ("src", "dst" in the above
-example) had to be alphanumeric only, and could not contain special
-characters like hyphens or underscores. If Ansible reports that it
-cannot find a named cloud in your clouds.yml file, try removing any
-special characters from the names.*
 
 
 Usage example
@@ -101,9 +56,23 @@ mkdir -p "$OS_MIGRATE_DATA"
 Put basic variables into `$HOME/os-migrate-vars.yml`:
 
 ```yaml
-# source and destination clouds, referring to names chosen in clouds.yml
-os_migrate_src_cloud: src
-os_migrate_dst_cloud: dst
+# authentication for source and destination clouds
+os_migrate_src_auth:
+  auth_url: http://192.168.122.85/identity
+  password: password
+  project_domain_id: default
+  project_name: demo
+  user_domain_id: default
+  username: demo
+os_migrate_src_region_name: RegionOne
+os_migrate_dst_auth:
+  auth_url: http://192.168.122.85/identity
+  password: password
+  project_domain_id: default
+  project_name: alt_demo
+  user_domain_id: default
+  username: alt_demo
+os_migrate_dst_region_name: RegionOne
 
 # where to put exported resources
 os_migrate_data_dir: /home/myuser/os-migrate-data
@@ -126,7 +95,7 @@ ansible-playbook \
 ```
 
 Now you should have a `networks.yml` file with serialized data about
-the networks visible by the `src` named cloud (tenant). To view the
+the networks visible using the `os_migrate_src_auth` credentials. To view the
 file:
 
 ```bash
@@ -134,8 +103,8 @@ cat $OS_MIGRATE_DATA/networks.yml
 ```
 
 You can edit the YAML file, for example keep only a subset of networks
-that you want to import into `dst` named cloud, and remove
-others. When the contents are in desired state, import the networks:
+that you want to import into cloud identified by `os_migrate_dst_auth`, and
+remove others. When the contents are in desired state, import the networks:
 
 ```bash
 ansible-playbook \
@@ -144,4 +113,5 @@ ansible-playbook \
     $OS_MIGRATE/playbooks/import_networks.yml
 ```
 
-This should create the desired networks in `dst` named cloud.
+This should create the desired networks in the cloud identified by
+`os_migrate_dst_auth`.

--- a/os_migrate/README.md
+++ b/os_migrate/README.md
@@ -21,6 +21,23 @@
   </a>
 </p>
 
+Parallel cloud migration is a way to modernize an OpenStack deployment. Instead 
+of upgrading an OpenStack cluster in place, a second OpenStack cluster is deployed 
+alongside, and tenant content is migrated from the original cluster to the new one. 
+As hardware resources free up in the original cluster, they can be gradually 
+added to the new cluster.
+
+OS-Migrate is an open source project that provides a framework for exporting and
+importing resources between two clouds.  It's a collection of Ansible playbooks 
+that provide the basic functionality, but may not fit each use case out of the 
+box.  You can craft custom playbooks using the OS-Migrate collection pieces 
+(roles and modules) as building blocks.
+
+OS-Migrate strictly uses the official OpenStack API and does not utilize direct 
+database access or other methods to export or import data.  The Ansible playbooks 
+contained in OS-Migrate are idempotent.  If a command fails, you can retry with 
+the same command.
+
 ## Usage
 
 Refer to [user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).


### PR DESCRIPTION
This patch adds more data to the repo README and updates the
the user doc to remove clouds.yml info and replace it with
the newer auth vars.

* Note this patch is still WIP as I'm trying to figure out the
best way to adapt the blog post to the user docs as well.