### PR TITLE
Prefix and shorten export variable names

### DIFF
--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -3,7 +3,6 @@
     - include_role:
         name: os_migrate.os_migrate.conversion_host
       vars:
-        os_migrate_conversion_net_mtu: "{{ os_migrate_src_conversion_net_mtu|default(omit) }}"
         os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
         os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
         os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -16,12 +15,14 @@
         os_migrate_conversion_image_name: "{{ os_migrate_src_conversion_image_name|default(omit) }}"
         os_migrate_conversion_external_network_name:
           "{{ os_migrate_src_conversion_external_network_name }}"
+        os_migrate_conversion_net_mtu: "{{ os_migrate_src_conversion_net_mtu|default(omit) }}"
+        os_migrate_conversion_subnet_dns_nameservers:
+          "{{ os_migrate_src_conversion_subnet_dns_nameservers|default(omit) }}"
       when: os_migrate_deploy_src_conversion_host|default(true)|bool
 
     - include_role:
         name: os_migrate.os_migrate.conversion_host
       vars:
-        os_migrate_conversion_net_mtu: "{{ os_migrate_dst_conversion_net_mtu|default(omit) }}"
         os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
         os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
         os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -34,6 +35,9 @@
         os_migrate_conversion_image_name: "{{ os_migrate_dst_conversion_image_name|default(omit) }}"
         os_migrate_conversion_external_network_name:
           "{{ os_migrate_dst_conversion_external_network_name }}"
+        os_migrate_conversion_net_mtu: "{{ os_migrate_dst_conversion_net_mtu|default(omit) }}"
+        os_migrate_conversion_subnet_dns_nameservers:
+          "{{ os_migrate_dst_conversion_subnet_dns_nameservers|default(omit) }}"
       when: os_migrate_deploy_dst_conversion_host|default(true)|bool
 
     - include_role:

--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -11,12 +11,14 @@ os_migrate_dst_conversion_net_mtu: "{{
   1400 if os_migrate_dst_release > 10
   else omit }}"
 
+# If we install packages we need a DNS server working
+os_migrate_src_conversion_subnet_dns_nameservers: ['8.8.8.8']
+os_migrate_dst_conversion_subnet_dns_nameservers: ['8.8.8.8']
+
 os_migrate_conversion_subnet_name: os_migrate_conv
 os_migrate_conversion_subnet_cidr: 192.168.10.0/24
 os_migrate_conversion_subnet_alloc_start: 192.168.10.10
 os_migrate_conversion_subnet_alloc_end: 192.168.10.99
-# If we install packages we need a DNS server working
-os_migrate_conversion_subnet_dns_nameservers: ['8.8.8.8']
 
 os_migrate_conversion_router_name: os_migrate_conv
 os_migrate_conversion_router_ip: 192.168.10.1

--- a/os_migrate/roles/export_flavors/defaults/main.yml
+++ b/os_migrate/roles/export_flavors/defaults/main.yml
@@ -1,2 +1,2 @@
-export_flavors_name_filter:
+os_migrate_flavors_filter:
   - regex: .*

--- a/os_migrate/roles/export_flavors/tasks/main.yml
+++ b/os_migrate/roles/export_flavors/tasks/main.yml
@@ -20,7 +20,7 @@
   set_fact:
     export_flavors_ids_names: "{{ (
       export_flavors_ids_names
-        | os_migrate.os_migrate.stringfilter(export_flavors_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_flavors_filter,
                                              attribute='name') ) }}"
 
 - name: export flavor

--- a/os_migrate/roles/export_images/defaults/main.yml
+++ b/os_migrate/roles/export_images/defaults/main.yml
@@ -1,4 +1,4 @@
-export_images_blobs: true
-export_images_name_filter:
+os_migrate_export_images_blobs: true
+os_migrate_images_filter:
   - regex: .*
 os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"

--- a/os_migrate/roles/export_images/tasks/main.yml
+++ b/os_migrate/roles/export_images/tasks/main.yml
@@ -32,7 +32,7 @@
   set_fact:
     export_images_ids_names: "{{ (
       export_images_ids_names
-        | os_migrate.os_migrate.stringfilter(export_images_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_images_filter,
                                              attribute='name') ) }}"
 
 - name: export image metadata
@@ -52,7 +52,7 @@
   file:
     path: "{{ os_migrate_image_blobs_dir }}"
     state: directory
