### PR TITLE
Gitignore local directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /releases/*
 
 /.venv
+/local
 /tests/func/auth.yml
 /tests/func/tmpdata
 /toolbox/vagrant/.vagrant


### PR DESCRIPTION
This directory allows putting some personal files in, e.g. credential
or parameter files for manual testing. This directory is available in
`./toolbox/venv-shell` containers.