### PR TITLE
Fix Resource Updates

### DIFF
--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -78,5 +78,5 @@ class Network(resource.Resource):
         return refs
 
     @staticmethod
-    def _update_sdk_res(conn, name_or_id, sdk_params):
-        return conn.network.update_network(name_or_id, **sdk_params)
+    def _update_sdk_res(conn, sdk_res, sdk_params):
+        return conn.network.update_network(sdk_res, **sdk_params)

--- a/os_migrate/plugins/module_utils/resource.py
+++ b/os_migrate/plugins/module_utils/resource.py
@@ -195,7 +195,7 @@ class Resource():
         if existing:
             if self._needs_update(self.from_sdk(conn, existing)):
                 self._remove_readonly_params(sdk_params)
-                self._update_sdk_res(conn, sdk_params['name'], sdk_params)
+                self._update_sdk_res(conn, existing, sdk_params)
                 return True
         else:
             self._create_sdk_res(conn, sdk_params)

--- a/os_migrate/plugins/module_utils/router.py
+++ b/os_migrate/plugins/module_utils/router.py
@@ -104,5 +104,5 @@ class Router(resource.Resource):
         return refs
 
     @staticmethod
-    def _update_sdk_res(conn, name_or_id, sdk_params):
-        return conn.network.update_router(name_or_id, **sdk_params)
+    def _update_sdk_res(conn, sdk_res, sdk_params):
+        return conn.network.update_router(sdk_res, **sdk_params)

--- a/os_migrate/plugins/module_utils/security_group.py
+++ b/os_migrate/plugins/module_utils/security_group.py
@@ -38,5 +38,5 @@ class SecurityGroup(resource.Resource):
         return conn.network.find_security_group(name_or_id, **(filters or {}))
 
     @staticmethod
-    def _update_sdk_res(conn, name_or_id, sdk_params):
-        return conn.network.update_security_group(name_or_id, **sdk_params)
+    def _update_sdk_res(conn, sdk_res, sdk_params):
+        return conn.network.update_security_group(sdk_res, **sdk_params)

--- a/os_migrate/plugins/module_utils/subnet.py
+++ b/os_migrate/plugins/module_utils/subnet.py
@@ -71,8 +71,8 @@ class Subnet(resource.Resource):
         return conn.network.find_subnet(name_or_id, **(filters or {}))
 
     @staticmethod
-    def _update_sdk_res(conn, name_or_id, sdk_params):
-        return conn.network.update_subnet(name_or_id, **sdk_params)
+    def _update_sdk_res(conn, sdk_res, sdk_params):
+        return conn.network.update_subnet(sdk_res, **sdk_params)
 
     @staticmethod
     def _refs_from_sdk(conn, sdk_res):


### PR DESCRIPTION
For the resources that support updating, the code previously called
the update sending the resource name causing the update to fail
from the corresponding API with a "BadRequest" error.  This patch
updates the code to use the instance of the resource itself when
calling the associated update method.

Co-authored-by: Jiri Stransky <jistr@redhat.com>