-  when: export_images_blobs
+  when: os_migrate_export_images_blobs
 
 - name: export image blobs
   os_migrate.os_migrate.export_image_blob:
@@ -66,4 +66,4 @@
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
   loop: "{{ export_images_ids_names }}"
-  when: export_images_blobs
+  when: os_migrate_export_images_blobs

--- a/os_migrate/roles/export_keypairs/defaults/main.yml
+++ b/os_migrate/roles/export_keypairs/defaults/main.yml
@@ -1,2 +1,2 @@
-export_keypairs_name_filter:
+os_migrate_keypairs_filter:
   - regex: .*

--- a/os_migrate/roles/export_keypairs/tasks/main.yml
+++ b/os_migrate/roles/export_keypairs/tasks/main.yml
@@ -20,7 +20,7 @@
   set_fact:
     export_keypairs_ids_names: "{{ (
       export_keypairs_ids_names
-        | os_migrate.os_migrate.stringfilter(export_keypairs_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_keypairs_filter,
                                              attribute='name') ) }}"
 
 - name: export keypair

--- a/os_migrate/roles/export_networks/defaults/main.yml
+++ b/os_migrate/roles/export_networks/defaults/main.yml
@@ -1,2 +1,2 @@
-export_networks_name_filter:
+os_migrate_networks_filter:
   - regex: .*

--- a/os_migrate/roles/export_networks/tasks/main.yml
+++ b/os_migrate/roles/export_networks/tasks/main.yml
@@ -21,7 +21,7 @@
   set_fact:
     export_networks_ids_names: "{{ (
       export_networks_ids_names
-        | os_migrate.os_migrate.stringfilter(export_networks_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_networks_filter,
                                              attribute='name') ) }}"
 
 - name: export network

--- a/os_migrate/roles/export_router_interfaces/defaults/main.yml
+++ b/os_migrate/roles/export_router_interfaces/defaults/main.yml
@@ -1,2 +1,2 @@
-export_routers_name_filter:
+os_migrate_routers_filter:
   - regex: .*

--- a/os_migrate/roles/export_router_interfaces/tasks/main.yml
+++ b/os_migrate/roles/export_router_interfaces/tasks/main.yml
@@ -21,7 +21,7 @@
   set_fact:
     export_routers_ids_names: "{{ (
       export_routers_ids_names
-        | os_migrate.os_migrate.stringfilter(export_routers_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,
                                              attribute='name') ) }}"
 
 - name: export router interfaces

--- a/os_migrate/roles/export_routers/defaults/main.yml
+++ b/os_migrate/roles/export_routers/defaults/main.yml
@@ -1,2 +1,2 @@
-export_routers_name_filter:
+os_migrate_routers_filter:
   - regex: .*

--- a/os_migrate/roles/export_routers/tasks/main.yml
+++ b/os_migrate/roles/export_routers/tasks/main.yml
@@ -21,7 +21,7 @@
   set_fact:
     export_routers_ids_names: "{{ (
       export_routers_ids_names
-        | os_migrate.os_migrate.stringfilter(export_routers_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,
                                              attribute='name') ) }}"
 
 - name: export router

--- a/os_migrate/roles/export_security_group_rules/defaults/main.yml
+++ b/os_migrate/roles/export_security_group_rules/defaults/main.yml
@@ -1,2 +1,2 @@
-export_security_groups_name_filter:
+os_migrate_security_groups_filter:
   - regex: .*

--- a/os_migrate/roles/export_security_group_rules/tasks/main.yml
+++ b/os_migrate/roles/export_security_group_rules/tasks/main.yml
@@ -21,7 +21,7 @@
   set_fact:
     export_security_groups_ids_names: "{{ (
       export_security_groups_ids_names
-        | os_migrate.os_migrate.stringfilter(export_security_groups_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,
                                              attribute='name') ) }}"
 
 # In this case we will export all the security groups

--- a/os_migrate/roles/export_security_groups/defaults/main.yml
+++ b/os_migrate/roles/export_security_groups/defaults/main.yml
@@ -1,2 +1,2 @@
-export_security_groups_name_filter:
+os_migrate_security_groups_filter:
   - regex: .*

--- a/os_migrate/roles/export_security_groups/tasks/main.yml
+++ b/os_migrate/roles/export_security_groups/tasks/main.yml
@@ -21,7 +21,7 @@
   set_fact:
     export_security_groups_ids_names: "{{ (
       export_security_groups_ids_names
