### PR TITLE
specify the image format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ test-unit: reinstall
 
 toolbox-build:
 	cd toolbox && \
-	podman build --build-arg NO_VAGRANT=$(NO_VAGRANT) -t localhost/os_migrate_toolbox:latest . && \
+	podman build --format docker --build-arg NO_VAGRANT=$(NO_VAGRANT) -t localhost/os_migrate_toolbox:latest . && \
 	podman tag localhost/os_migrate_toolbox:latest localhost/os_migrate_toolbox:$$(date "+%Y_%m_%d")
 
 toolbox-clean:


### PR DESCRIPTION
we need to make sure the V2s2 manifest is stored in each image, if not, when we pull the container image the v2s2 format type will be set to ""