### PR TITLE
Migration of rebuildable servers

### DIFF
--- a/os_migrate/plugins/module_utils/exc.py
+++ b/os_migrate/plugins/module_utils/exc.py
@@ -41,3 +41,13 @@ class UnexpectedValue(Exception):
     def __init__(self, var, expected, got):
         message = self.msg_format.format(var, expected, got)
         super().__init__(message)
+
+
+class InconsistentState(Exception):
+    """Inconsistent state in data."""
+
+    msg_format = "Inconsistent state: '{}'."
+
+    def __init__(self, msg):
+        message = self.msg_format.format(msg)
+        super().__init__(message)

--- a/os_migrate/plugins/module_utils/reference.py
+++ b/os_migrate/plugins/module_utils/reference.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import openstack
 from openstack.exceptions import HttpException
 
 
@@ -279,7 +280,12 @@ def _fetch_ref(conn, get_method, id_, required=True, get_project_info=True):
         return None
 
     if get_project_info:
-        project_name, domain_name = _fetch_project_name_and_domain_name(conn, resource.project_id)
+        if isinstance(resource, openstack.image.v2.image.Image):
+            project_name, domain_name = _fetch_project_name_and_domain_name(
+                conn, resource.owner)
+        else:
+            project_name, domain_name = _fetch_project_name_and_domain_name(
+                conn, resource.project_id)
     else:
         project_name, domain_name = None, None
     return {

--- a/os_migrate/plugins/module_utils/resource.py
+++ b/os_migrate/plugins/module_utils/resource.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from copy import deepcopy
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
     import const, exc
 
@@ -36,6 +37,10 @@ class Resource():
     # updating it.  This list of parameter names is purged from the parameter
     # list before calling update.
     readonly_sdk_params = []
+    # Defaults for migration parameters. They are deep-copied into the
+    # resource serialization when the resource is being instantiated
+    # from_sdk.
+    migration_param_defaults = {}
 
     # ===== PUBLIC CLASS/STATIC METHODS (alphabetic sort) =====
 
@@ -84,6 +89,8 @@ class Resource():
         obj._data_from_sdk_and_refs(
             sdk_resource, cls._refs_from_sdk(conn, sdk_resource))
         obj.data['type'] = cls.resource_type
+        for k, v in cls.migration_param_defaults.items():
+            obj.data[const.RES_MIGRATION_PARAMS][k] = deepcopy(v)
         return obj
 
     # === PRIVATE CLASS/STATIC METHODS (alphabetic sort) ===

--- a/os_migrate/plugins/module_utils/resource.py
+++ b/os_migrate/plugins/module_utils/resource.py
@@ -227,7 +227,9 @@ class Resource():
 
     def update_migration_params(self, params_dict):
         for k, v in params_dict.items():
-            self.data[const.RES_MIGRATION_PARAMS][k] = v
+            # None means we leave the resource class defaults
+            if v is not None:
+                self.data[const.RES_MIGRATION_PARAMS][k] = v
 
     # TODO add validation
     # def is_data_valid(self):

--- a/os_migrate/plugins/module_utils/server.py
+++ b/os_migrate/plugins/module_utils/server.py
@@ -1,10 +1,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from copy import deepcopy
+
 import openstack
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
-    import const, reference, resource
+    import const, exc, reference, resource
 
 
 class Server(resource.Resource):
@@ -29,24 +31,30 @@ class Server(resource.Resource):
     params_from_refs = [
         'addresses_refs',
         'flavor_ref',
+        'image_ref',
         'security_group_refs',
     ]
     sdk_params_from_refs = [
         'flavor_id',
+        'image_id',
     ]
 
     migration_param_defaults = {
-        'boot_disk_copy': True,
+        'boot_disk_copy': False,
     }
 
     @classmethod
     def from_sdk(cls, conn, sdk_resource):
         obj = super(Server, cls).from_sdk(conn, sdk_resource)
+        params = obj.params()
+        migration_params = obj.migration_params()
+        if params.get('image_ref') is None:
+            migration_params['boot_disk_copy'] = True
         return obj
 
     def create(self, conn, block_device_mapping):
         sdk_params = self.sdk_params(conn)
-        sdk_params['block_device_mapping'] = block_device_mapping
+        self.update_sdk_params_block_device_mapping(sdk_params, block_device_mapping)
         return conn.compute.create_server(**sdk_params)
 
     def sdk_params(self, conn):
@@ -70,6 +78,47 @@ class Server(resource.Resource):
                     })
 
         return sdk_params
