### PR TITLE
Export of Glance images

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -183,7 +183,7 @@ jobs:
           # Pre-requisite
           ENABLED_SERVICES=mysql,key
           # Neutron
-          ENABLED_SERVICES+=,q-svc,q-dhcp,q-meta,q-l3,q-agt
+          ENABLED_SERVICES+=,q-svc,q-dhcp,q-meta,q-l3,q-agt,g-api
           EOF
           cat local.conf
           sudo ./tools/create-stack-user.sh

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 /.venv
 /local
 /tests/func/auth.yml
-/tests/func/tmpdata
+/tests/func/tmp
 /toolbox/vagrant/.vagrant
 /toolbox/vagrant/env

--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,11 @@ test-func: reinstall
 	ansible-playbook \
 		-v \
 		-i $(ROOT_DIR)/os_migrate/localhost_inventory.yml \
-		-e os_migrate_data_dir=$(ROOT_DIR)/tests/func/tmpdata \
+		-e os_migrate_tests_tmp_dir=$(ROOT_DIR)/tests/func/tmp \
+		-e os_migrate_data_dir=$(ROOT_DIR)/tests/func/tmp/data \
 		-e @$(ROOT_DIR)/tests/auth.yml \
 		$(FUNC_TEST_ARGS) test_all.yml
 
-# FIXME: remove the parameters from here, put them in a file (like we
-# already have auth.yml).
 test-e2e: reinstall
 	set -euo pipefail; \
 	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
@@ -79,7 +78,8 @@ test-e2e: reinstall
 	ansible-playbook \
 		-v \
 		-i $(OS_MIGRATE)/localhost_inventory.yml \
-		-e os_migrate_data_dir=$(ROOT_DIR)/tests/func/tmpdata \
+		-e os_migrate_tests_tmp_dir=$(ROOT_DIR)/tests/func/tmp \
+		-e os_migrate_data_dir=$(ROOT_DIR)/tests/func/tmp/data \
 		-e os_migrate_conversion_host_key=$(ROOT_DIR)/tests/func/tmpdata/conversion/ssh.key \
                 -e @$(ROOT_DIR)/tests/e2e/scenario_variables.yml \
 		-e @$(ROOT_DIR)/tests/auth.yml \

--- a/os_migrate/playbooks/export_images.yml
+++ b/os_migrate/playbooks/export_images.yml
@@ -1,0 +1,3 @@
+- hosts: migrator
+  roles:
+    - os_migrate.os_migrate.export_images

--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -6,6 +6,7 @@ RES_TYPE = 'type'
 RES_INFO = '_info'
 
 # Supported resource types
+RES_TYPE_IMAGE = 'openstack.image.Image'
 RES_TYPE_NETWORK = 'openstack.network.Network'
 RES_TYPE_ROUTER = 'openstack.network.Router'
 RES_TYPE_ROUTER_INTERFACE = 'openstack.network.RouterInterface'

