### PR TITLE
Store workload migration logs in a separate dir

### DIFF
--- a/os_migrate/plugins/modules/import_workload_prelim.py
+++ b/os_migrate/plugins/modules/import_workload_prelim.py
@@ -61,9 +61,9 @@ options:
       - Data structure with server parameters as loaded from OS-Migrate workloads YAML file.
     required: true
     type: dict
-  data_dir:
+  log_dir:
     description:
-      - OS-Migrate data directory.
+      - Directory for storing log and state files.
     required: true
     type: str
   availability_zone:
@@ -146,7 +146,7 @@ workload.yml:
           user_domain_id: default
       src_validate_certs: False
       data: "{{ item }}"
-      data_dir: "{{ os_migrate_data_dir }}"
+      log_dir: "{{ os_migrate_data_dir }}/workload_logs"
     register: prelim
 
   - debug:
@@ -192,7 +192,7 @@ def run_module():
         dst_filters=dict(type='dict', required=False, default={}),
         src_conversion_host=dict(type='dict', required=True),
         data=dict(type='dict', required=True),
-        data_dir=dict(type='str', default=None),
+        log_dir=dict(type='str', default=None),
     )
 
     result = dict(
@@ -209,7 +209,7 @@ def run_module():
 
     server_name = params['name']
     result['server_name'] = server_name
-    data_dir = module.params['data_dir']
+    log_dir = module.params['log_dir']
 
     # Do not convert source conversion host!
     if info['id'] == module.params['src_conversion_host']['id']:
@@ -229,8 +229,8 @@ def run_module():
         msg = 'Skipping instance {} because it is not in state SHUTOFF!'
         module.exit_json(skipped=True, skip_reason=msg.format(name), **result)
 
-    result['log_file'] = os.path.join(data_dir, server_name) + '.log'
-    result['state_file'] = os.path.join(data_dir, server_name) + '.state'
+    result['log_file'] = os.path.join(log_dir, server_name) + '.log'
+    result['state_file'] = os.path.join(log_dir, server_name) + '.state'
     result['changed'] = True
 
     module.exit_json(**result)

--- a/os_migrate/roles/import_workloads/tasks/main.yml
+++ b/os_migrate/roles/import_workloads/tasks/main.yml
@@ -15,6 +15,11 @@
     path: "{{ os_migrate_data_dir }}/workloads.yml"
   register: read_workloads
 
+- name: create directory for workload migration logs
+  file:
+    path: "{{ os_migrate_data_dir }}/workload_logs"
+    state: directory
+
 - name: get source conversion host address
   os_migrate.os_migrate.os_conversion_host_info:
     auth: "{{ os_migrate_src_auth }}"

--- a/os_migrate/roles/import_workloads/tasks/workload.yml
+++ b/os_migrate/roles/import_workloads/tasks/workload.yml
@@ -11,7 +11,7 @@
       dst_filters: "{{ os_migrate_dst_filters }}"
       src_conversion_host:
         "{{ os_src_conversion_host_info.openstack_conversion_host }}"
-      data_dir: "{{ os_migrate_data_dir }}"
+      log_dir: "{{ os_migrate_data_dir }}/workload_logs"
       data: "{{ item }}"
     register: prelim
 
@@ -33,8 +33,8 @@
       conversion_host:
         "{{ os_src_conversion_host_info.openstack_conversion_host }}"
       data: "{{ item }}"
-      log_file: "{{ os_migrate_data_dir }}/{{ prelim.server_name }}.log"
-      state_file: "{{ os_migrate_data_dir }}/{{ prelim.server_name }}.state"
+      log_file: "{{ prelim.log_file }}"
+      state_file: "{{ prelim.state_file }}"
       ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
       ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
     register: exports
@@ -58,8 +58,8 @@
       src_conversion_host_address:
         "{{ os_src_conversion_host_info.openstack_conversion_host.address }}"
       volume_map: "{{ exports.volume_map }}"
-      state_file: "{{ os_migrate_data_dir }}/{{ prelim.server_name }}.state"
-      log_file: "{{ os_migrate_data_dir }}/{{ prelim.server_name }}.log"
+      log_file: "{{ prelim.log_file }}"
+      state_file: "{{ prelim.state_file }}"
     register: transfer
     when: prelim.changed
 
@@ -93,8 +93,8 @@
       ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
       transfer_uuid: "{{ exports.transfer_uuid }}"
       volume_map: "{{ exports.volume_map }}"
-      state_file: "{{ os_migrate_data_dir }}/{{ prelim.server_name }}.state"
-      log_file: "{{ os_migrate_data_dir }}/{{ prelim.server_name }}.log"
+      log_file: "{{ prelim.log_file }}"
+      state_file: "{{ prelim.state_file }}"
     when: prelim.changed
 
   rescue:


### PR DESCRIPTION
Previously workload migration logs were stored directly in
os_migrate_data_dir together with resource YAMLs. This meant that when
migrating multiple workloads, the directory would get cluttered. Let's
separate workload migration logs into its own directory.