+
+    def update_sdk_params_block_device_mapping(self, sdk_params, block_device_mapping):
+        params, info = self.params_and_info()
+        migration_params = self.migration_params()
+        sdk_params['block_device_mapping'] = deepcopy(block_device_mapping)
+        # shadowing to make sure we don't modify the function argument
+        block_device_mapping = sdk_params['block_device_mapping']
+
+        has_boot_volume = len(list(filter(
+            lambda mapping: str(mapping['boot_index']) != '-1', block_device_mapping))) > 0
+        if migration_params['boot_disk_copy'] and not has_boot_volume:
+            raise exc.InconsistentState(
+                ("Instance '{0}' ({1}) has boot_disk_copy enabled but block device mapping "
+                 "has no boot volume: {2}").format(
+                     params['name'], info['id'], block_device_mapping),
+            )
+        if not migration_params['boot_disk_copy'] and has_boot_volume:
+            raise exc.InconsistentState(
+                ("Instance '{0}' ({1}) has boot_disk_copy disabled but block device mapping "
+                 "has a boot volume: {2}").format(
+                     params['name'], info['id'], block_device_mapping)
+            )
+
+        image_id = sdk_params.get('image_id', None)
+        if not has_boot_volume:
+            if image_id is not None:
+                block_device_mapping.insert(0, {
+                    'boot_index': 0,
+                    'delete_on_termination': True,
+                    'destination_type': 'local',
+                    'source_type': 'image',
+                    'uuid': image_id,
+                })
+            else:
+                raise exc.InconsistentState(
+                    ("Instance '{0}' ({1}) has neither boot volume nor image reference. "
+                     "Block device mapping: {2}").format(
+                         params['name'], info['id'], block_device_mapping)
+                )
+        else:
+            sdk_params.pop('image_id')
 
     @staticmethod
     def _find_sdk_res(conn, name_or_id, filters=None):
@@ -103,6 +152,10 @@ class Server(resource.Resource):
         refs['flavor_ref'] = reference.flavor_ref(
             conn, flavor_id)
 
+        refs['image_id'] = sdk_res['image']['id']
+        refs['image_ref'] = reference.image_ref(
+            conn, sdk_res['image']['id'])
+
         sec_groups = list(conn.compute.fetch_server_security_groups(sdk_res)
                           .security_groups)
         refs['security_group_ids'] = [
@@ -115,12 +168,13 @@ class Server(resource.Resource):
 
     def _refs_from_ser(self, conn, filters=None):
         refs = {}
+        params = self.params()
 
         # Nova only returns network names in response, not IDs. This
         # can be insufficient in edge cases. We have to hope that
         # private/public network names don't collide, and do a lookup
         # without project scope.
-        refs['addresses_refs'] = self.params()['addresses_refs']
+        refs['addresses_refs'] = params['addresses_refs']
         refs['addresses_ids'] = {}
         for net_name, net_addrs in refs['addresses_refs'].items():
             net_id = reference.network_id(conn, {
@@ -130,13 +184,16 @@ class Server(resource.Resource):
             })
             refs['addresses_ids'][net_id] = net_addrs
 
+        refs['flavor_ref'] = params['flavor_ref']
         refs['flavor_id'] = reference.flavor_id(
-            conn, self.params()['flavor_ref'])
-        refs['flavor_ref'] = self.params()['flavor_ref']
+            conn, params['flavor_ref'])
 
