### PR TITLE
Dev: Docs minor improvement

### DIFF
--- a/docs/src/devel/contributing.rst
+++ b/docs/src/devel/contributing.rst
@@ -165,7 +165,7 @@ associated export role, reading the data file and then calling the
 module you created for import.
 
 
-Commit messages
+Commit Messages
 ---------------
 
 For every pull request we request contributors to be compliant with the
@@ -191,19 +191,19 @@ Accepted types:
 - `chg` or `Chg`: changes in the CI automation, documentation or any other change not presented as a new feature
 - `fix` or `Fix`: a bugfix
 
-Message subject (first line)
+Message Subject (First Line)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The first line should not be longer than 70 characters, the second line is always
 blank and other lines should be wrapped at 80 characters.
 
-Ignoring the message subject
+Ignoring the Message Subject
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If the commit's message subject starts with `dev:` or `Dev:` it will be
+If the commit message subject starts with `dev:` or `Dev:` it will be
 ommited when rendering the changelog. 
 
-Message body
+Message Body
 ^^^^^^^^^^^^
 
 Uses the imperative, present tense: “change” not “changed” nor “changes” and

--- a/docs/src/devel/contributing.rst
+++ b/docs/src/devel/contributing.rst
@@ -164,6 +164,51 @@ data. A common pattern is validating the data file created by the
 associated export role, reading the data file and then calling the
 module you created for import.
 
+
+Commit messages
+---------------
+
+For every pull request we request contributors to be compliant with the
+following notation to help generating automatically the project's changelog.
+
+Format
+^^^^^^
+
+.. code-block:: console
+
+    <feat>: <add an awesome feature>
+    ^----^  ^----------------------^
+    |       |
+    |       +-> Summary in present tense.
+    |
+    +-------> Type: [Nn]ew, [cC]hg, [fF]ix.
+
+    <body> ----> The commit's body.
+
+Accepted types:
+
+- `new` or `New`: newly implemented features
+- `chg` or `Chg`: changes in the CI automation, documentation or any other change not presented as a new feature
+- `fix` or `Fix`: a bugfix
+
+Message subject (first line)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The first line should not be longer than 70 characters, the second line is always
+blank and other lines should be wrapped at 80 characters.
+
+Ignoring the message subject
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the commit's message subject starts with `dev:` or `Dev:` it will be
+ommited when rendering the changelog. 
+
+Message body
+^^^^^^^^^^^^
+
+Uses the imperative, present tense: “change” not “changed” nor “changes” and
+includes motivation for the change and contrasts with previous behavior.
+
 Documentation
 -------------
 

--- a/scripts/gitchangelog.rc
+++ b/scripts/gitchangelog.rc
@@ -62,8 +62,7 @@ ignore_regexps = [
     r'@cosmetic', r'!cosmetic',
     r'@refactor', r'!refactor',
     r'@wip', r'!wip',
-    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[p|P]kg:',
-    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[d|D]ev:',
+    r'^([dD]ev).*$',
     r'^(.{3,3}\s*:)?\s*[fF]irst commit.?\s*$',
     r'^Merge pull request.*',
     r'^$',  ## ignore commits with empty messages


### PR DESCRIPTION
This patch adds a docs reference
for the commit's style convention.

Please enter the commit message for your changes. Lines starting