### PR TITLE
Include the fixed IP when restoring the server

### DIFF
--- a/tests/e2e/seed.yml
+++ b/tests/e2e/seed.yml
@@ -160,6 +160,10 @@
     min_disk: 1
     min_ram: 128
     state: present
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
 
 - name: create osm_server
   os_server:


### PR DESCRIPTION
The nics parameter is not documented in the upstream
docs, also there is no way in inject the MAC address,
or assign the floating IP when executing create_server

This should be fixed by creating a port and assign it
to the node before is created.