### PR TITLE
Adds Role to Install Conversion Host Content

### DIFF
--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -52,3 +52,17 @@
         name: os_migrate.os_migrate.conversion_host
         tasks_from: link_insert_private_key.yml
       when: os_migrate_link_conversion_hosts|default(true)|bool
+
+- hosts: os_migrate_conv_src
+  tasks:
+    - include_role:
+        name: os_migrate.os_migrate.conversion_host_content
+      when: os_migrate_conversion_host_content_install|default(true)|bool
+
+- hosts: os_migrate_conv_dst
+  become_user: root
+  become: yes
+  tasks:
+    - include_role:
+        name: os_migrate.os_migrate.conversion_host_content
+      when: os_migrate_conversion_host_content_install|default(true)|bool

--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -25,3 +25,5 @@ os_migrate_conversion_host_name: os_migrate_conv
 os_migrate_conversion_image_name: os_migrate_conv
 
 os_migrate_conversion_ssh_user: cloud-user
+
+os_migrate_conversion_host_content_install: true

--- a/os_migrate/roles/conversion_host_content/README.md
+++ b/os_migrate/roles/conversion_host_content/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/master/doc/user/README.md).

--- a/os_migrate/roles/conversion_host_content/tasks/centos.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/centos.yml
@@ -1,0 +1,13 @@
+- name: install epel release
+  yum:
+    name: epel-release
+    state: present
+
+- name: install content
+  yum:
+    name:
+      - nbdkit
+      - nbdkit-basic-plugins
+      - qemu-img
+      - libguestfs-tools
+    state: present

--- a/os_migrate/roles/conversion_host_content/tasks/main.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: display host os
+  debug: msg="Conversion Host OS is {{ ansible_distribution }}."
+
+- name: install epel release for CentOS
+  yum:
+    name: epel-release
+    state: present
+  when: ansible_distribution in ['CentOS']
+
+- name: install content
+  yum:
+    name:
+      - nbdkit
+      - nbdkit-basic-plugins
+      - qemu-img
+      - libguestfs-tools
+    state: present
+  when: ansible_distribution in ['CentOS', 'RedHat']

--- a/os_migrate/roles/conversion_host_content/tasks/rhel.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/rhel.yml
@@ -1,0 +1,11 @@
+- name: noop
+  debug: msg="we might need to do some RHSM stuff here"
+
+- name: install content
+  yum:
+    name:
+      - nbdkit
+      - nbdkit-basic-plugins
+      - qemu-img
+      - libguestfs-tools
+    state: present


### PR DESCRIPTION
This patch adds a role to install content for the conversion host
conditionally.  The role currently supports CentOS and RHEL but
is written in a way that should be simple to add additional OS
support if needed in the future.

[ccamacho]: We will merge this and iterate over, there is one simple change to make it work.