-        refs['security_group_refs'] = self.params()['security_group_refs']
+        refs['image_ref'] = params['image_ref']
+        refs['image_id'] = reference.image_id(conn, params['image_ref'])
+
+        refs['security_group_refs'] = params['security_group_refs']
         refs['security_group_ids'] = [
             reference.security_group_id(conn, sec_group_ref)
-            for sec_group_ref in self.params()['security_group_refs']]
+            for sec_group_ref in params['security_group_refs']]
 
         return refs

--- a/os_migrate/plugins/module_utils/server.py
+++ b/os_migrate/plugins/module_utils/server.py
@@ -35,6 +35,10 @@ class Server(resource.Resource):
         'flavor_id',
     ]
 
+    migration_param_defaults = {
+        'boot_disk_copy': True,
+    }
+
     @classmethod
     def from_sdk(cls, conn, sdk_resource):
         obj = super(Server, cls).from_sdk(conn, sdk_resource)

--- a/os_migrate/plugins/modules/import_workload_transfer_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_transfer_volumes.py
@@ -587,21 +587,21 @@ def run_module():
 
         if path == '/dev/vda':
             entry = {
-                'uuid': uuid,
+                'boot_index': 0,
+                'delete_on_termination': True,
+                'destination_type': 'volume',
                 'device_name': name,
                 'source_type': 'volume',
-                'destination_type': 'volume',
-                'boot_index': '0',
-                'delete_on_termination': True,
+                'uuid': uuid,
             }
         else:
             entry = {
-                'uuid': uuid,
+                'boot_index': -1,
+                'delete_on_termination': False,
+                'destination_type': 'volume',
                 'device_name': name,
                 'source_type': 'volume',
-                'destination_type': 'volume',
-                'boot_index': '-1',
-                'delete_on_termination': False,
+                'uuid': uuid,
             }
         block_device_mapping.append(entry)
 

--- a/os_migrate/roles/export_workloads/defaults/main.yml
+++ b/os_migrate/roles/export_workloads/defaults/main.yml
@@ -1,4 +1,7 @@
 os_migrate_workloads_filter:
   - regex: .*
-# TODO: Default this to false when rebuildable instances are supported.
-os_migrate_workload_boot_disk_copy: true
+
+# `null` means we let the Server class decide on defaults.
+# In case of boot_disk_copy, the default differs based on whether
+# the server was created as boot-from-volume or not.
+os_migrate_workloads_boot_disk_copy: null

--- a/os_migrate/roles/export_workloads/tasks/main.yml
+++ b/os_migrate/roles/export_workloads/tasks/main.yml
@@ -32,7 +32,7 @@
     path: "{{ os_migrate_data_dir }}/workloads.yml"
     name: "{{ item['id'] }}"
     migration_params:
-      boot_disk_copy: "{{ os_migrate_workload_boot_disk_copy }}"
+      boot_disk_copy: "{{ os_migrate_workloads_boot_disk_copy }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"

--- a/os_migrate/tests/unit/test_resource.py
+++ b/os_migrate/tests/unit/test_resource.py
@@ -129,6 +129,9 @@ class TestResource(unittest.TestCase):
         res.update_migration_params({'migparam1': 'val1'})
         res.update_migration_params({'migparam2': 'val2'})
         self.assertEqual(res.migration_params(), {'migparam1': 'val1', 'migparam2': 'val2'})
+        res.update_migration_params({'migparam3': None, 'migparam4': 'val4'})
+        self.assertEqual(res.migration_params(),
+                         {'migparam1': 'val1', 'migparam2': 'val2', 'migparam4': 'val4'})
 
     def test_needs_update(self):
         res1 = FakeResource.from_data(valid_fakeresource_data())

--- a/os_migrate/tests/unit/test_resource.py
+++ b/os_migrate/tests/unit/test_resource.py
@@ -20,6 +20,9 @@ class FakeResource(resource.Resource):
     params_from_refs = ['param3name', 'param4name']
     sdk_params_from_refs = ['param3id', 'param4id']
     readonly_sdk_params = ['readonly_param']
+    migration_param_defaults = {
+        'migparam1': 'migval1',
+    }
 
     @staticmethod
     def _create_sdk_res(conn, sdk_params):
