### PR TITLE
Speed up dev iteration on e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ test-e2e-tenant: reinstall
 		-e os_migrate_tests_tmp_dir=$(ROOT_DIR)/tests/e2e/tmp \
 		-e os_migrate_data_dir=$(ROOT_DIR)/tests/e2e/tmp/data \
 		-e os_migrate_conversion_host_key=$(ROOT_DIR)/tests/e2e/tmpdata/conversion/ssh.key \
-                -e @$(ROOT_DIR)/tests/e2e/tenant/scenario_variables.yml \
 		-e @$(ROOT_DIR)/tests/auth_tenant.yml \
+		-e @$(ROOT_DIR)/tests/e2e/tenant/scenario_variables.yml \
 		$(E2E_TEST_ARGS) test_as_tenant.yml
 
 test-e2e-admin: reinstall
@@ -100,8 +100,8 @@ test-e2e-admin: reinstall
 		-e os_migrate_tests_tmp_dir=$(ROOT_DIR)/tests/e2e/tmp \
 		-e os_migrate_data_dir=$(ROOT_DIR)/tests/e2e/tmp/data \
 		-e os_migrate_conversion_host_key=$(ROOT_DIR)/tests/e2e/tmpdata/conversion/ssh.key \
-                -e @$(ROOT_DIR)/tests/e2e/admin/scenario_variables.yml \
 		-e @$(ROOT_DIR)/tests/auth_admin.yml \
+		-e @$(ROOT_DIR)/tests/e2e/admin/scenario_variables.yml \
 		$(E2E_TEST_ARGS) test_as_admin.yml
 
 test-fast: test-lint test-sanity test-unit

--- a/os_migrate/plugins/modules/import_workload_prelim.py
+++ b/os_migrate/plugins/modules/import_workload_prelim.py
@@ -222,6 +222,7 @@ def run_module():
     if len(list(conn.compute.servers(details=False, name=server_name, **module.params['dst_filters']))) > 0:
         module.exit_json(msg='VM already exists on destination!', **result)
 
+    # FIXME: let's check this in realtime, not based on what's in the data files.
     # Make sure source instance is shutdown before proceeding.
     if info['status'] != 'SHUTOFF':
         name = server_name

--- a/os_migrate/roles/conversion_host/tasks/conv_hosts_inventory.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_hosts_inventory.yml
@@ -1,0 +1,28 @@
+- name: add conversion hosts to inventory
+  include_tasks: conv_host_inventory.yml
+  vars:
+    inventory_name: "{{ item.inventory_name }}"
+    os_migrate_conversion_auth: "{{ item.os_migrate_conversion_auth }}"
+    os_migrate_conversion_auth_type: "{{ item.os_migrate_conversion_auth_type }}"
+    os_migrate_conversion_region_name: "{{ item.os_migrate_conversion_region_name }}"
+    os_migrate_conversion_validate_certs: "{{ item.os_migrate_conversion_validate_certs }}"
+    os_migrate_conversion_ca_cert: "{{ item.os_migrate_conversion_ca_cert }}"
+    os_migrate_conversion_client_cert: "{{ item.os_migrate_conversion_client_cert }}"
+    os_migrate_conversion_client_key: "{{ item.os_migrate_conversion_client_key }}"
+  loop:
+    - inventory_name: os_migrate_conv_src
+      os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
+      os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
+      os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+      os_migrate_conversion_validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+      os_migrate_conversion_ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+      os_migrate_conversion_client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+      os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+    - inventory_name: os_migrate_conv_dst
+      os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
+      os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
+      os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
+      os_migrate_conversion_validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+      os_migrate_conversion_ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+      os_migrate_conversion_client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+      os_migrate_conversion_client_key: "{{ os_migrate_dst_client_key|default(omit) }}"

--- a/os_migrate/roles/conversion_host/tasks/link_prepare.yml
+++ b/os_migrate/roles/conversion_host/tasks/link_prepare.yml
@@ -1,31 +1,5 @@
-- name: add conversion hosts to inventory
-  include_tasks: conv_host_inventory.yml
-  vars:
-    inventory_name: "{{ item.inventory_name }}"
-    os_migrate_conversion_auth: "{{ item.os_migrate_conversion_auth }}"
-    os_migrate_conversion_auth_type: "{{ item.os_migrate_conversion_auth_type }}"
-    os_migrate_conversion_region_name: "{{ item.os_migrate_conversion_region_name }}"
-    os_migrate_conversion_validate_certs: "{{ item.os_migrate_conversion_validate_certs }}"
-    os_migrate_conversion_ca_cert: "{{ item.os_migrate_conversion_ca_cert }}"
-    os_migrate_conversion_client_cert: "{{ item.os_migrate_conversion_client_cert }}"
-    os_migrate_conversion_client_key: "{{ item.os_migrate_conversion_client_key }}"
-  loop:
-    - inventory_name: os_migrate_conv_src
-      os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
-      os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-      os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
-      os_migrate_conversion_validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      os_migrate_conversion_ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      os_migrate_conversion_client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - inventory_name: os_migrate_conv_dst
-      os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
-      os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
-      os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-      os_migrate_conversion_validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      os_migrate_conversion_ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      os_migrate_conversion_client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      os_migrate_conversion_client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+- name: add both conversion hosts to inventory
+  import_tasks: conv_hosts_inventory.yml
 
 - name: create folder for link keypairs
   file:

