### PR TITLE
Fix workload migration pt.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ test-e2e: reinstall
 		-e os_migrate_dst_conversion_host_name=osm_uch_dst \
 		-e os_migrate_src_conversion_host_flavor=m1.medium \
 		-e os_migrate_dst_conversion_host_flavor=m1.medium \
-		-e os_migrate_src_client_key=~/.ssh/id_rsa.pub \
-		-e os_migrate_dst_client_key=~/.ssh/id_rsa.pub \
-		-e os_migrate_conversion_host_key=~/.ssh/id_rsa \
+		-e os_migrate_src_client_key=~/ssh-ci/id_rsa.pub \
+		-e os_migrate_dst_client_key=~/ssh-ci/id_rsa.pub \
+		-e os_migrate_conversion_host_key=~/ssh-ci/id_rsa \
 		-e os_migrate_conversion_host_image=rhel-osp-migration-conversion-host.qcow2 \
 		-e @$(ROOT_DIR)/tests/auth.yml \
 		$(FUNC_TEST_ARGS) test_all.yml

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ FUNC_TEST_ARGS ?=
 build: unlink-latest os_migrate-os_migrate-latest.tar.gz
 
 install: os_migrate-os_migrate-latest.tar.gz
-	if [ -n "${VIRTUAL_ENV:-}" ]; then \
+	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
+		echo "Sourcing venv."; \
 		source /root/venv/bin/activate; \
 	fi; \
 	cd releases; \
@@ -37,6 +38,7 @@ os_migrate-os_migrate-latest.tar.gz:
 test-lint: reinstall
 	set -euo pipefail; \
 	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
+		echo "Sourcing venv."; \
 		source /root/venv/bin/activate; \
 	fi; \
 	./scripts/linters.sh
@@ -53,6 +55,7 @@ test: test-fast test-func
 test-func: reinstall
 	set -euo pipefail; \
 	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
+		echo "Sourcing venv."; \
 		source /root/venv/bin/activate; \
 	fi; \
 	cd tests/func; \
@@ -66,6 +69,7 @@ test-func: reinstall
 test-e2e: reinstall
 	set -euo pipefail; \
 	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
+		echo "Sourcing venv."; \
 		source /root/venv/bin/activate; \
 	fi; \
 	cd tests/e2e; \
@@ -95,6 +99,7 @@ test-fast: test-lint test-sanity test-unit
 test-sanity: reinstall
 	set -euo pipefail; \
 	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
+		echo "Sourcing venv."; \
 		source /root/venv/bin/activate; \
 	fi; \
 	cd /root/.ansible/collections/ansible_collections/os_migrate/os_migrate; \
@@ -103,6 +108,7 @@ test-sanity: reinstall
 test-unit: reinstall
 	set -euo pipefail; \
 	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
+		echo "Sourcing venv."; \
 		source /root/venv/bin/activate; \
 	fi; \
 	cd /root/.ansible/collections/ansible_collections/os_migrate/os_migrate; \

--- a/os_migrate/localhost_inventory.yml
+++ b/os_migrate/localhost_inventory.yml
@@ -2,3 +2,4 @@ migrator:
   hosts:
     localhost:
       ansible_connection: local
+      ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/os_migrate/plugins/module_utils/server.py
+++ b/os_migrate/plugins/module_utils/server.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import openstack
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
-    import const, reference, resource
+    import const, resource
 
 
 class Server(resource.Resource):
@@ -28,7 +28,6 @@ class Server(resource.Resource):
     @classmethod
     def from_sdk(cls, conn, sdk_resource):
         obj = super(Server, cls).from_sdk(conn, sdk_resource)
-        obj.info()['flavor_id'] = sdk_resource['flavor']['id']
         return obj
 
     @staticmethod
@@ -38,8 +37,7 @@ class Server(resource.Resource):
     @staticmethod
     def _refs_from_sdk(conn, sdk_res):
         refs = {}
-        refs['flavor_name'] = reference.server_flavor_name(
-            conn, sdk_res['flavor']['id'])
+        refs['flavor_name'] = sdk_res['flavor']['original_name']
         refs['security_group_names'] = [security_group['name'] for
                                         security_group in
                                         sdk_res['security_groups']]

--- a/os_migrate/plugins/modules/export_workload.py
+++ b/os_migrate/plugins/modules/export_workload.py
@@ -110,7 +110,8 @@ def run_module():
     )
 
     sdk, conn = openstack_cloud_from_module(module)
-    sdk_server = conn.compute.find_server(module.params['name'], ignore_missing=False)
+    sdk_server_nodetails = conn.compute.find_server(module.params['name'], ignore_missing=False)
+    sdk_server = conn.compute.get_server(sdk_server_nodetails['id'])
     srv = server.Server.from_sdk(conn, sdk_server)
 
     result['changed'] = filesystem.write_or_replace_resource(

--- a/os_migrate/plugins/modules/import_workload_export_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_export_volumes.py
@@ -359,13 +359,11 @@ class OpenStackSourceHost(OpenStackHostBase):
             self.log.info('Image-based instance, creating snapshot...')
             image = self.conn.compute.create_server_image(
                 name='rhosp-migration-root-{0}'.format(sourcevm.name),
-                server=sourcevm.id)
-            for second in range(DEFAULT_TIMEOUT):
-                refreshed_image = self.conn.get_image_by_id(image.id)
-                if refreshed_image.status == 'active':
-                    break
-                time.sleep(1)
-            else:
+                server=sourcevm.id,
+                wait=True,
+                timeout=DEFAULT_TIMEOUT)
+            image = self.conn.get_image_by_id(image.id)  # refresh
+            if image.status != 'active':
                 raise RuntimeError(
                     'Could not create new image of image-based instance!')
             volume = self.conn.create_volume(

--- a/os_migrate/tests/unit/test_workload.py
+++ b/os_migrate/tests/unit/test_workload.py
@@ -19,7 +19,7 @@ def sdk_server():
             ],
         },
         flavor={
-            'id': 'a96b2815-3525-4eea-9ab4-14ba58e17835',
+            'original_name': 'm1.small',
         },
         id='uuid-test-server',
         security_groups=[
@@ -28,7 +28,6 @@ def sdk_server():
         ],
         name='test-server',
         status='ACTIVE',