-        | os_migrate.os_migrate.stringfilter(export_security_groups_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,
                                              attribute='name') ) }}"
 
 - name: export security groups

--- a/os_migrate/roles/export_subnets/defaults/main.yml
+++ b/os_migrate/roles/export_subnets/defaults/main.yml
@@ -1,2 +1,2 @@
-export_subnets_name_filter:
+os_migrate_subnets_filter:
   - regex: .*

--- a/os_migrate/roles/export_subnets/tasks/main.yml
+++ b/os_migrate/roles/export_subnets/tasks/main.yml
@@ -21,7 +21,7 @@
   set_fact:
     export_subnets_ids_names: "{{ (
       export_subnets_ids_names
-        | os_migrate.os_migrate.stringfilter(export_subnets_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_subnets_filter,
                                              attribute='name') ) }}"
 
 - name: export subnet

--- a/os_migrate/roles/export_workloads/defaults/main.yml
+++ b/os_migrate/roles/export_workloads/defaults/main.yml
@@ -1,2 +1,2 @@
-export_workloads_name_filter:
+os_migrate_workloads_filter:
   - regex: .*

--- a/os_migrate/roles/export_workloads/tasks/main.yml
+++ b/os_migrate/roles/export_workloads/tasks/main.yml
@@ -24,7 +24,7 @@
   set_fact:
     export_workloads_ids_names: "{{ (
       export_workloads_ids_names
-        | os_migrate.os_migrate.stringfilter(export_workloads_name_filter,
+        | os_migrate.os_migrate.stringfilter(os_migrate_workloads_filter,
                                              attribute='name') ) }}"
 
 - name: export workload

--- a/tests/e2e/run.yml
+++ b/tests/e2e/run.yml
@@ -13,7 +13,7 @@
         # skipping the universal conversion host (osm_uch)
         # which is used to move the VM's.
         # We create it on in seed.yml but we dont export it.
-        export_networks_name_filter:
+        os_migrate_networks_filter:
           - regex: '^osm_(?!uch)'
 
     - name: load exported data
@@ -44,7 +44,7 @@
         # skipping the universal conversion host (osm_uch)
         # which is used to move the VM's.
         # We create it on in seed.yml but we dont export it.
-        export_subnets_name_filter:
+        os_migrate_subnets_filter:
           - regex: '^osm_(?!uch)'
 
     - name: load exported data
@@ -71,7 +71,7 @@
     - include_role:
         name: os_migrate.os_migrate.export_security_groups
       vars:
-        export_security_groups_name_filter:
+        os_migrate_security_groups_filter:
           - regex: '^osm_'
 
     - name: load exported data
@@ -99,7 +99,7 @@
     - include_role:
         name: os_migrate.os_migrate.export_security_group_rules
       vars:
-        export_security_groups_name_filter:
+        os_migrate_security_groups_filter:
           - regex: '^osm_'
 
     - name: load exported data
@@ -131,7 +131,7 @@
         # skipping the universal conversion host (osm_uch)
         # which is used to move the VM's.
         # We create it on in seed.yml but we dont export it.
-        export_routers_name_filter:
+        os_migrate_routers_filter:
           - regex: '^osm_(?!uch)'
 
     - name: load exported data
@@ -166,7 +166,7 @@
     - include_role:
         name: os_migrate.os_migrate.export_images
       vars:
-        export_images_name_filter:
+        os_migrate_images_filter:
           - regex: '^osm_'
 
     - name: load exported data
@@ -197,7 +197,7 @@
         # skipping the universal conversion host (osm_uch)
         # which is used to move the VM's.
         # We create it on in seed.yml but we dont export it.
-        export_workloads_name_filter:
+        os_migrate_workloads_filter:
           - regex: '^osm_(?!uch)'
 
     - name: load exported data

--- a/tests/func/idempotence/flavor.yml
+++ b/tests/func/idempotence/flavor.yml
@@ -3,7 +3,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_flavors
   vars:
-    export_flavors_name_filter:
+    os_migrate_flavors_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test

--- a/tests/func/idempotence/image.yml
+++ b/tests/func/idempotence/image.yml
@@ -3,7 +3,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_images
   vars:
-    export_images_name_filter:
+    os_migrate_images_filter:
       - regex: '^osm_'
 
 - name: re-load image_resources for idempotency test

