### PR TITLE
Allow setting conversion subnet DNS separately for src/dst

### DIFF
--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -3,7 +3,6 @@
     - include_role:
         name: os_migrate.os_migrate.conversion_host
       vars:
-        os_migrate_conversion_net_mtu: "{{ os_migrate_src_conversion_net_mtu|default(omit) }}"
         os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
         os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
         os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -16,12 +15,14 @@
         os_migrate_conversion_image_name: "{{ os_migrate_src_conversion_image_name|default(omit) }}"
         os_migrate_conversion_external_network_name:
           "{{ os_migrate_src_conversion_external_network_name }}"
+        os_migrate_conversion_net_mtu: "{{ os_migrate_src_conversion_net_mtu|default(omit) }}"
+        os_migrate_conversion_subnet_dns_nameservers:
+          "{{ os_migrate_src_conversion_subnet_dns_nameservers|default(omit) }}"
       when: os_migrate_deploy_src_conversion_host|default(true)|bool
 
     - include_role:
         name: os_migrate.os_migrate.conversion_host
       vars:
-        os_migrate_conversion_net_mtu: "{{ os_migrate_dst_conversion_net_mtu|default(omit) }}"
         os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
         os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
         os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -34,6 +35,9 @@
         os_migrate_conversion_image_name: "{{ os_migrate_dst_conversion_image_name|default(omit) }}"
         os_migrate_conversion_external_network_name:
           "{{ os_migrate_dst_conversion_external_network_name }}"
+        os_migrate_conversion_net_mtu: "{{ os_migrate_dst_conversion_net_mtu|default(omit) }}"
+        os_migrate_conversion_subnet_dns_nameservers:
+          "{{ os_migrate_dst_conversion_subnet_dns_nameservers|default(omit) }}"
       when: os_migrate_deploy_dst_conversion_host|default(true)|bool
 
     - include_role:

--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -11,12 +11,14 @@ os_migrate_dst_conversion_net_mtu: "{{
   1400 if os_migrate_dst_release > 10
   else omit }}"
 
+# If we install packages we need a DNS server working
+os_migrate_src_conversion_subnet_dns_nameservers: ['8.8.8.8']
+os_migrate_dst_conversion_subnet_dns_nameservers: ['8.8.8.8']
+
 os_migrate_conversion_subnet_name: os_migrate_conv
 os_migrate_conversion_subnet_cidr: 192.168.10.0/24
 os_migrate_conversion_subnet_alloc_start: 192.168.10.10
 os_migrate_conversion_subnet_alloc_end: 192.168.10.99
-# If we install packages we need a DNS server working
-os_migrate_conversion_subnet_dns_nameservers: ['8.8.8.8']
 
 os_migrate_conversion_router_name: os_migrate_conv
 os_migrate_conversion_router_ip: 192.168.10.1


### PR DESCRIPTION
DNS nameservers is a parameter for conversion subnet where it makes
sense to allow different values between src/dst clouds.