-        flavor_name='m1.small',
         security_group_names=[
             'testing123',
             'default',
@@ -90,7 +89,6 @@ class TestServer(unittest.TestCase):
         self.assertEqual(info['id'], 'uuid-test-server')
         self.assertEqual(params['name'], 'test-server')
         self.assertEqual(info['status'], 'ACTIVE')
-        self.assertEqual(info['flavor_id'], 'a96b2815-3525-4eea-9ab4-14ba58e17835')
         self.assertEqual(params['flavor_name'], 'm1.small')
         self.assertEqual(params['security_group_names'], [
             'testing123',

--- a/tests/e2e/seed.yml
+++ b/tests/e2e/seed.yml
@@ -197,7 +197,8 @@
 
 - name: Create the key folder
   file:
-    path: "{{ '~' | expanduser }}/.ssh"
+    path: "{{ '~' | expanduser }}/ssh-ci"
+    mode: 0700
     state: directory
   tags: always
 
@@ -205,7 +206,7 @@
   # This will not regenerate the key if
   # it already exists
   openssh_keypair:
-    path: "{{ '~' | expanduser }}/.ssh/id_rsa"
+    path: "{{ '~' | expanduser }}/ssh-ci/id_rsa"
   tags: always
 
 - name: Create new keypair as osm_key
@@ -213,7 +214,7 @@
     auth: "{{ item.auth }}"
     state: present
     name: osm_key
-    public_key_file: "{{ '~' | expanduser }}/.ssh/id_rsa.pub"
+    public_key_file: "{{ '~' | expanduser }}/ssh-ci/id_rsa.pub"
     validate_certs: "{{ item.validate_certs }}"
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
@@ -291,6 +292,53 @@
       flavor: "{{ os_migrate_dst_conversion_host_flavor|default(omit) }}"
   tags:
     - always
+
+# This is just to unblock CI. Inserting the main private ssh key into
+# the migration host itself is undesirable for end user envs. Once we
+# switch to a proper playbook which deploys conversion hosts, this
+# should be solved better, by generating another key and authorizing
+# dst conv host to ssh into src conv host.
+- name: Hack to insert ssh key to dst host
+  block:
+    - name: Fetch dst conv host info
+      os_server_info:
+        filters:
+          name: "{{ os_migrate_dst_conversion_host_name }}"
+        auth: "{{ os_migrate_dst_auth }}"
+        validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+        ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+        client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+        client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+      register: _dst_conv_host
+
+    - name: Set dst conv host ip fact
+      set_fact:
+        _dst_conv_ip: "{{ _dst_conv_host.openstack_servers[0].accessIPv4 }}"
+
+    - name: Wait until the dst conversion host is reachable
+      wait_for:
+        port: 22
+        host: '{{ _dst_conv_ip }}'
+        search_regex: OpenSSH
+        delay: 10
+        timeout: 600
+
+    - name: Inject ssh key to dst host
+      shell: |
+        ssh -o StrictHostKeyChecking=no \
+            -i {{ '~' | expanduser }}/ssh-ci/id_rsa \
+            cloud-user@{{ _dst_conv_ip }} mkdir -p .ssh
+        cat "{{ '~' | expanduser }}/ssh-ci/id_rsa" \
+            | ssh -o StrictHostKeyChecking=no \
+                -i {{ '~' | expanduser }}/ssh-ci/id_rsa \
+                cloud-user@{{ _dst_conv_ip }} "cat > .ssh/id_rsa"
+        ssh -o StrictHostKeyChecking=no \
+            -i {{ '~' | expanduser }}/ssh-ci/id_rsa \
+            cloud-user@{{ _dst_conv_ip }} chmod 0700 .ssh
+        ssh -o StrictHostKeyChecking=no \
+            -i {{ '~' | expanduser }}/ssh-ci/id_rsa \
+            cloud-user@{{ _dst_conv_ip }} chmod 0600 .ssh/id_rsa
+
 
 # In order to be able to migrate the VMS they must be turned off
 - name: Shutdown osm_server


### PR DESCRIPTION
In CI we're hitting this error:

    File "/tmp/ansible_os_migrate.os_migrate.import_workload_export_volumes_payload_4g3ps56s/ansible_os_migrate.os_migrate.import_workload_export_volumes_payload.zip/ansible_collections/os_migrate/os_migrate/plugins/modules/import_workload_export_volumes.py", line 364, in _detach_data_volumes_from_source
    AttributeError: 'NoneType' object has no attribute 'id'

Looks like the call to create snapshot returns None. We'll try moving
the timeout into the call itself and using wait=True.