### PR TITLE
Add readme files to all roles, pointing to user docs

### DIFF
--- a/os_migrate/roles/export_networks/README.md
+++ b/os_migrate/roles/export_networks/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/export_router_interfaces/README.md
+++ b/os_migrate/roles/export_router_interfaces/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/export_routers/README.md
+++ b/os_migrate/roles/export_routers/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/export_security_group_rules/README.md
+++ b/os_migrate/roles/export_security_group_rules/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/export_security_groups/README.md
+++ b/os_migrate/roles/export_security_groups/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/export_subnets/README.md
+++ b/os_migrate/roles/export_subnets/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/export_workloads/README.md
+++ b/os_migrate/roles/export_workloads/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/import_networks/README.md
+++ b/os_migrate/roles/import_networks/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/import_router_interfaces/README.md
+++ b/os_migrate/roles/import_router_interfaces/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/import_routers/README.md
+++ b/os_migrate/roles/import_routers/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/import_security_group_rules/README.md
+++ b/os_migrate/roles/import_security_group_rules/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/import_security_groups/README.md
+++ b/os_migrate/roles/import_security_groups/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/import_subnets/README.md
+++ b/os_migrate/roles/import_subnets/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/import_workloads/README.md
+++ b/os_migrate/roles/import_workloads/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/prelude_dst/README.md
+++ b/os_migrate/roles/prelude_dst/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/prelude_src/README.md
+++ b/os_migrate/roles/prelude_src/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/validate_data_dir/README.md
+++ b/os_migrate/roles/validate_data_dir/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).


### PR DESCRIPTION
It looks like this is now required, otherwise the Galaxy publish
script fails with:

ERROR! Galaxy import process failed: No role readme found. (Code: None)