### PR TITLE
Adds Import and Export Roles for Nova Flavors

### DIFF
--- a/os_migrate/playbooks/export_flavors.yml
+++ b/os_migrate/playbooks/export_flavors.yml
@@ -1,0 +1,3 @@
+- hosts: migrator
+  roles:
+    - os_migrate.os_migrate.export_flavors

--- a/os_migrate/playbooks/import_flavors.yml
+++ b/os_migrate/playbooks/import_flavors.yml
@@ -1,0 +1,3 @@
+- hosts: migrator
+  roles:
+    - os_migrate.os_migrate.import_flavors

--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -7,6 +7,7 @@ RES_INFO = '_info'
 
 # Supported resource types
 RES_TYPE_IMAGE = 'openstack.image.Image'
+RES_TYPE_FLAVOR = 'openstack.compute.Flavor'
 RES_TYPE_NETWORK = 'openstack.network.Network'
 RES_TYPE_ROUTER = 'openstack.network.Router'
 RES_TYPE_ROUTER_INTERFACE = 'openstack.network.RouterInterface'

--- a/os_migrate/plugins/module_utils/flavor.py
+++ b/os_migrate/plugins/module_utils/flavor.py
@@ -1,0 +1,43 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import openstack
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import const, resource
+
+
+class Flavor(resource.Resource):
+    resource_type = const.RES_TYPE_FLAVOR
+    sdk_class = openstack.compute.v2.flavor.Flavor
+
+    info_from_sdk = [
+        'id',
+    ]
+
+    params_from_sdk = [
+        'description',
+        'disk',
+        'ephemeral',
+        'extra_specs',
+        'is_disabled',
+        'is_public',
+        'links',
+        'name',
+        'ram',
+        'rxtx_factor',
+        'swap',
+        'vcpus',
+    ]
+
+    @staticmethod
+    def _create_sdk_res(conn, sdk_params):
+        return conn.compute.create_flavor(**sdk_params)
+
+    @staticmethod
+    def _find_sdk_res(conn, name_or_id, filters=None):
+        return conn.compute.find_flavor(name_or_id, **(filters or {}))
+
+    @staticmethod
+    def _update_sdk_res(conn, sdk_res, sdk_params):
+        return

