### PR TITLE
Stop busy-looping during volume transfer (fix for 100% CPU usage)

### DIFF
--- a/os_migrate/plugins/modules/import_workload_transfer_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_transfer_volumes.py
@@ -465,6 +465,7 @@ class OpenStackDestinationHost(OpenStackHostBase):
                     except (IOError, OSError) as err:
                         if err.errno != errno.EAGAIN:
                             raise
+                        time.sleep(1)
                         continue
                     if buf:
                         try:


### PR DESCRIPTION
The EAGAIN error code is used when polling, meaning there's no data to
read right now but it should be tried again later. Instead of trying
right away, sleep for a second. This will prevent Ansible from eating
100% CPU on the migrator machine.

Closes: https://github.com/os-migrate/os-migrate/issues/280