@@ -83,7 +86,9 @@ def valid_fakeresource_data():
             'param3name': 'param3nameval',
             'param4name': 'param4nameval',
         },
-        '_migration_params': {},
+        '_migration_params': {
+            'migparam1': 'migval1',
+        },
         '_info': {
             'info1': 'info1val',
             'info2': 'info2val',

--- a/tests/e2e/tenant/run_workload.yml
+++ b/tests/e2e/tenant/run_workload.yml
@@ -16,6 +16,13 @@
         os_migrate_workloads_filter:
           - regex: '^osm_(?!uch)'
 
+    - name: set boot disk copy
+      replace:
+        path: "{{ os_migrate_data_dir }}/workloads.yml"
+        regexp: "boot_disk_copy: false"
+        replace: "boot_disk_copy: true"
+      when: set_boot_volume_copy|default(false)|bool
+
     - name: load exported data
       set_fact:
         resources: "{{ (lookup('file',
@@ -33,12 +40,3 @@
 
     - include_role:
         name: os_migrate.os_migrate.import_workloads
-
-  rescue:
-    - name: 1 hour to debug the environment
-      wait_for:
-        timeout: 3600
-
-    - name: mark the task as failed
-      fail:
-        msg: "Failed to run the workload migration"

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -18,6 +18,8 @@
           tags:
             - test_clean_before
             - test_workload
+            - test_image_workload_boot_copy
+            - test_image_workload_boot_nocopy
       tags: always
     - include_tasks: tenant/clean_pre_workload.yml
       args:
@@ -27,35 +29,70 @@
             - test_pre_workload
       tags: always
 
+    # pre-workload seed & migrate
     - include_tasks: tenant/seed_pre_workload.yml
       args:
         apply:
           tags: test_pre_workload
       tags: always
-    - include_tasks: tenant/seed_workload.yml
-      args:
-        apply:
-          tags: test_workload
-      tags: always
-
     - include_tasks: tenant/run_pre_workload.yml
       args:
         apply:
           tags: test_pre_workload
       tags: always
+
+    # server from image with attached volume
+    # migration w/o boot volume copy
+    - include_tasks: tenant/seed_workload.yml
+      args:
+        apply:
+          tags:
+            - test_workload
+            - test_image_workload_boot_nocopy
+      tags: always
     - include_tasks: tenant/run_workload.yml
       args:
         apply:
-          tags: test_workload
+          tags:
+            - test_workload
+            - test_image_workload_boot_nocopy
+      tags: always
+    - include_tasks: tenant/clean_workload.yml
+      args:
+        apply:
+          tags:
+            - test_workload
+            - test_image_workload_boot_nocopy
       tags: always
 
+    # server from image with attached volume
+    # migration with boot volume copy
+    - include_tasks: tenant/seed_workload.yml
+      args:
+        apply:
+          tags:
+            - test_workload
+            - test_image_workload_boot_copy
+      tags: always
+    - include_tasks: tenant/run_workload.yml
+      args:
+        apply:
+          tags:
+            - test_workload
+            - test_image_workload_boot_copy
+      tags: always
+      vars:
+        set_boot_volume_copy: true
     - include_tasks: tenant/clean_workload.yml
       args:
         apply:
           tags:
             - test_clean_after
             - test_workload
+            - test_image_workload_boot_copy
       tags: always
+
+    # pre-workload cleanup
     - include_tasks: tenant/clean_pre_workload.yml
       args:
         apply:


### PR DESCRIPTION
* This enables the boot_disk_copy migration parameter for
  workloads. When it's `false`, server is booted from an image. When
  it's `true`, server boot disk is copied and the destination
  server is created as boot-from-volume.

* Default value for boot_disk_copy depends on each server. Servers
  booted from a volume default to `true` (as that is the only sensible
  option), servers booted from an image default to `false`.

* `image_ref` is added to the server serialization to track the Glance
  image that should be used to create the server.

* E2e tests for workload migration are now testing these cases:

  * Instance booted from an image, with boot_disk_copy: false.

  * Instance booted from an image, with boot_disk_copy: true.