### PR TITLE
[stable/0.3] Fix exporting router interfaces when router name filter is undefined

### DIFF
--- a/os_migrate/roles/export_router_interfaces/defaults/main.yml
+++ b/os_migrate/roles/export_router_interfaces/defaults/main.yml
@@ -1,0 +1,2 @@
+export_routers_name_filter:
+  - regex: .*


### PR DESCRIPTION
Just a missing default.

Closes https://github.com/os-migrate/os-migrate/issues/201

(cherry picked from commit fc81f87d147980aae45f205959d42628885f4b36)