--- a/os_migrate/plugins/module_utils/image.py
+++ b/os_migrate/plugins/module_utils/image.py
@@ -1,0 +1,163 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import hashlib
+import openstack
+import os
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import const, reference, resource
+
+
+class Image(resource.Resource):
+
+    resource_type = const.RES_TYPE_IMAGE
+    sdk_class = openstack.image.v2.image.Image
+
+    info_from_sdk = [
+        'checksum',
+        'created_at',
+        'direct_url',
+        'file',
+        'id',
+        'instance_uuid',
+        'kernel_id',
+        'locations',
+        'metadata',
+        'owner_id',  # like project_id in other resources
+        'ramdisk_id',
+        'schema',
+        'size',
+        'status',
+        'updated_at',
+        'url',
+    ]
+    params_from_sdk = [
+        'architecture',
+        'container_format',
+        'disk_format',
+        'has_auto_disk_config',
+        'hash_algo',
+        'hash_value',
+        'hw_cpu_cores',
+        'hw_cpu_policy',
+        'hw_cpu_sockets',
+        'hw_cpu_thread_policy',
+        'hw_cpu_threads',
+        'hw_disk_bus',
+        'hw_machine_type',
+        'hw_qemu_guest_agent',
+        'hw_rng_model',
+        'hw_scsi_model',
+        'hw_serial_port_count',
+        'hw_video_model',
+        'hw_video_ram',
+        'hw_vif_model',
+        'hw_watchdog_action',
+        'hypervisor_type',
+        'instance_type_rxtx_factor',
+        'is_hidden',
+        'is_hw_boot_menu_enabled',
+        'is_hw_vif_multiqueue_enabled',
+        'is_protected',
+        'min_disk',
+        'min_ram',
+        'name',
+        'needs_config_drive',
+        'needs_secure_boot',
+        'os_admin_user',
+        'os_command_line',
+        'os_distro',
+        'os_require_quiesce',
+        'os_shutdown_timeout',
+        'os_type',
+        'os_version',
+        'properties',
+        'store',
+        'virtual_size',
+        'visibility',
+        'vm_mode',
+        'vmware_adaptertype',
+        'vmware_ostype',
+    ]
+    params_from_refs = [
+        'kernel_ref',
+        'ramdisk_ref',
+    ]
+    sdk_params_from_refs = [
+        'kernel_id',
+        'ramdisk_id',
+    ]
+
+    @classmethod
+    def from_sdk(cls, conn, sdk_resource):
+        obj = super(Image, cls).from_sdk(conn, sdk_resource)
+        params = obj.params()
+        # We need to remove 'self' from properties as it would break
+        # idempotency check and it's not really a property anyway.
+        if 'self' in (params.get('properties') or {}).keys():
+            del params['properties']['self']
+        return obj
+
+    @staticmethod
+    def _create_sdk_res(conn, sdk_params):
+        return conn.image.create_image(**sdk_params)
+
+    @staticmethod
+    def _find_sdk_res(conn, name_or_id, filters=None):
+        return conn.image.find_image(name_or_id, **(filters or {}))
+
+    @staticmethod
+    def _refs_from_sdk(conn, sdk_res):
+        refs = {}
+        refs['kernel_id'] = sdk_res['kernel_id']
+        refs['kernel_ref'] = reference.image_ref(conn, sdk_res['kernel_id'])
+        refs['ramdisk_id'] = sdk_res['ramdisk_id']
+        refs['ramdisk_ref'] = reference.image_ref(conn, sdk_res['ramdisk_id'])
+        return refs
+
+    def _refs_from_ser(self, conn, filters=None):
+        refs = {}
+        params = self.params()
+        refs['kernel_ref'] = params['kernel_ref']
+        refs['kernel_id'] = reference.image_id(conn, params['kernel_ref'])
+        refs['ramdisk_ref'] = params['ramdisk_ref']
+        refs['ramdisk_id'] = reference.image_id(conn, params['ramdisk_ref'])
+        return refs
+
+    @staticmethod
+    def _update_sdk_res(conn, sdk_res, sdk_params):
+        return conn.image.update_image(sdk_res, **sdk_params)
+
+    def _to_sdk_params(self, refs):
+        sdk_params = super(Image, self)._to_sdk_params(refs)
+        # Special Glance thing - properties should be specified as
+        # kwargs.
+        for key, val in (sdk_params.get('properties') or {}).items():
+            sdk_params[key] = val
+        return sdk_params
+
+
+def export_blob(conn, sdk_res, path):
+    if os.path.exists(path):
+        return False
+
+    chunk_size = 1024 * 1024  # 1 KB
+    checksum = hashlib.md5()
+    try:
+        with open(path, "wb") as image_file:
+            response = conn.image.download_image(sdk_res, stream=True)
+
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                checksum.update(chunk)
+                image_file.write(chunk)
+
+            if response.headers["Content-MD5"] != checksum.hexdigest():
+                raise Exception("Downloaded image checksum mismatch")
+    except:  # noqa: E722
+        # Do not keep incomplete downloads as the idempotence
+        # mechanism would consider them successfully downloaded.
+        os.remove(path)
+        raise
+
+    return True

--- a/os_migrate/plugins/module_utils/reference.py
+++ b/os_migrate/plugins/module_utils/reference.py
@@ -4,6 +4,30 @@ __metaclass__ = type
 from openstack.exceptions import HttpException
 
 