--- a/os_migrate/plugins/modules/export_flavor.py
+++ b/os_migrate/plugins/modules/export_flavor.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: export_flavor
+
+short_description: Export OpenStack Nova Flavor
+
+extends_documentation_fragment: openstack
+
+version_added: "2.9"
+
+author: "OpenStack tenant migration tools (@os-migrate)"
+
+description:
+  - "Export OpenStack Nova Flavor definition into an OS-Migrate YAML"
+
+options:
+  auth:
+    description:
+      - Dictionary with parameters for chosen auth type.
+    required: true
+    type: dict
+  auth_type:
+    description:
+      - Auth type plugin for OpenStack. Can be omitted if using password authentication.
+    required: false
+    type: str
+  region_name:
+    description:
+      - OpenStack region name. Can be omitted if using default region.
+    required: false
+    type: str
+  path:
+    description:
+      - Resources YAML file to where network will be serialized.
+      - In case the resource file already exists, it must match the
+        os-migrate version.
+      - In case the resource of same type and name exists in the file,
+        it will be replaced.
+    required: true
+    type: str
+  name:
+    description:
+      - Name (or ID) of a Nova Flavor to export.
+    required: true
+    type: str
+  availability_zone:
+    description:
+      - Availability zone.
+    required: false
+    type: str
+  cloud:
+    description:
+      - Ignored. Present for backwards compatibility.
+    required: false
+    type: raw
+'''
+
+EXAMPLES = '''
+- name: Export myflavor into /opt/os-migrate/flavors.yml
+  os_migrate.os_migrate.export_flavor:
+    cloud: source_cloud
+    path: /opt/os-migrate/flavors.yml
+    name: myflavor
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack \
+    import openstack_full_argument_spec, openstack_cloud_from_module
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import filesystem
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import flavor
+
+
+def run_module():
+    argument_spec = openstack_full_argument_spec(
+        path=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+    )
+    # TODO: check the del
+    # del argument_spec['cloud']
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        # TODO: Consider check mode. We'd fetch the resource and check
+        # if the file representation matches it.
+        # supports_check_mode=True,
+    )
+
+    sdk, conn = openstack_cloud_from_module(module)
+    sdk_flavor = conn.compute.find_flavor(module.params['name'], ignore_missing=False)
+    data = flavor.Flavor.from_sdk(conn, sdk_flavor)
+
+    result['changed'] = filesystem.write_or_replace_resource(
+        module.params['path'], data)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/import_flavor.py
+++ b/os_migrate/plugins/modules/import_flavor.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: import_flavor
+
+short_description: Import OpenStack Nova Flavor
+
+extends_documentation_fragment: openstack
+
+version_added: "2.9"
+
+author: "OpenStack tenant migration tools (@os-migrate)"
+
+description:
+  - "Import OpenStack Nova Flavor from an OS-Migrate YAML structure"
+
+options:
+  auth:
+    description:
+      - Dictionary with parameters for chosen auth type.
+    required: true
+    type: dict
+  auth_type:
+    description:
+      - Auth type plugin for OpenStack. Can be omitted if using password authentication.
+    required: false
+    type: str
+  region_name:
+    description:
+      - OpenStack region name. Can be omitted if using default region.
+    required: false
+    type: str
+  data:
+    description:
+      - Data structure with subnet parameters as loaded from OS-Migrate YAML file.
+    required: true
+    type: dict
+  filters:
+    description:
+      - Options for filtering existing resources to be looked up, e.g. by project.
+    required: true
+    type: dict
+  availability_zone:
+    description:
+      - Availability zone.
+    required: false
+    type: str
+  cloud:
+    description:
+      - Ignored. Present for backwards compatibility.
+    required: false
+    type: raw
+'''
+
+EXAMPLES = '''
+- name: Import myflavor from /opt/os-migrate/flavors.yml
+  os_migrate.os_migrate.import_flavor:
+    cloud: source_cloud
+    data:
+      - type: openstack.flavor
+        params:
+          name: my_flavor
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack \
+    import openstack_full_argument_spec, openstack_cloud_from_module
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import flavor
+
+
+def run_module():
+    argument_spec = openstack_full_argument_spec(
+        data=dict(type='dict', required=True),
+        filters=dict(type='dict', required=False, default={}),
+    )
+    # TODO: check the del
+    # del argument_spec['cloud']
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        # TODO: Consider check mode. We'd fetch the resource and check
+        # if the file representation matches it.
+        # supports_check_mode=True,
+    )
+
+    sdk, conn = openstack_cloud_from_module(module)
+    flv = flavor.Flavor.from_data(module.params['data'])
+    result['changed'] = flv.create_or_update(conn, module.params['filters'])
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/roles/export_flavors/README.md
+++ b/os_migrate/roles/export_flavors/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/main/doc/user/README.md).

--- a/os_migrate/roles/export_flavors/defaults/main.yml
+++ b/os_migrate/roles/export_flavors/defaults/main.yml
@@ -1,0 +1,2 @@
+export_flavors_name_filter:
+  - regex: .*

--- a/os_migrate/roles/export_flavors/meta/main.yml
+++ b/os_migrate/roles/export_flavors/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: os-migrate
+  description: os-migrate resource
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.9
+  platforms:
+    - name: Fedora
+      versions:
+        - 30
+  galaxy_tags: ["os-migrate"]
+dependencies:
+  - role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_flavors/tasks/main.yml
+++ b/os_migrate/roles/export_flavors/tasks/main.yml
@@ -1,0 +1,37 @@
+- name: scan available flavors
+  os_flavor_info:
+    auth: "{{ os_migrate_src_auth }}"
+    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  register: src_flavors_info
+
+- name: create id-name pairs of flavors to export
+  set_fact:
+    export_flavors_ids_names: "{{ (
+      src_flavors_info.openstack_flavors
+        | json_query('[*].{name: name, id: id}')
+        | sort(attribute='id') ) }}"
+
+- name: filter names of flavors to export
+  set_fact:
+    export_flavors_ids_names: "{{ (
+      export_flavors_ids_names
+        | os_migrate.os_migrate.stringfilter(export_flavors_name_filter,
+                                             attribute='name') ) }}"
+
+- name: export flavor
+  os_migrate.os_migrate.export_flavor:
+    auth: "{{ os_migrate_src_auth }}"
+    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    path: "{{ os_migrate_data_dir }}/flavors.yml"
+    name: "{{ item['id'] }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  loop: "{{ export_flavors_ids_names }}"