--- a/tests/e2e/common/prep.yml
+++ b/tests/e2e/common/prep.yml
@@ -4,7 +4,6 @@
     path: "{{ os_migrate_data_dir }}"
     state: absent
   tags:
-    - always
     - test_prep
 
 - name: create os_migrate_tests_tmp_dir
@@ -12,7 +11,6 @@
     path: "{{ os_migrate_tests_tmp_dir }}"
     state: directory
   tags:
-    - always
     - test_prep
 
 - name: create os_migrate_data_dir
@@ -20,5 +18,4 @@
     path: "{{ os_migrate_data_dir }}"
     state: directory
   tags:
-    - always
     - test_prep

--- a/tests/e2e/tenant/clean_pre_workload.yml
+++ b/tests/e2e/tenant/clean_pre_workload.yml
@@ -1,27 +1,15 @@
-- name: remove osm_server
-  os_server:
-    auth: "{{ item.auth }}"
-    name: osm_server
+- name: Remove pre-workload test data
+  file:
+    path: "{{ os_migrate_data_dir }}/{{ item }}"
     state: absent
-    delete_fip: yes
-    validate_certs: "{{ item.validate_certs }}"
-    ca_cert: "{{ item.ca_cert }}"
-    client_cert: "{{ item.client_cert }}"
-    client_key: "{{ item.client_key }}"
-    wait: yes
   loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
+    - image_blobs
+    - images.yml
+    - networks.yml
+    - routers.yml
+    - security_group_rules.yml
+    - security_groups.yml
+    - subnets.yml
 
 - name: remove osm_image
   os_image:
@@ -64,8 +52,6 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
 
 - name: remove osm_router
   os_router:
@@ -88,8 +74,6 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
 
 - name: remove osm_server_port
   os_port:
@@ -112,8 +96,6 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
 
 - name: remove osm_subnet
   os_subnet:
@@ -135,8 +117,6 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
 
 - name: remove osm_net
   os_network:
@@ -158,8 +138,6 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
 
 - name: remove osm_security_group
   os_security_group:
@@ -181,8 +159,6 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
 
 - name: remove osm_security_group_rule
   os_security_group_rule:
@@ -204,28 +180,3 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
-
-- name: Remove volumes
-  os_volume:
-    auth: "{{ item.auth }}"
-    state: absent
-    display_name: rhosp-migration-root-osm_server
-    validate_certs: "{{ item.validate_certs }}"
-    ca_cert: "{{ item.ca_cert }}"
-    client_cert: "{{ item.client_cert }}"
-    client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always

--- a/tests/e2e/tenant/clean_workload.yml
+++ b/tests/e2e/tenant/clean_workload.yml
@@ -1,0 +1,52 @@
+- name: Remove workload test data
+  file:
+    path: "{{ os_migrate_data_dir }}/{{ item }}"
+    state: absent
+  loop:
+    - osm_server.log
+    - osm_server.state
+    - workloads.yml
+
+- name: Remove osm_server
+  os_server:
+    auth: "{{ item.auth }}"
+    name: osm_server
+    state: absent
+    delete_fip: yes
+    validate_certs: "{{ item.validate_certs }}"
+    ca_cert: "{{ item.ca_cert }}"
+    client_cert: "{{ item.client_cert }}"
+    client_key: "{{ item.client_key }}"
+    wait: yes
+  loop:
+    - auth: "{{ os_migrate_src_auth }}"
+      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+    - auth: "{{ os_migrate_dst_auth }}"
+      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+- name: Remove volumes
+  os_volume:
+    auth: "{{ item.auth }}"
+    state: absent
+    display_name: rhosp-migration-root-osm_server
+    validate_certs: "{{ item.validate_certs }}"
+    ca_cert: "{{ item.ca_cert }}"
+    client_cert: "{{ item.client_cert }}"
+    client_key: "{{ item.client_key }}"
+  loop:
+    - auth: "{{ os_migrate_src_auth }}"
+      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+    - auth: "{{ os_migrate_dst_auth }}"
+      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"

