### PR TITLE
Walkthrough doc updates and formatting fixes

### DIFF
--- a/doc/user/walkthrough.md
+++ b/doc/user/walkthrough.md
@@ -1,109 +1,226 @@
-Migrating Data Between Disparate OpenStack Tenants
-==================================================
+OS Migrate Walkthrough
+======================
 
-In this post we will cover a parallel cloud migration from a Red Hat OpenStack
-Platform 13 cluster to a Red Hat OpenStack Platform 16 cluster using some tools
-put together by Red Hat engineering. The goal is to demonstrate control plane
-and workload migration between clusters.
+OS Migrate is a framework for OpenStack parallel cloud migration
+(migrating content between OpenStack tenants which are not necessarily
+in the same cloud). It’s a collection of Ansible playbooks that
+provide the basic functionality, but may not fit each use case out of
+the box. You can craft custom playbooks using the OS-Migrate
+collection pieces (roles and modules) as building blocks.
 
-This is a technology preview, so we're not recommending this for customers to
-use in production at this time. However, we like to show our work early and
-would be happy to get feedback from the OpenStack Platform users who might like
-to test this out in a non-production environment.
+Parallel cloud migration is a way to modernize an OpenStack
+deployment. Instead of upgrading an OpenStack cluster in place, a
+second OpenStack cluster is deployed alongside, and tenant content is
+migrated from the original cluster to the new one. Parallel cloud
+migration is best suited for environments which are due for a hardware
+refresh cycle. It may also be performed without a hardware refresh,
+but extra hardware resources are needed to bootstrap the new
+cluster. As hardware resources free up in the original cluster, they
+can be gradually added to the new cluster.
 