--- a/os_migrate/roles/import_flavors/README.md
+++ b/os_migrate/roles/import_flavors/README.md
@@ -1,0 +1,2 @@
+Please refer to
+[OS Migrate user docs](https://github.com/os-migrate/os-migrate/blob/main/doc/user/README.md).

--- a/os_migrate/roles/import_flavors/defaults/main.yml
+++ b/os_migrate/roles/import_flavors/defaults/main.yml
@@ -1,0 +1,1 @@
+import_flavors_validate_file: true

--- a/os_migrate/roles/import_flavors/meta/main.yml
+++ b/os_migrate/roles/import_flavors/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: os-migrate
+  description: os-migrate resource
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.9
+  platforms:
+    - name: Fedora
+      versions:
+        - 30
+  galaxy_tags: ["os-migrate"]
+dependencies:
+  - role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_flavors/tasks/main.yml
+++ b/os_migrate/roles/import_flavors/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: validate loaded resources
+  os_migrate.os_migrate.validate_resource_files:
+    paths:
+      - "{{ os_migrate_data_dir }}/flavors.yml"
+  register: flavors_file_validation
+  when: import_flavors_validate_file
+
+- name: stop when errors found
+  fail:
+    msg: "{{ flavors_file_validation.errors|join(' ') }}"
+  when: not ( flavors_file_validation.ok | bool )
+
+- name: read flavors resource file
+  os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/flavors.yml"
+  register: read_flavors
+
+- name: import flavors
+  os_migrate.os_migrate.import_flavor:
+    auth: "{{ os_migrate_dst_auth }}"
+    auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
+    data: "{{ item }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+  loop: "{{ read_flavors.resources }}"

--- a/os_migrate/tests/sanity/ignore-2.9.txt
+++ b/os_migrate/tests/sanity/ignore-2.9.txt
@@ -24,3 +24,5 @@ plugins/modules/os_routers_info.py validate-modules:missing-gplv3-license
 plugins/modules/os_security_groups_info.py validate-modules:missing-gplv3-license
 plugins/modules/read_resources.py validate-modules:missing-gplv3-license
 plugins/modules/validate_resource_files.py validate-modules:missing-gplv3-license
+plugins/modules/export_flavor.py validate-modules:missing-gplv3-license
+plugins/modules/import_flavor.py validate-modules:missing-gplv3-license

--- a/os_migrate/tests/unit/test_flavor.py
+++ b/os_migrate/tests/unit/test_flavor.py
@@ -1,0 +1,112 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import openstack
+import unittest
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import const, flavor
+
+
+def sdk_flavor():
+    return openstack.compute.v2.flavor.Flavor(
+        description='',
+        disk=256,
+        ephemeral=1,
+        extra_specs={},
+        id='uuid-test-flavor',
+        is_disabled=False,
+        is_public=True,
+        name='test-flavor',
+        ram=128,
+        rxtx_factor=1.5,
+        swap=64,
+        vcpus=2,
+        links=[
+            {'rel': 'self',
+             'href': 'http://192.168.122.85/compute/v2.1/flavors/d1'},
+            {'rel': 'bookmark',
+             'href': 'http://192.168.122.85/compute/flavors/d1'}],
+    )
+
+
+def serialized_flavor():
+    return {
+        const.RES_PARAMS: {
+            'description': '',
+            'disk': 256,
+            'ephemeral': 1,
+            'extra_specs': {},
+            'is_disabled': False,
+            'is_public': True,
+            'links': [
+                {'rel': 'self',
+                 'href': 'http://192.168.122.85/compute/v2.1/flavors/d1'},
+                {'rel': 'bookmark',
+                 'href': 'http://192.168.122.85/compute/flavors/d1'}
+            ],
+            'name': 'test-flavor',
+            'ram': 128,
+            'rxtx_factor': 1.5,
+            'swap': 64,
+            'vcpus': 2,
+        },
+        const.RES_INFO: {
+            'id': 'uuid-test-flavor',
+        },
+        const.RES_TYPE: 'openstack.compute.Flavor',
+    }
+
+
+class TestFlavor(unittest.TestCase):
+
+    def test_serialize_flavor(self):
+        sdk_net = sdk_flavor()
+        flv = flavor.Flavor.from_sdk(None, sdk_net)  # conn=None
+        params, info = flv.params_and_info()
+
+        self.assertEqual(flv.type(), const.RES_TYPE_FLAVOR)
+        self.assertEqual(params['description'], '')
+        self.assertEqual(params['disk'], 256)
+        self.assertEqual(params['ephemeral'], 1)
+        self.assertEqual(params['extra_specs'], {})
+        self.assertEqual(params['is_disabled'], False)
+        self.assertEqual(params['is_public'], True)
+        self.assertEqual(params['links'], [
+            {'rel': 'self',
+             'href': 'http://192.168.122.85/compute/v2.1/flavors/d1'},
+            {'rel': 'bookmark',
+             'href': 'http://192.168.122.85/compute/flavors/d1'}
+        ],)
+        self.assertEqual(params['name'], 'test-flavor')
+        self.assertEqual(params['ram'], 128)
+        self.assertEqual(params['rxtx_factor'], 1.5)
+        self.assertEqual(params['swap'], 64)
+        self.assertEqual(params['vcpus'], 2)
+
+        self.assertEqual(info['id'], 'uuid-test-flavor')
+
+    def test_flavor_sdk_params(self):
+        flv = flavor.Flavor.from_data(serialized_flavor())
+        sdk_params = flv._to_sdk_params(None)
+
+        self.assertEqual(sdk_params['description'], '')
+        self.assertEqual(sdk_params['disk'], 256)
+        self.assertEqual(sdk_params['ephemeral'], 1)
+        self.assertEqual(sdk_params['extra_specs'], {})
+        self.assertEqual(sdk_params['is_disabled'], False)
+        self.assertEqual(sdk_params['is_public'], True)
+        self.assertEqual(sdk_params['links'], [
+            {'rel': 'self',
+             'href': 'http://192.168.122.85/compute/v2.1/flavors/d1'},
+            {'rel': 'bookmark',
+             'href': 'http://192.168.122.85/compute/flavors/d1'}
+        ],)
+        self.assertEqual(sdk_params['name'], 'test-flavor')
+        self.assertEqual(sdk_params['ram'], 128)
+        self.assertEqual(sdk_params['rxtx_factor'], 1.5)
+        self.assertEqual(sdk_params['swap'], 64)
+        self.assertEqual(sdk_params['vcpus'], 2)
+
+        # disallowed params when creating a flavor
+        self.assertNotIn('id', sdk_params)

--- a/tests/func/run/all.yml
+++ b/tests/func/run/all.yml
@@ -52,4 +52,11 @@
     apply:
       tags:
         - test_image
+
+- name: Include flavor tasks
+  include_tasks: flavor.yml
+  args:
+    apply:
+      tags:
+        - test_flavor
   tags: always

--- a/tests/func/run/flavor.yml
+++ b/tests/func/run/flavor.yml
@@ -1,0 +1,18 @@
+- include_role:
+    name: os_migrate.os_migrate.export_flavors
+
+- name: load exported data
+  set_fact:
+    flavor_resources: "{{ (lookup('file',
+                                  os_migrate_data_dir +
+                                  '/flavors.yml') | from_yaml)
+                   ['resources'] }}"
+
+- name: verify data contents
+  assert:
+    that:
+      - (flavor_resources | json_query("[?params.name ==
+                            'm1.small'].params.disk") == [20])
+
+- include_role:
+    name: os_migrate.os_migrate.import_flavors


### PR DESCRIPTION
This patch adds import and export roles, supporting files and tests
for migrating Nova Flavors between clouds.