--- a/tests/e2e/tenant/run_pre_workload.yml
+++ b/tests/e2e/tenant/run_pre_workload.yml
@@ -33,7 +33,6 @@
 
     - include_role:
         name: os_migrate.os_migrate.import_networks
-  tags: always
 
 - name: Subnet tasks
   block:
@@ -64,7 +63,6 @@
 
     - include_role:
         name: os_migrate.os_migrate.import_subnets
-  tags: always
 
 - name: Security group tasks
   block:
@@ -92,7 +90,6 @@
 
     - include_role:
         name: os_migrate.os_migrate.import_security_groups
-  tags: always
 
 - name: Security group rules tasks
   block:
@@ -120,7 +117,6 @@
 
     - include_role:
         name: os_migrate.os_migrate.import_security_group_rules
-  tags: always
 
 - name: Router tasks
   block:
@@ -159,7 +155,6 @@
 
     - include_role:
         name: os_migrate.os_migrate.import_routers
-  tags: always
 
 - name: Image tasks
   block:
@@ -186,45 +181,3 @@
 
     - include_role:
         name: os_migrate.os_migrate.import_images
-  tags: always
-
-- name: Workloads tasks
-  block:
-    - include_role:
-        name: os_migrate.os_migrate.export_workloads
-      vars:
-        # This expression should export all osm_ workloads
-        # skipping the universal conversion host (osm_uch)
-        # which is used to move the VM's.
-        # We create it on in seed.yml but we dont export it.
-        os_migrate_workloads_filter:
-          - regex: '^osm_(?!uch)'
-
-    - name: load exported data
-      set_fact:
-        resources: "{{ (lookup('file',
-                               os_migrate_data_dir +
-                               '/workloads.yml') | from_yaml)
-                       ['resources'] }}"
-
-    - name: verify data contents
-      assert:
-        that:
-          - (resources |
-            json_query("[?params.name ==
-            'osm_server'].params.name")
-            == ['osm_server'])
-
-    - include_role:
-        name: os_migrate.os_migrate.import_workloads
-
-  rescue:
-    - name: 1 hour to debug the environment
-      wait_for:
-        timeout: 3600
-
-    - name: mark the task as failed
-      fail:
-        msg: "Failed to run the workload migration"
-
-  tags: always

--- a/tests/e2e/tenant/run_workload.yml
+++ b/tests/e2e/tenant/run_workload.yml
@@ -1,0 +1,44 @@
+# FIXME: Find a way we can test the whole playbook rather than just
+# the role. Either make sure we're not in a play here and use
+# import_playbook, or spawn an ansible-playbook subprocess? The latter
+# might be actually a more precise way to test the real end-user
+# experience.
+
+- name: Workloads tasks
+  block:
+    - include_role:
+        name: os_migrate.os_migrate.export_workloads
+      vars:
+        # This expression should export all osm_ workloads
+        # skipping the universal conversion host (osm_uch)
+        # which is used to move the VM's.
+        # We create it on in seed.yml but we dont export it.
+        os_migrate_workloads_filter:
+          - regex: '^osm_(?!uch)'
+
+    - name: load exported data
+      set_fact:
+        resources: "{{ (lookup('file',
+                               os_migrate_data_dir +
+                               '/workloads.yml') | from_yaml)
+                       ['resources'] }}"
+
+    - name: verify data contents
+      assert:
+        that:
+          - (resources |
+            json_query("[?params.name ==
+            'osm_server'].params.name")
+            == ['osm_server'])
+
+    - include_role:
+        name: os_migrate.os_migrate.import_workloads
+
+  rescue:
+    - name: 1 hour to debug the environment
+      wait_for:
+        timeout: 3600
+
+    - name: mark the task as failed
+      fail:
+        msg: "Failed to run the workload migration"

--- a/tests/e2e/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tenant/seed_pre_workload.yml
@@ -19,7 +19,6 @@
       ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  tags: always
 
 - name: Create osm subnet
   os_subnet:
@@ -43,7 +42,6 @@
       ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  tags: always
 
 - name: Create security group
   os_security_group:
@@ -61,7 +59,6 @@
       ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  tags: always
 
 - name: Create security group rule
   os_security_group_rule:
@@ -78,7 +75,6 @@
       ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  tags: always
 
 - name: create osm_router
   os_router:
@@ -100,21 +96,18 @@
       ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  tags: always
 
 - name: Create the key folder
   file:
     path: "{{ '~' | expanduser }}/ssh-ci"
     mode: 0700
     state: directory
-  tags: always
 
 - name: Generate a keypair for the migration
   # This will not regenerate the key if
   # it already exists
   openssh_keypair:
     path: "{{ '~' | expanduser }}/ssh-ci/id_rsa"
