### PR TITLE
Prepare release 0.4.0

### DIFF
--- a/os_migrate/galaxy.yml
+++ b/os_migrate/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: os_migrate
 name: os_migrate
-version: 0.3.0
+version: 0.4.0
 readme: README.md
 authors:
   - Jiri Stransky <jistr@redhat.com>

--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -1,4 +1,4 @@
-OS_MIGRATE_VERSION = '0.3.0'  # updated by build.sh
+OS_MIGRATE_VERSION = '0.4.0'  # updated by build.sh
 
 # Main serialization sections
 RES_PARAMS = 'params'

--- a/tests/func/data/validate_data_dir/invalid/networks-duplicate.yml
+++ b/tests/func/data/validate_data_dir/invalid/networks-duplicate.yml
@@ -1,4 +1,4 @@
-os_migrate_version: 0.3.0
+os_migrate_version: 0.4.0
 resources:
   - _info:
       availability_zones: []

--- a/tests/func/data/validate_data_dir/invalid/networks.yml
+++ b/tests/func/data/validate_data_dir/invalid/networks.yml
@@ -1,4 +1,4 @@
-os_migrate_version: 0.3.0
+os_migrate_version: 0.4.0
 resources:
   - _info:
       availability_zones: []

--- a/tests/func/data/validate_data_dir/valid/networks.yml
+++ b/tests/func/data/validate_data_dir/valid/networks.yml
@@ -1,4 +1,4 @@
-os_migrate_version: 0.3.0
+os_migrate_version: 0.4.0
 resources:
   - _info:
       availability_zones: []


### PR DESCRIPTION
Mainly utilizes a new workload migration approach with new conversion
host and conversion host deployment/deletion playbooks.