--- a/tests/func/idempotence/keypair.yml
+++ b/tests/func/idempotence/keypair.yml
@@ -3,7 +3,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_keypairs
   vars:
-    export_keypairs_name_filter:
+    os_migrate_keypairs_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test

--- a/tests/func/idempotence/network.yml
+++ b/tests/func/idempotence/network.yml
@@ -3,7 +3,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_networks
   vars:
-    export_networks_name_filter:
+    os_migrate_networks_filter:
       - regex: '^osm_'
 
 - name: re-load network_resources for idempotency test

--- a/tests/func/idempotence/router.yml
+++ b/tests/func/idempotence/router.yml
@@ -3,7 +3,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_routers
   vars:
-    export_routers_name_filter:
+    os_migrate_routers_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test

--- a/tests/func/idempotence/router_interface.yml
+++ b/tests/func/idempotence/router_interface.yml
@@ -3,7 +3,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_router_interfaces
   vars:
-    export_routers_name_filter:
+    os_migrate_routers_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test

--- a/tests/func/idempotence/security_group.yml
+++ b/tests/func/idempotence/security_group.yml
@@ -3,7 +3,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_security_groups
   vars:
-    export_security_groups_name_filter:
+    os_migrate_security_groups_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test

--- a/tests/func/idempotence/security_group_rule.yml
+++ b/tests/func/idempotence/security_group_rule.yml
@@ -3,7 +3,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_security_group_rules
   vars:
-    export_security_groups_name_filter:
+    os_migrate_security_groups_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test

--- a/tests/func/idempotence/subnet.yml
+++ b/tests/func/idempotence/subnet.yml
@@ -3,7 +3,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_subnets
   vars:
-    export_subnets_name_filter:
+    os_migrate_subnets_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test

--- a/tests/func/run/image.yml
+++ b/tests/func/run/image.yml
@@ -6,7 +6,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_images
   vars:
-    export_images_name_filter:
+    os_migrate_images_filter:
       - regex: '^osm_'
 
 - name: load exported data

--- a/tests/func/run/network.yml
+++ b/tests/func/run/network.yml
@@ -6,7 +6,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_networks
   vars:
-    export_networks_name_filter:
+    os_migrate_networks_filter:
       - regex: '^osm_'
 
 - name: load exported data

--- a/tests/func/run/router.yml
+++ b/tests/func/run/router.yml
@@ -6,7 +6,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_routers
   vars:
-    export_routers_name_filter:
+    os_migrate_routers_filter:
       - regex: '^osm_'
 
 - name: load exported data

--- a/tests/func/run/router_interface.yml
+++ b/tests/func/run/router_interface.yml
@@ -6,7 +6,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_router_interfaces
   vars:
-    export_routers_name_filter:
+    os_migrate_routers_filter:
       - regex: '^osm_'
 
 - name: load exported data

--- a/tests/func/run/security_group.yml
+++ b/tests/func/run/security_group.yml
@@ -6,7 +6,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_security_groups
   vars:
-    export_security_groups_name_filter:
+    os_migrate_security_groups_filter:
       - regex: '^osm_'
 
 - name: load exported data

--- a/tests/func/run/security_group_rule.yml
+++ b/tests/func/run/security_group_rule.yml
@@ -6,7 +6,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_security_group_rules
   vars:
-    export_security_groups_name_filter:
+    os_migrate_security_groups_filter:
       - regex: '^osm_'
 
 - name: load exported data

--- a/tests/func/run/subnet.yml
+++ b/tests/func/run/subnet.yml
@@ -6,7 +6,7 @@
 - include_role:
     name: os_migrate.os_migrate.export_subnets
   vars:
-    export_subnets_name_filter:
+    os_migrate_subnets_filter:
       - regex: '^osm_'
 
 - name: load exported data


### PR DESCRIPTION
We had a bunch of unprefixed variables like:

export_networks_name_filter

We should add the os_migrate prefix and we can perhaps shorten the
variable name to still remain descriptive enough, like this:

os_migrate_networks_filter

The rename in this sense is applied across the project to all affected
variables.

This rename also opens up the possibility to use this filter on
imports in the future, allowing to work on full YAML files while
selecting just a few resources to import. It cannot be done right now
because the stringfilter module only supports looking at direct
attribute and not nested ones, so we cannot look at ['params']['name']
presently. An enhancement for stringfilter could be implemented.