-Parallel cloud migration is a way to modernize an OpenStack Platform deployment.
-Instead of upgrading an OpenStack Platform cluster in place, a second OpenStack
-Platform cluster is deployed alongside, and tenant content is migrated from the
-original cluster to the new one. Parallel cloud migration is best suited for
-environments which are due for a hardware refresh cycle. It may also be
-performed without a hardware refresh, but extra hardware resources are needed to
-bootstrap the new cluster. As hardware resources free up in the original
-cluster, they can be gradually added to the new cluster.
+OS-Migrate strictly uses the official OpenStack API and does not
+utilize direct database access or other methods to export or import
+data. The Ansible playbooks contained in OS-Migrate are idempotent. If
+a command fails, you can retry with the same command.
 
 ![OSP-OSP Migration Overview](https://raw.githubusercontent.com/os-migrate/os-migrate/main/media/walkthrough/2020-06-24-osp-migrate-fig1.png?sanitize=true)
 
-[OS-Migrate](https://github.com/os-migrate/os-migrate) is an open source project that provides a framework for exporting and
-importing resources between two clouds. It’s a collection of Ansible playbooks
-that provide the basic functionality, but may not fit each use case out of the
-box. You can craft custom playbooks using the OS-Migrate collection pieces
-(roles and modules) as building blocks.
+The migration is generally performed in this sequence:
 
-OS-Migrate strictly uses the official OpenStack API and does not utilize direct
-database access or other methods to export or import data. The Ansible playbooks
-contained in OS-Migrate are idempotent. If a command fails, you can retry with
-the same command.
+* prerequisites: authentication, parameter files,
 
-Pre-workload Migration
-----------------------
+* pre-workload migration, which copies applicable resources into the
+  destination cloud (e.g. networks, security groups, images) while
+  workloads keep running in the source cloud,
 
-Workloads require the support of several resources in a given cloud to operate
-properly. Some of these resources include networks, subnets, routers, router
-interfaces, security groups, and security group rules. The pre-workload
-migration process includes exporting these resources from a source cloud to a
-destination cloud.
+* workload migration, which stops usage of applicable resources in the
+  source cloud and moves them into the destination cloud (VMs,
+  volumes).
 
-Exporting or importing resources is enabled by running the corresponding
-playbook from os-migrate.  Let's look at a concrete example.  To export the
-networks run the "export_networks" playbook and a YAML file is created.  
+Prerequisites
+-------------
 
-```commandline
-# export OS_MIGRATE=/home/migrator/.ansible/collections/ansible_collections/os_migrate/os_migrate
-# ansible-playbook -i $OS_MIGRATE/localhost_inventory.yml -e @os-migrate-vars.yml $OS_MIGRATE/playbooks/export_networks.yml
+### Authentication
+
+Users are encouraged to use os-migrate using specific credentials for
+each project/tenant, this means not using the admin user to execute the
+resources migration.
+In the case that a user is required to use the admin credentials
+this `admin` user needs to have access to the tenant resources, otherwise
+you will hit an error similar to the following:
+
 ```
+keystoneauth1.exceptions.http.Unauthorized: The request you have made requires authentication. (HTTP 401)
+```
+
+To pass this error there are some options.
+
+* Add the `admin` user as a `_member_` of each project.
+
+Depending on how many projects need to be migrated this approach
+seems to be suboptimal as there are involved several configuration
+updates in the projects that will need to be reverted after the
+migration completes.
+
+* Create a group including the admin user and add the group to each project as member.
+
+The difference with this approach is that once the migration is completed, by
+removing the group, all the references in all the projects will be removed automatically.
+
+### Parameter file
+
+Let's create an `os-migrate-vars.yml` file with Ansible variables:
 
 ```yaml
-os_migrate_version: 0.0.2
+os_migrate_src_auth:
+  auth_url: http://192.168.0.13.199/v3
+  password: srcpassword
+  project_domain_name: Default
+  project_name: src
+  user_domain_name: Default
+  username: src
+os_migrate_src_region_name: regionOne
+os_migrate_dst_auth:
+  auth_url: http://192.167.0.16:5000/v3
+  password: dstpassword
+  project_domain_name: Default
+  project_name: dst
+  user_domain_name: Default
+  username: dst
+os_migrate_dst_region_name: regionOne
+
+os_migrate_data_dir: /home/migrator/os-migrate-data
+```
+
+The file contains the source and destination tenant credentials, a
+directory on the migrator host (typically localhost) and a directory
+where the exported data will be saved. There can also
+
+#### A note about Keystone v2
+
+As depicted in content of the previously defined `os-migrate-vars.yml`
+file, the parameters `os_migrate_src_auth` and `os_migrate_dst_auth`
+refer to the usage of Keystone v3. In the case of a user needing to
+execute a migration between tenants not supporting Keystone v3 the
+following error will be raised:
+
+```
+keystoneauth1.exceptions.discovery.DiscoveryFailure: Cannot use v2 authentication with domain scope
+```
+
+To fix this issue, the user must adjust their auth parameters in this way:
+
+```yaml
+os_migrate_src_auth:
+  auth_url: http://192.168.0.13.199/v2.0
+  password: srcpassword
+  project_name: src
+  username: src
+os_migrate_src_region_name: regionOne
+```
+
+Notice that the parameters `project_domain_id` and `user_domain_id` do not
+exist and the `auth_url` parameter points to the Keystone v2 endpoint.
+
+### Shortcuts
+
+We will use the OS Migrate collection path and an ansible-playbook
+command with the following arguments routinely, so let's save them as
+variables in the shell:
+
+```bash
+export OSM_DIR=/home/migrator/.ansible/collections/ansible_collections/os_migrate/os_migrate
+export OSM_CMD="ansible-playbook -v -i $OSM_DIR/localhost_inventory.yml -e @os-migrate-vars.yml"
+```
+
+Pre-workload migration
+----------------------
+
+Workloads require the support of several resources in a given cloud to
+operate properly. Some of these resources include networks, subnets,
+routers, router interfaces, security groups, and security group
+rules. The pre-workload migration process includes exporting these
+resources from the source cloud onto the migrator machine, the option
+to edit the resources if desired, and importing them into the
+destination cloud.
+
+Exporting or importing resources is enabled by running the
+corresponding playbook from OS Migrate. Let's look at a concrete
+example. To export the networks, run the "export_networks" playbook.
+
+### Export and import
+
+To export the networks:
+
+```bash
+$OSM_CMD $OSM_DIR/playbooks/export_networks.yml
+```
+
+This will create networks.yml file in the data directory, similar to this:
+
+```yaml
+os_migrate_version: 0.4.0
 resources:
-- _info:
-availability_zones:
-- nova
-created_at: '2020-04-07T14:08:30Z'
-id: a1eb31f6-2cdc-4896-b582-8950dafa34aa
-project_id: 2f444c71265048f7a9d21f81db6f21a4
-qos_policy_id: null
-revision_number: 3
-status: ACTIVE
-subnet_ids:
-- a5052e10-5e00-432b-a826-29695677aca0
-- d450ffd0-972e-4398-ab49-6ba9e29e2499
-updated_at: '2020-04-07T14:08:34Z'
-  params:
-availability_zone_hints: []
-description: ''
-dns_domain: null
-is_admin_state_up: true
-is_default: null
-is_port_security_enabled: true
-is_router_external: false
-is_shared: false
-is_vlan_transparent: null
-mtu: 1450
-name: osm_net
-provider_network_type: null
-provider_physical_network: null
-provider_segmentation_id: null
-qos_policy_name: null
-segments: null
-  type: openstack.network.Network
+  - _info:
+      availability_zones:
+        - nova
+      created_at: '2020-04-07T14:08:30Z'
+      id: a1eb31f6-2cdc-4896-b582-8950dafa34aa
+      project_id: 2f444c71265048f7a9d21f81db6f21a4
+      qos_policy_id: null
+      revision_number: 3
+      status: ACTIVE
+      subnet_ids:
+        - a5052e10-5e00-432b-a826-29695677aca0
+        - d450ffd0-972e-4398-ab49-6ba9e29e2499
+      updated_at: '2020-04-07T14:08:34Z'
+    params:
+      availability_zone_hints: []
+      description: ''
+      dns_domain: null
+      is_admin_state_up: true
+      is_default: null
+      is_port_security_enabled: true
+      is_router_external: false
+      is_shared: false
+      is_vlan_transparent: null
+      mtu: 1450
+      name: osm_net
+      provider_network_type: null
+      provider_physical_network: null
+      provider_segmentation_id: null
+      qos_policy_name: null
+      segments: null
+    type: openstack.network.Network
 ```
 
-You may edit the file as needed and then run the "import_networks" playbook to
-import the networks from this file into the destination cloud.
+You may edit the file as needed and then run the "import_networks"
+playbook to import the networks from this file into the destination
+cloud:
 
-```commandline
-# ansible-playbook -i $OS_MIGRATE/localhost_inventory.yml -e @os-migrate-vars.yml $OS_MIGRATE/playbooks/import_networks.yml
+```bash
+$OSM_CMD $OSM_DIR/playbooks/import_networks.yml
 ```
 
-You can repeat this process for routers, router interfaces, security groups,
-security group rules, and subnets.
+You can repeat this process for other resources like subnets, security
+groups, security group rules, routers, router interfaces, images and
+keypairs.
+
+For a full list of available playbooks, run:
+
+```bash
+ls $OSM_DIR/playbooks
+```
 
 ![Pre-workload Migration (data flow)](https://raw.githubusercontent.com/os-migrate/os-migrate/main/media/walkthrough/2020-06-24-osp-migrate-fig2.png?raw=true)
 
 ![Pre-workload Migration (workflow)](https://raw.githubusercontent.com/os-migrate/os-migrate/main/media/walkthrough/2020-06-24-osp-migrate-fig3.png?raw=true)
 
+Pre-workload migration recorded demo:
+
 [![Watch the video](https://img.youtube.com/vi/e7KXy5Hq4CM/maxresdefault.jpg)](https://youtu.be/e7KXy5Hq4CMA)
 
-Workload Migration
+Workload migration
 ------------------
 
 Workload information is exported in a similar method to networks, security
@@ -111,7 +228,7 @@ groups, etc. as in the previous sections. Run the "export_workloads" playbook,
 and edit the resulting workloads.yml as desired:
 
 ```yaml
-os_migrate_version: 0.0.1
+os_migrate_version: 0.4.0
 resources:
 - _info:
     addresses:
@@ -134,29 +251,25 @@ resources:
 
 Note that this playbook only extracts metadata about instances in the specified
 tenant - it does not download OpenStack volumes directly to the migration data
-directory! Data transfer is handled by the import_workloads playbook, and it is
+directory. Data transfer is handled by the import_workloads playbook, and it is
 a fairly involved process to create an environment where this playbook will run
 successfully. The next few sections detail the process and some of the rationale
 for various design choices.
 
-Process Summary
----------------
+### Process summary
 
 This flowchart illustrates the high-level migration workflow, from a user’s
 point of view:
 
 ![alt text](https://raw.githubusercontent.com/os-migrate/os-migrate/main/media/walkthrough/2020-06-24-osp-migrate-fig4.png?raw=true)
 
-The process involves the deployment of a "Universal Conversion Host" on source
-and destination clouds. A UCH is an OpenStack instance booted from the
-"Universal Conversion Image" provided by ManageIQ
-[here](https://releases.manageiq.org/v2v-conversion-host-appliance-devel.qc2).
-This image contains the tools needed for exporting and converting virtual
-machines from various virtualization platforms. The official release for this
-appliance has not been finalized, but the final process will work the same way.
+The process involves the deployment of a "conversion host" on source
+and destination clouds. A conversion host is an OpenStack instance
+which will be used to transfer binary volume data from the source to
+the destination cloud. Currently, CentOS 8 is expected to be the image
+from which conversion hosts are created.
 
 The following diagram helps explain the need for a conversion host VM:
-
 
 ![Workload migration (data flow)](https://raw.githubusercontent.com/os-migrate/os-migrate/main/media/walkthrough/2020-06-24-osp-migrate-fig5.png?raw=true)
 
@@ -168,223 +281,86 @@ destination clouds:
 
 Source Cloud:
 
-    - Detach volumes from the target instance to migrate
+* Detach volumes from the target instance to migrate
 
-    - Attach the volumes to the source conversion host
+* Attach the volumes to the source conversion host
 
-    - Export the volumes as block devices and wait for destination conversion
-      host to connect
+* Export the volumes as block devices and wait for destination conversion
+  host to connect
 
 Destination Cloud:
 
-    - Create new volumes on the destination conversion host, one for each source
-      volume
+* Create new volumes on the destination conversion host, one for each source
+  volume
 
-    - Attach the new volumes to the destination conversion host
+* Attach the new volumes to the destination conversion host
 
-    - Connect to the block devices exported by source conversion host, and copy
-      the data to the new attached volumes
+* Connect to the block devices exported by source conversion host, and copy
+  the data to the new attached volumes
 
-    - Detach the volumes from the destination conversion host
+* Detach the volumes from the destination conversion host
 
-    - Create a new instance using the new volumes
+* Create a new instance using the new volumes
 
 This method keeps broad compatibility with the various flavors and
 configurations of OpenStack using as much of an API-only approach as possible,
 while allowing the use of libguestfs-based tooling to minimize total data
 transfer.
 
-Preparation
------------
+### Preparation
 
-Before beginning, there are a number of things to gather or validate to help
-guide a successful migration:
-
-    - Verify the configuration of basic OpenStack services. The migration
-      tooling makes use of glance, cinder, nova, keystone, and neutron. Most
-      other services (e.g. Swift) are not currently required.
-
-    - Verify credentials for the tenant containing the workloads to migrate in
-      the source OpenStack cloud and the tenant to receive the workloads in the
-      destination OpenStack cloud. Migration does not require administrative
-      credentials in either of these tenants.
-
-     - Make sure networking and security groups are configured to allow external
-       SSH access to instances in the source and destination tenants - the
-       destination conversion host will run SSH commands on the source
-       conversion host.
-
-    - Shut down the instances that are going to be migrated. Currently this 
-      OpenStack to OpenStack migration solution only supports cold migration.
-
-    - Verify quotas on both source and destination clouds:
-    
-        - The source cloud will need at least one instance slot available for
-          the conversion host, and one available volume and one available
-          snapshot to migrate volume-based instances. This is because in order
-          to migrate boot volumes that cannot be detached, a volume snapshot of
-          a VM's boot disk will be taken and a new volume will be created from
-          that volume snapshot. This new volume will be attached to the source
-          conversion host for export, and should be removed along with the
-          snapshot after the process completes.
-
-        - For instances started directly from an image, the source tenant will
-          need to be able to create one server image and one volume from that
-          image. In this case, a new server image snapshot is created from the
-          instance, and a new volume is created from that image.
-
-        - The destination cloud will need one instance slot reserved for the
-          conversion host, and one volume for every volume attached to the
-          instances coming in from the source cloud. Image-based instances on
-          the source cloud will be converted to volume-based instances on the
-          destination, so allocate one extra volume for every such instance.
-    
-    - Configure SSH keys. It is recommended to create a new SSH key for
-      migration purposes. This key will need to be authorized on the source
-      and destination conversion hosts, and it will need to be provided to the
-      ansible playbook orchestrating the migration. This step is required
-      because the ansible playbook needs password-less SSH access to the
-      destination conversion host, and the destination conversion host needs
-      password-less SSH access to the source conversion host. The examples
-      assume that a new SSH key has been generated and placed in the os_migrate
-      ansible data directory on the migrator workstation.
-    
-    - Install conversion host instances on the source and destination clouds:
-    
-        - Obtain a Universal Conversion Image[1] and upload it to the source and
-          destination tenants, alongside the VMs that are going to be migrated.
-          Launch this image as a new instance in the source and destination
-          tenants using the SSH key from the previous step, and verify external
-          network access.
-
-        - Obtain the VMware vSphere Virtual Disk Development Kit[2]. This is not
-          actually used for an OpenStack-to-OpenStack migration, but the
-          underlying virt-v2v-wrapper tool may check for its existence depending
-          on the version of the conversion host appliance. This kit is not
-          redistributable and therefore must be installed manually to /opt on
-          the source and destination conversion host instances, for example:
-
-```commandline
-# scp -i migration.key VMware-vix-disklib-6.5.2-6195444.x86_64.tar.gz cloud-user@192.168.55.30:/home/cloud-user
-VMware-vix-disklib-6.5.2-6195444.x86_64.tar.gz                                    100%   19MB  41.2MB/s   00:00
-# ssh -i migration.key cloud-user@192.168.55.30 sudo tar -xf /home/cloud-user/VMware-vix-disklib-6.5.2-6195444.x86_64.tar.gz -C /opt
-```
-
-- [[1] Universal Conversion Image](https://releases.manageiq.org/v2v-conversion-host-appliance-devel.qc2)
-- [[2] VMware vSphere Virtual Disk Development Kit](https://my.vmware.com/web/vmware/details?downloadGroup=VDDK652&productId=614)
-
-Authentication
---------------
-
-Users are encouraged to use os-migrate using specific credentials for
-each project/tenant, this means not using the admin user to execute the
-resources migration.
-In the case that a user is required to use the admin credentials
-this `admin` user needs to have access to the tenant resources, otherwise
-you will hit an error similar to the following:
-
-```bash
-keystoneauth1.exceptions.http.Unauthorized: The request you have made requires authentication. (HTTP 401)
-```
-
-To pass this error there are some options.
-
-* Add the `admin` user as a `_member_` of each project.
-
-Depending on how many projects need to be migrated this approach
-seems to be suboptimal as there are involved several configuration
-updates in the projects that will need to be reverted after the
-migration completes.
-
-* Create a group including the admin user and add the group to each project as member.
-
-The difference with this approach is that once the migration is completed, by
-removing the group, all the references in all the projects will be removed automatically.
-
-Migration
----------
-
-To actually perform the migration, configure the os_migrate ansible variables to
-include information about source and target clouds, and about the conversion
-hosts on each one. For example:
+We'll put additional parameters into `os-migrate-vars.yml`:
 
 ```yaml
-# cat os-migrate-vars.yml
-os_migrate_data_dir: /home/migrator/os-migrate-data
-os_migrate_conversion_host_key: /home/migrator/os-migrate-data/migrate.key
-os_migrate_src_filters: {}
-
-os_migrate_src_auth:
-        auth_url: https://192.168.55.53:13000/v3
-        username: migration-source-user
-        password: migrate
-        project_domain_id: default
-        project_name: migration-source-project
-        user_domain_id: default
-os_migrate_src_validate_certs: False
-os_migrate_src_conversion_host: source-conversion-host
-
-os_migrate_dst_auth:
-        auth_url: https://192.168.55.54:13000/v3
-        username: migration-destination-user
-        password: migrate
-        project_domain_id: default
-        project_name: migration-destination-project
-        user_domain_id: default
-os_migrate_dst_validate_certs: False
-os_migrate_dst_conversion_host: destination-conversion-host
+os_migrate_conversion_external_network_name: public
+os_migrate_conversion_flavor_name: m1.large
 ```
 
-As depicted in content of the previously defined `os-migrate-vars.yml` file.
-The parameters `os_migrate_src_auth` and `os_migrate_dst_auth` refer to the
-usage of Keystone v3. In the case of a user needing to execute a migration
-between tenants not supporting Keystone v3 the following error will raise.
+These define the flavor and external network we want to use for our
+conversion hosts.
+
+By default the migration will use an image named `os_migrate_conv` for
+conversion hosts. Make sure this image exists in Glance on both
+clouds. Currently it should be a
+[CentOS 8 cloud image](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2).
+
+### Conversion host deployment
+
+The conversion host deployment playbook creates the instances,
+installs additional required packages, and authorizes the destination
+conversion host to connect to the source conversion host for the
+actual data transfer.
 
 ```bash
-keystoneauth1.exceptions.discovery.DiscoveryFailure: Cannot use v2 authentication with domain scope
+$OSM_CMD $OSM_DIR/deploy_conversion_hosts.yml
 ```
 
-To fix this issue, the user must adjust their clouds.yaml file before executing the
-`auth-from-clouds.sh` script to something similar to the following auth code.
+### Migration
 
-```yaml
-clouds:
-  src10:
-    auth:
-      auth_url: http://192.168.55.53:5000/v2.0
-      password: migrate
-      project_name: src
-      username: migration-source-user
-    region_name: regionOne
-    verify: False
-```
-
-Notice that the parameters `project_domain_id` and `user_domain_id` do not
-exist and the `auth_url` parameter points to the Keystone v2 endpoint.
+Before migrating workloads, the destination cloud must have imported
+all other resources (networks, security groups, etc.) or the migration
+will fail. Matching named resources (including flavor names) must
+exist on the destination before the instances are created.
 
 If not already exported, export workload information with the export_workloads
 playbook. Each instance listed in the resulting workloads.yml will be migrated,
 except for the one matching the name given to the source conversion host
-instance. Note: before migrating workloads, the destination cloud must have
-imported all other resources (networks, security groups, etc.) or the migration
-will fail! Matching named resources (including flavor names) must exist on the
-destination before the instances are created.
+instance.
 
-```commandline
-# export OS_MIGRATE=/home/migrator/.ansible/collections/ansible_collections/os_migrate/os_migrate
-# ansible-playbook -i $OS_MIGRATE/localhost_inventory.yml -e @os-migrate-vars.yml $OS_MIGRATE/playbooks/export_workloads.yml
+```bash
+$OSM_CMD $OSM_DIR/playbooks/export_workloads.yml
 ```
 
-Finally, run the import_workloads playbook:
+Then run the import_workloads playbook:
 
-```commandline
-# ansible-playbook -i $OS_MIGRATE/localhost_inventory.yml -e @os-migrate-vars.yml $OS_MIGRATE/playbooks/import_workloads.yml
+```bash
+$OSM_CMD $OSM_DIR/playbooks/import_workloads.yml
 ```
 
 After a few minutes, results should start showing up looking something like
 this:
 
-```commandline
+```
 PLAY [migrator] ********************************************************************************************************************
 
 TASK [Gathering Facts] ********************************************************************************************************************
@@ -431,21 +407,11 @@ name or ID of the specified conversion host. If there is already an instance on
 the destination matching the name of the current instance, it will be marked
 "ok" and no extra work will be performed:
 
-```commandline
+```
 TASK [import_workloads : import workloads] ******************************************************************************************************************
 ok: [localhost] => (item={'_info': {'addresses': {'external_network': [{'OS-EXT-IPS-MAC:mac_addr': 'fa:16:3e:98:19:a0', 'OS-EXT-IPS:type': 'fixed', 'addr': '10.19.2.41', 'version': 4}]}, 'flavor_id': 'a96b2815-3525-4eea-9ab4-14ba58e17835', 'id': '0025f062-f684-4e02-9da2-3219e011ec74', 'status': 'SHUTOFF'}, 'params': {'flavor_name': 'm1.small', 'name': 'migration-vm', 'security_group_names': ['testing123', 'default']}, 'type': 'openstack.compute.Server'})
 ```
 
-Current in-flight work includes better transfer progress tracking and removal of
-the VDDK requirement.
-
-Status and final thoughts
--------------------------
-
-As we mentioned, this is a technology preview and not ready for production use.
-But we hope to make this available in the future for customers looking to ease
-the upgrade path between LTS releases of Red Hat OpenStack Platform. Keep
-watching the Red Hat Blog for updates and more about our work on OpenStack
-Platform.
+Workload migration recorded demo:
 
 [![Watch the video](https://img.youtube.com/vi/gEKvgIZqrQY/maxresdefault.jpg)](https://youtu.be/gEKvgIZqrQY)


### PR DESCRIPTION
This makes walkthrough doc up to date and generally into a better
shape. Some notable changes:

* Prerequisites section regarding authentication and parameters which
  are used for both pre-workload and workload migration is
  consolidated and moved at the beginning of the doc.

* Nesting of headlines is fixed.

* Removed mentions RH OSP.

* Updated conversion host deployment to use the playbook instead of
  manual wiring instructions.

* Updated the workload migration process to the new one which runs on
  plain CentOS and doesn't require VDDK.

* Command shortcuts.