-  tags: always
 
 - name: Create new keypair as osm_key
   os_keypair:
@@ -137,8 +130,6 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  tags:
-    - always
 
 - name: make sure test_inputs dir exists
   file:
@@ -164,38 +155,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-
-- name: create osm_server
-  os_server:
-    auth: "{{ os_migrate_src_auth }}"
-    name: osm_server
-    state: present
-    # TODO: We don't have flavors or images
-    flavor: "{{ os_migrate_src_osm_server_flavor|default(m1.small) }}"
-    key_name: osm_key
-    image: "{{ os_migrate_src_osm_server_image|default(omit) }}"
-    network: osm_net
-    security_groups: osm_security_group
-    # We get a floating IP
-    # for the workload VM
-    auto_ip: yes
-    # Wait for the instance to be created
-    wait: yes
-    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  tags: always
-
-# In order to be able to migrate the VMS they must be turned off
-- name: Shutdown osm_server
-  os_server_action:
-    auth: "{{ os_migrate_src_auth }}"
-    server: osm_server
-    action: stop
-    wait: yes
-    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  tags: always

--- a/tests/e2e/tenant/seed_workload.yml
+++ b/tests/e2e/tenant/seed_workload.yml
@@ -1,0 +1,32 @@
+- name: create osm_server
+  os_server:
+    auth: "{{ os_migrate_src_auth }}"
+    name: osm_server
+    state: present
+    # TODO: We don't have flavors or images
+    flavor: "{{ os_migrate_src_osm_server_flavor|default(m1.small) }}"
+    key_name: osm_key
+    image: "{{ os_migrate_src_osm_server_image|default(omit) }}"
+    network: osm_net
+    security_groups: osm_security_group
+    # We get a floating IP
+    # for the workload VM
+    auto_ip: yes
+    # Wait for the instance to be created
+    wait: yes
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+
+# In order to be able to migrate the VMS they must be turned off
+- name: Shutdown osm_server
+  os_server_action:
+    auth: "{{ os_migrate_src_auth }}"
+    server: osm_server
+    action: stop
+    wait: yes
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -12,20 +12,60 @@
 - name: Migration tests
   hosts: migrator
   tasks:
-    - include_tasks: tenant/clean.yml
+    - include_tasks: tenant/clean_workload.yml
       args:
         apply:
-          tags: test_clean_before
+          tags:
+            - test_clean_before
+            - test_workload
       tags: always
-    - import_tasks: tenant/seed.yml
-    - import_tasks: tenant/run.yml
-    - include_tasks: tenant/clean.yml
+    - include_tasks: tenant/clean_pre_workload.yml
       args:
         apply:
-          tags: test_clean_after
+          tags:
+            - test_clean_before
+            - test_pre_workload
+      tags: always
+
+    - include_tasks: tenant/seed_pre_workload.yml
+      args:
+        apply:
+          tags: test_pre_workload
+      tags: always
+    - include_tasks: tenant/seed_workload.yml
+      args:
+        apply:
+          tags: test_workload
+      tags: always
+
+    - include_tasks: tenant/run_pre_workload.yml
+      args:
+        apply:
+          tags: test_pre_workload
+      tags: always
+    - include_tasks: tenant/run_workload.yml
+      args:
+        apply:
+          tags: test_workload
+      tags: always
+
+    - include_tasks: tenant/clean_workload.yml
+      args:
+        apply:
+          tags:
+            - test_clean_after
+            - test_workload
+      tags: always
+    - include_tasks: tenant/clean_pre_workload.yml
+      args:
+        apply:
+          tags:
+            - test_clean_after
+            - test_pre_workload
       tags: always
   tags:
     - test_migration
 
 - name: Delete conversion hosts
   import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/delete_conversion_hosts.yml"
+  when: test_clean_conversion_hosts_after|default(true)|bool


### PR DESCRIPTION
Currently running e2e tests does all this: deploy conversion hosts,
seed pre-workload resources, then workload resources, then migrate
pre-workload, then migrate workload, then clean everything up.

For working on workload migration, it would be great if we could leave
conversion hosts and pre-workload resources in place between test
runs, and only cycle seed-migrate-clean on the actual workload. This
is now implemented, but the default test run remains unchanged.

First i can just run everything without cleaning up:

```
./toolbox/run bash -c "E2E_TEST_ARGS='--skip-tags test_clean_after -e test_clean_conversion_hosts_after=false' make test-e2e-tenant"
```

And then i can run workload tests specifically, which will auto-clean
before and after, but only the workload parts:

```
./toolbox/run bash -c "E2E_TEST_ARGS='--tags test_workload' make test-e2e-tenant"
```