+def image_id(conn, ref, required=True):
+    """Fetch ID of Image identified by reference dict `ref`. Use
+    OpenStack SDK connection `conn` to fetch the info. If `required`,
+    ensure the fetch is successful.
+
+    Returns: the ID, or None if not found and not `required`
+
+    Raises: openstack's ResourceNotFound when `required` but not found
+    """
+    return _fetch_id(conn, conn.image.find_image, ref, required)
+
+
+def image_ref(conn, id_, required=True):
+    """Create reference dict for Image identified by ID `id_`. Use
+    OpenStack SDK connection `conn` to fetch the info. If `required`,
+    ensure the fetch is successful.
+
+    Returns: the ref dict, or None if not found and not `required`
+
+    Raises: openstack's ResourceNotFound when `required` but not found
+    """
+    return _fetch_ref(conn, conn.image.find_image, id_, required)
+
+
 def network_id(conn, ref, required=True):
     """Fetch ID of Network identified by reference dict `ref`. Use
     OpenStack SDK connection `conn` to fetch the info. If `required`,

--- a/os_migrate/plugins/modules/export_image_blob.py
+++ b/os_migrate/plugins/modules/export_image_blob.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: export_image_blob
+
+short_description: Export OpenStack image
+
+extends_documentation_fragment: openstack
+
+version_added: "2.9"
+
+author: "OpenStack tenant migration tools (@os-migrate)"
+
+description:
+  - "Export OpenStack image definition into an OS-Migrate YAML"
+
+options:
+  auth:
+    description:
+      - Dictionary with parameters for chosen auth type.
+    required: true
+    type: dict
+  auth_type:
+    description:
+      - Auth type plugin for OpenStack. Can be omitted if using password authentication.
+    required: false
+    type: str
+  region_name:
+    description:
+      - OpenStack region name. Can be omitted if using default region.
+    required: false
+    type: str
+  path:
+    description:
+      - Resources YAML file to where image will be serialized.
+      - In case the resource file already exists, it must match the
+        os-migrate version.
+      - In case the resource of same type and name exists in the file,
+        it will be replaced.
+    required: true
+    type: str
+  name:
+    description:
+      - Name (or ID) of a Image to export.
+    required: true
+    type: str
+  availability_zone:
+    description:
+      - Availability zone.
+    required: false
+    type: str
+  cloud:
+    description:
+      - Ignored. Present for backwards compatibility.
+    required: false
+    type: raw
+'''
+
+EXAMPLES = '''
+- name: Export myimage into /opt/os-migrate/images.yml
+  os_migrate.os_migrate.export_image_blob:
+    path: /opt/os-migrate/images.yml
+    name: myimage
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack \
+    import openstack_full_argument_spec, openstack_cloud_from_module
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import image
+
+
+def run_module():
+    argument_spec = openstack_full_argument_spec(
+        path=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+    )
+    # TODO: check the del
+    # del argument_spec['cloud']
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        # TODO: Consider check mode. We'd fetch the resource and check
+        # if the file representation matches it.
+        # supports_check_mode=True,
+    )
+
+    sdk, conn = openstack_cloud_from_module(module)
+    sdk_image = conn.image.find_image(module.params['name'], ignore_missing=False)
+    result['changed'] = image.export_blob(conn, sdk_image, module.params['path'])
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/export_image_meta.py
+++ b/os_migrate/plugins/modules/export_image_meta.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: export_image_meta
+
+short_description: Export OpenStack image
+
+extends_documentation_fragment: openstack
+
+version_added: "2.9"
+
+author: "OpenStack tenant migration tools (@os-migrate)"
+
+description:
+  - "Export OpenStack image definition into an OS-Migrate YAML"
+
+options:
+  auth:
+    description:
+      - Dictionary with parameters for chosen auth type.
+    required: true
+    type: dict
+  auth_type:
+    description:
+      - Auth type plugin for OpenStack. Can be omitted if using password authentication.
+    required: false
+    type: str
+  region_name:
+    description:
+      - OpenStack region name. Can be omitted if using default region.
+    required: false
+    type: str
+  path:
+    description:
+      - Resources YAML file to where image will be serialized.
+      - In case the resource file already exists, it must match the
+        os-migrate version.
+      - In case the resource of same type and name exists in the file,
+        it will be replaced.
+    required: true
+    type: str
+  name:
+    description:
+      - Name (or ID) of a Image to export.
+    required: true
+    type: str
+  availability_zone:
+    description:
+      - Availability zone.
+    required: false
+    type: str
+  cloud:
+    description:
+      - Ignored. Present for backwards compatibility.
+    required: false
+    type: raw
+'''
+
+EXAMPLES = '''
+- name: Export myimage into /opt/os-migrate/images.yml
+  os_migrate.os_migrate.export_image_meta:
+    path: /opt/os-migrate/images.yml
+    name: myimage
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack \
+    import openstack_full_argument_spec, openstack_cloud_from_module
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import filesystem
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import image
+
+
+def run_module():
+    argument_spec = openstack_full_argument_spec(
+        path=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+    )
+    # TODO: check the del
+    # del argument_spec['cloud']
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        # TODO: Consider check mode. We'd fetch the resource and check
+        # if the file representation matches it.
+        # supports_check_mode=True,
+    )
+
+    sdk, conn = openstack_cloud_from_module(module)
+    sdk_image = conn.image.find_image(module.params['name'], ignore_missing=False)
+    ser_image = image.Image.from_sdk(conn, sdk_image)
+
+    result['changed'] = filesystem.write_or_replace_resource(
+        module.params['path'], ser_image)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/roles/export_images/defaults/main.yml
+++ b/os_migrate/roles/export_images/defaults/main.yml
@@ -1,0 +1,4 @@
+export_images_blobs: true
+export_images_name_filter:
+  - regex: .*
+os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"

--- a/os_migrate/roles/export_images/meta/main.yml
+++ b/os_migrate/roles/export_images/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: os-migrate
+  description: os-migrate resource
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.9
+  platforms:
+    - name: Fedora
+      versions:
+        - 30
+  galaxy_tags: ["os-migrate"]
+dependencies:
+  - role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_images/tasks/main.yml
+++ b/os_migrate/roles/export_images/tasks/main.yml
@@ -1,0 +1,60 @@
+- name: scan available images
+  os_image_info:
+    auth: "{{ os_migrate_src_auth }}"
+    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  register: src_images_info
+
+# FIXME: os_image_info doesn't support os_migrate_src_filters, so
+# apply the filter somehow differently?
+
+- name: create id-name pairs of images to export
+  set_fact:
+    export_images_ids_names: "{{ (
+      src_images_info.openstack_image
+        | json_query('[*].{name: name, id: id}')
+        | sort(attribute='id') ) }}"
+
+- name: filter names of images to export
+  set_fact:
+    export_images_ids_names: "{{ (
+      export_images_ids_names
+        | os_migrate.os_migrate.stringfilter(export_images_name_filter,
+                                             attribute='name') ) }}"
+
+- name: export image metadata
+  os_migrate.os_migrate.export_image_meta:
+    auth: "{{ os_migrate_src_auth }}"
+    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    path: "{{ os_migrate_data_dir }}/images.yml"
+    name: "{{ item['id'] }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  loop: "{{ export_images_ids_names }}"
+
+- name: make sure image blob dir exists
+  file:
+    path: "{{ os_migrate_image_blobs_dir }}"
+    state: directory
+  when: export_images_blobs
+
+- name: export image blobs
+  os_migrate.os_migrate.export_image_blob:
+    auth: "{{ os_migrate_src_auth }}"
+    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    path: "{{ os_migrate_image_blobs_dir }}/{{ item['id'] }}-{{ item['name'] }}"
+    name: "{{ item['id'] }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  loop: "{{ export_images_ids_names }}"
+  when: export_images_blobs

--- a/os_migrate/tests/sanity/ignore-2.9.txt
+++ b/os_migrate/tests/sanity/ignore-2.9.txt
@@ -1,4 +1,6 @@
 plugins/modules/auth_info.py validate-modules:missing-gplv3-license
+plugins/modules/export_image_blob.py validate-modules:missing-gplv3-license
+plugins/modules/export_image_meta.py validate-modules:missing-gplv3-license
 plugins/modules/export_network.py validate-modules:missing-gplv3-license
 plugins/modules/export_router.py validate-modules:missing-gplv3-license
 plugins/modules/export_router_interfaces.py validate-modules:missing-gplv3-license

--- a/os_migrate/tests/unit/test_image.py
+++ b/os_migrate/tests/unit/test_image.py
@@ -1,0 +1,213 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import openstack
+import unittest
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
+    import const, image
+
+
+def sdk_image():
+    return openstack.image.v2.image.Image(**{
+        'architecture': None,
+        'checksum': 'fb49d369b157546e5aeb07327e7666ce',
+        'container_format': 'bare',
+        'created_at': '2020-06-26T13:50:57Z',
+        'direct_url': 'swift+config://ref1/glance/uuid-test-image',
+        'disk_format': 'qcow2',
+        'file': '/v2/images/uuid-test-image/file',
+        'has_auto_disk_config': None,
+        'hash_algo': None,
+        'hash_value': None,
+        'hw_cpu_cores': None,
+        'hw_cpu_policy': None,
+        'hw_cpu_sockets': None,
+        'hw_cpu_thread_policy': None,
+        'hw_cpu_threads': None,
+        'hw_disk_bus': None,
+        'hw_machine_type': None,
+        'hw_qemu_guest_agent': None,
+        'hw_rng_model': None,
+        'hw_scsi_model': None,
+        'hw_serial_port_count': None,
+        'hw_video_model': None,
+        'hw_video_ram': None,
+        'hw_vif_model': None,
+        'hw_watchdog_action': None,
+        'hypervisor_type': None,
+        'id': 'uuid-test-image',
+        'instance_type_rxtx_factor': None,
+        'instance_uuid': None,
+        'is_hidden': None,
+        'is_hw_boot_menu_enabled': None,
+        'is_hw_vif_multiqueue_enabled': None,
+        'is_protected': False,
+        'kernel_id': 'uuid-test-kernel',
+        'locations': None,
+        'metadata': None,
+        'min_disk': 20,
+        'min_ram': 4096,
+        'name': 'test-image',
+        'needs_config_drive': None,
+        'needs_secure_boot': None,
+        'os_admin_user': None,
+        'os_command_line': None,
+        'os_distro': None,
+        'os_require_quiesce': None,
+        'os_shutdown_timeout': None,
+        'os_type': None,
+        'os_version': None,
+        'owner_id': 'uuid-test-project',
+        'ramdisk_id': 'uuid-test-ramdisk',
+        'schema': '/v2/schemas/image',
+        'size': 1248591872,
+        'status': 'active',
+        'store': None,
+        'tags': [],
+        'updated_at': '2020-06-26T13:55:52Z',
+        'url': None,
+        'virtual_size': None,
+        'visibility': 'public',
+        'vm_mode': None,
+        'vmware_adaptertype': None,
+        'vmware_ostype': None,
+    })
+
+
+def serialized_image():
+    return {
+        const.RES_PARAMS: {
+            'architecture': None,
+            'container_format': 'bare',
+            'disk_format': 'qcow2',
+            'has_auto_disk_config': None,
+            'hash_algo': None,
+            'hash_value': None,
+            'hw_cpu_cores': None,
+            'hw_cpu_policy': None,
+            'hw_cpu_sockets': None,
+            'hw_cpu_thread_policy': None,
+            'hw_cpu_threads': None,
+            'hw_disk_bus': None,
+            'hw_machine_type': None,
+            'hw_qemu_guest_agent': None,
+            'hw_rng_model': None,
+            'hw_scsi_model': None,
+            'hw_serial_port_count': None,
+            'hw_video_model': None,
+            'hw_video_ram': None,
+            'hw_vif_model': None,
+            'hw_watchdog_action': None,
+            'hypervisor_type': None,
+            'instance_type_rxtx_factor': None,
+            'is_hidden': None,
+            'is_hw_boot_menu_enabled': None,
+            'is_hw_vif_multiqueue_enabled': None,
+            'is_protected': False,
+            'kernel_ref': {
+                'name': 'test-kernel',
+                'project_name': 'test-project',
+                'domain_name': 'Default',
+            },
+            'min_disk': 20,
+            'min_ram': 4096,
+            'name': 'test-image',
+            'needs_config_drive': None,
+            'needs_secure_boot': None,
+            'os_admin_user': None,
+            'os_command_line': None,
+            'os_distro': None,
+            'os_require_quiesce': None,
+            'os_shutdown_timeout': None,
+            'os_type': None,
+            'os_version': None,
+            'properties': None,
+            'ramdisk_ref': {
+                'name': 'test-ramdisk',
+                'project_name': 'test-project',
+                'domain_name': 'Default',
+            },
+            'store': None,
+            'virtual_size': None,
+            'visibility': 'public',
+            'vm_mode': None,
+            'vmware_adaptertype': None,
+            'vmware_ostype': None,
+        },
+        const.RES_INFO: {
+            'checksum': 'fb49d369b157546e5aeb07327e7666ce',
+            'created_at': '2020-06-26T13:50:57Z',
+            'direct_url': 'swift+config://ref1/glance/uuid-test-image',
+            'file': '/v2/images/uuid-test-image/file',
+            'id': 'uuid-test-image',
+            'instance_uuid': None,
+            'kernel_id': 'uuid-test-kernel',
+            'locations': None,
+            'metadata': None,
+            'owner_id': 'uuid-test-project',
+            'ramdisk_id': 'uuid-test-ramdisk',
+            'schema': '/v2/schemas/image',
+            'size': 1248591872,
+            'status': 'active',
+            'updated_at': '2020-06-26T13:55:52Z',
+            'url': None,
+        },
+        const.RES_TYPE: 'openstack.image.Image',
+    }
+
+
+def image_refs():
+    return {
+        'kernel_id': 'uuid-test-kernel',
+        'kernel_ref': {
+            'name': 'test-kernel',
+            'project_name': 'test-project',
+            'domain_name': 'Default',
+        },
+        'ramdisk_id': 'uuid-test-ramdisk',
+        'ramdisk_ref': {
+            'name': 'test-ramdisk',
+            'project_name': 'test-project',
+            'domain_name': 'Default',
+        },
+    }
+
+
+# "Disconnected" variant of Image resource where we make sure not to
+# make requests using `conn`.
+class Image(image.Image):
+
+    def _refs_from_ser(self, conn):
+        return image_refs()
+
+    @staticmethod
+    def _refs_from_sdk(conn, sdk_res):
+        return image_refs()
+
+
+class TestImage(unittest.TestCase):
+
+    # see full diffs in test errors
+    maxDiff = None
+
+    def test_serialize_image(self):
+        image_data = sdk_image()
+        serialized = Image.from_sdk(None, image_data)
+        params, info = serialized.params_and_info()
+
+        self.assertEqual(serialized.type(), 'openstack.image.Image')
+        self.assertEqual(params, serialized_image()['params'])
+        self.assertEqual(info, serialized_image()['_info'])
+
+    def test_deserialize_image(self):
+        ser = Image.from_data(serialized_image())
+        params = ser.params()
+        refs = ser._refs_from_ser(None)  # conn=None
+        sdk_params = ser._to_sdk_params(refs)
+
+        self.assertEqual(sdk_params['kernel_id'], refs['kernel_id'])
+        self.assertEqual(sdk_params['min_disk'], params['min_disk'])
+        self.assertEqual(sdk_params['min_ram'], params['min_ram'])
+        self.assertEqual(sdk_params['name'], params['name'])
+        self.assertEqual(sdk_params['ramdisk_id'], refs['ramdisk_id'])

--- a/scripts/linters.sh
+++ b/scripts/linters.sh
@@ -25,6 +25,7 @@ flake8 \
 # Bash hate
 find ./ \
      -not -wholename ".tox/*" \
+     -and -not -wholename "./local/*" \
      -and -not -wholename "*.test/*" \
      -and -name "*.sh" -print0 \
     | xargs -0 bashate -v --ignore E006
@@ -32,7 +33,8 @@ find ./ \
 #Yaml lint
 find ./ \
      -not -wholename ".tox/*" \
-     -and -not -wholename "./tests/func/tmpdata/*" \
+     -and -not -wholename "./local/*" \
+     -and -not -wholename "./tests/func/tmp/*" \
      -and -name "*.yml" -print0 \
     | xargs -0 -I {} yamllint -d '{
         extends: default,
@@ -46,6 +48,7 @@ find ./ \
 # Ansible lint
 find ./ \
      -not -wholename ".tox/*" \
-     -and -not -wholename "./tests/func/tmpdata/*" \
+     -and -not -wholename "./local/*" \
+     -and -not -wholename "./tests/func/tmp/*" \
      -and -name "*.yml" -print0 \
     | xargs -0 ansible-lint

--- a/tests/e2e/clean.yml
+++ b/tests/e2e/clean.yml
@@ -1,8 +1,33 @@
-- name: Remove osm_key keypair
-  os_keypair:
+- name: remove osm_server
+  os_server:
     auth: "{{ item.auth }}"
+    name: osm_server
     state: absent
-    name: osm_key
+    delete_fip: yes
+    validate_certs: "{{ item.validate_certs }}"
+    ca_cert: "{{ item.ca_cert }}"
+    client_cert: "{{ item.client_cert }}"
+    client_key: "{{ item.client_key }}"
+    wait: yes
+  loop:
+    - auth: "{{ os_migrate_src_auth }}"
+      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+    - auth: "{{ os_migrate_dst_auth }}"
+      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+  tags:
+    - always
+
+- name: remove osm_image
+  os_image:
+    auth: "{{ item.auth }}"
+    name: osm_image
+    state: absent
     validate_certs: "{{ item.validate_certs }}"
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
@@ -18,20 +43,16 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
 
-- name: remove osm_server
-  os_server:
+- name: remove osm_key keypair
+  os_keypair:
     auth: "{{ item.auth }}"
-    name: osm_server
     state: absent
-    delete_fip: yes
+    name: osm_key
     validate_certs: "{{ item.validate_certs }}"
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-    wait: yes
   loop:
     - auth: "{{ os_migrate_src_auth }}"
       validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"

--- a/tests/e2e/prep.yml
+++ b/tests/e2e/prep.yml
@@ -7,6 +7,14 @@
     - always
     - test_prep
 
+- name: create os_migrate_tests_tmp_dir
+  file:
+    path: "{{ os_migrate_tests_tmp_dir }}"
+    state: directory
+  tags:
+    - always
+    - test_prep
+
 - name: create os_migrate_data_dir
   file:
     path: "{{ os_migrate_data_dir }}"

--- a/tests/e2e/run.yml
+++ b/tests/e2e/run.yml
@@ -4,7 +4,6 @@
 # might be actually a more precise way to test the real end-user
 # experience.
 
-# Network tasks
 - name: Network tasks
   block:
     - include_role:
@@ -36,7 +35,6 @@
         name: os_migrate.os_migrate.import_networks
   tags: always
 
-# Subnet tasks
 - name: Subnet tasks
   block:
     - include_role:
@@ -68,7 +66,6 @@
         name: os_migrate.os_migrate.import_subnets
   tags: always
 
-# Security group tasks
 - name: Security group tasks
   block:
     - include_role:
@@ -97,7 +94,6 @@
         name: os_migrate.os_migrate.import_security_groups
   tags: always
 
-# Security group rules tasks
 - name: Security group rules tasks
   block:
     - include_role:
@@ -126,7 +122,6 @@
         name: os_migrate.os_migrate.import_security_group_rules
   tags: always
 
-# Router tasks
 - name: Router tasks
   block:
     - include_role:
@@ -166,7 +161,33 @@
         name: os_migrate.os_migrate.import_routers
   tags: always
 
-# Workloads tasks
+- name: Image tasks
+  block:
+    - include_role:
+        name: os_migrate.os_migrate.export_images
+      vars:
+        export_images_name_filter:
+          - regex: '^osm_'
+
+    - name: load exported data
+      set_fact:
+        resources: "{{ (lookup('file',
+                               os_migrate_data_dir +
+                               '/images.yml') | from_yaml)
+                       ['resources'] }}"
+
+    - name: verify data contents
+      assert:
+        that:
+          - (resources |
+            json_query("[?params.name ==
+            'osm_image'].params.min_ram")
+            == [128])
+
+    # - include_role:
+    #     name: os_migrate.os_migrate.import_images
+  tags: always
+
 - name: Workloads tasks
   block:
     - include_role:

--- a/tests/e2e/seed.yml
+++ b/tests/e2e/seed.yml
@@ -140,6 +140,27 @@
   tags:
     - always
 
+- name: make sure test_inputs dir exists
+  file:
+    path: "{{ os_migrate_tests_tmp_dir }}/test_inputs"
+    state: directory
+
+- name: fetch cirros image
+  get_url:
+    url: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+    dest: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
+
+- name: create osm_image
+  os_image:
+    auth: "{{ os_migrate_src_auth }}"
+    name: osm_image
+    filename: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
+    container_format: bare
+    disk_format: raw
+    min_disk: 1
+    min_ram: 128
+    state: present
+
 - name: create osm_server
   os_server:
     auth: "{{ os_migrate_src_auth }}"

--- a/tests/func/clean/all.yml
+++ b/tests/func/clean/all.yml
@@ -1,3 +1,12 @@
+- name: Include image tasks
+  include_tasks: image.yml
+  args:
+    apply:
+      tags:
+        - test_image
+        - test_clean
+  tags: always
+
 - name: Include router tasks
   include_tasks: router.yml
   args:

--- a/tests/func/clean/image.yml
+++ b/tests/func/clean/image.yml
@@ -1,0 +1,8 @@
+- name: remove osm_image
+  os_image:
+    auth: "{{ item }}"
+    name: osm_image
+    state: absent
+  loop:
+    - "{{ os_migrate_src_auth }}"
+    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/global/prep.yml
+++ b/tests/func/global/prep.yml
@@ -7,6 +7,14 @@
     - always
     - test_prep
 
+- name: create os_migrate_tests_tmp_dir
+  file:
+    path: "{{ os_migrate_tests_tmp_dir }}"
+    state: directory
+  tags:
+    - always
+    - test_prep
+
 - name: create os_migrate_data_dir
   file:
     path: "{{ os_migrate_data_dir }}"

--- a/tests/func/idempotence/network.yml
+++ b/tests/func/idempotence/network.yml
@@ -6,9 +6,9 @@
     export_networks_name_filter:
       - regex: '^osm_'
 
-- name: re-load resources for idempotency test
+- name: re-load network_resources for idempotency test
   set_fact:
-    resources_idem: "{{ (lookup('file',
+    network_resources_idem: "{{ (lookup('file',
                                 os_migrate_data_dir +
                                 '/networks.yml') | from_yaml)
                         ['resources'] }}"
@@ -16,12 +16,12 @@
 - name: verify that export file did not change
   assert:
     that:
-      - resources_idem == resources
+      - network_resources_idem == network_resources
     fail_msg: |
-      resources_idem:
-      {{ resources_idem | to_nice_yaml }}
-      resources:
-      {{ resources | to_nice_yaml }}
+      network_resources_idem:
+      {{ network_resources_idem | to_nice_yaml }}
+      network_resources:
+      {{ network_resources | to_nice_yaml }}
 
 ### IMPORT IDEMPOTENCE ###
 

--- a/tests/func/run/all.yml
+++ b/tests/func/run/all.yml
@@ -45,3 +45,11 @@
       tags:
         - test_router
   tags: always
+
+- name: Include image tasks
+  include_tasks: image.yml
+  args:
+    apply:
+      tags:
+        - test_image
+  tags: always

--- a/tests/func/run/image.yml
+++ b/tests/func/run/image.yml
@@ -4,25 +4,25 @@
 # might be actually a more precise way to test the real end-user
 # experience.
 - include_role:
-    name: os_migrate.os_migrate.export_networks
+    name: os_migrate.os_migrate.export_images
   vars:
-    export_networks_name_filter:
+    export_images_name_filter:
       - regex: '^osm_'
 
 - name: load exported data
   set_fact:
-    network_resources: "{{ (lookup('file',
+    image_resources: "{{ (lookup('file',
                            os_migrate_data_dir +
-                           '/networks.yml') | from_yaml)
+                           '/images.yml') | from_yaml)
                    ['resources'] }}"
 
 - name: verify data contents
   assert:
     that:
-      - (network_resources |
+      - (image_resources |
         json_query("[?params.name ==
-        'osm_net'].params.name")
-        == ['osm_net'])
+        'osm_image'].params.min_ram")
+        == [128])
 
-- include_role:
-    name: os_migrate.os_migrate.import_networks
+# - include_role:
+#     name: os_migrate.os_migrate.import_images

--- a/tests/func/seed/all.yml
+++ b/tests/func/seed/all.yml
@@ -37,3 +37,11 @@
       tags:
         - test_router
   tags: always
+
+- name: Include image tasks
+  include_tasks: image.yml
+  args:
+    apply:
+      tags:
+        - test_image
+  tags: always

--- a/tests/func/seed/image.yml
+++ b/tests/func/seed/image.yml
@@ -1,0 +1,20 @@
+- name: make sure test_inputs dir exists
+  file:
+    path: "{{ os_migrate_tests_tmp_dir }}/test_inputs"
+    state: directory
+
+- name: fetch cirros image
+  get_url:
+    url: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+    dest: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
+
+- name: create osm_image
+  os_image:
+    auth: "{{ os_migrate_src_auth }}"
+    name: osm_image
+    filename: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
+    container_format: bare
+    disk_format: raw
+    min_disk: 1
+    min_ram: 128
+    state: present


### PR DESCRIPTION
Since Glance images contain binary data, the export is done via two
modules:

* export_image_meta -- exports image metadata (YAML file)

* export_image_blob -- exports image binary data

The export of binary data is optional. This split between metadata and
data exporting should leave us an open door towards migrating images
in a direct way between clouds (e.g. via conversion hosts) rather than
via the migrator host.