### PR TITLE
Fix: Revert to conditional empty variable check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,7 @@ test-unit: reinstall
 # TOOLBOX
 
 toolbox-build:
-	REUSE_TOOLBOX="${REUSE_TOOLBOX:-0}"; \
-	if [[ $(REUSE_TOOLBOX) -eq "0" ]]; then \
+	if [ "$${REUSE_TOOLBOX:-0}" -eq "0" ]; then \
 		echo "Building the toolbox container image"; \
 		cd toolbox && \
 		podman build --format docker --build-arg NO_VAGRANT=$(NO_VAGRANT) -t localhost/os_migrate_toolbox:latest . && \


### PR DESCRIPTION
Im following now the same approach we have in another
variables check in the same makefile.
Even if locally the check works in the job we have
errors like: if [[ EUSE_TOOLBOX -eq "0" ]]; then \
Notice that EUSE instead or REUSE