### PR TITLE
Fix subnet update test

### DIFF
--- a/tests/func/update/network.yml
+++ b/tests/func/update/network.yml
@@ -1,11 +1,9 @@
 - name: change item in file for update test
-  lineinfile:
-    dest: "{{ os_migrate_data_dir }}/networks.yml"
-    regexp: "description: ''"
-    line: "    description: 'osm_net_updated'"
-    state: present
+  replace:
+    path: "{{ os_migrate_data_dir }}/networks.yml"
+    regexp: "    description: ''"
+    replace: "    description: 'osm_net_updated'"
     backup: yes
-    backrefs: yes
 
 - name: scan available networks after before test
   os_networks_info:

--- a/tests/func/update/router.yml
+++ b/tests/func/update/router.yml
@@ -1,11 +1,9 @@
 - name: change item in file for update test
-  lineinfile:
-    dest: "{{ os_migrate_data_dir }}/routers.yml"
-    regexp: "description: ''"
-    line: "    description: 'osm_router_updated'"
-    state: present
+  replace:
+    path: "{{ os_migrate_data_dir }}/routers.yml"
+    regexp: "    description: ''"
+    replace: "    description: 'osm_router_updated'"
     backup: yes
-    backrefs: yes
 
 - name: scan available routers after before test
   os_migrate.os_migrate.os_routers_info:

--- a/tests/func/update/security_group.yml
+++ b/tests/func/update/security_group.yml
@@ -1,11 +1,9 @@
 - name: change item in file for update test
-  lineinfile:
-    dest: "{{ os_migrate_data_dir }}/security_groups.yml"
-    regexp: "description: OSM security group"
-    line: "    description: 'OSM security group updated'"
-    state: present
+  replace:
+    path: "{{ os_migrate_data_dir }}/security_groups.yml"
+    regexp: "    description: OSM security group"
+    replace: "    description: 'OSM security group updated'"
     backup: yes
-    backrefs: yes
 
 - name: scan available security_groups after before test
   os_migrate.os_migrate.os_security_groups_info:

--- a/tests/func/update/subnet.yml
+++ b/tests/func/update/subnet.yml
@@ -1,11 +1,9 @@
 - name: change item in file for update test
-  lineinfile:
-    dest: "{{ os_migrate_data_dir }}/subnets.yml"
+  replace:
+    path: "{{ os_migrate_data_dir }}/subnets.yml"
     regexp: "    description: ''"
-    line: "    description: 'osm_subnet_updated'"
-    state: present
+    replace: "    description: 'osm_subnet_updated'"
     backup: yes
-    backrefs: yes
 
 - name: scan available subnets after before test
   os_subnets_info:


### PR DESCRIPTION
The lineinfile module only makes sure one line is present. So after it
does its replacement in one spot, it stops replacing. Due to random
order of subnets in the file, it sometimes replaces the description of
the wrong subnet, resulting in intermittent failures. To make the
tests work, we simply replace descriptions of both subnets in the func
test, and then we check only one.

To keep tests consistent, use 'replace' instead of 'lineinfile' module
in other tests too.