### PR TITLE
New: Adds Logic to Unsubscribe RHEL Conversion Hosts

### DIFF
--- a/os_migrate/playbooks/delete_conversion_hosts.yml
+++ b/os_migrate/playbooks/delete_conversion_hosts.yml
@@ -2,6 +2,24 @@
   tasks:
     - include_role:
         name: os_migrate.os_migrate.conversion_host
+        tasks_from: conv_hosts_inventory.yml
+
+- hosts: os_migrate_conv_src
+  tasks:
+    - include_role:
+        name: os_migrate.os_migrate.conversion_host
+        tasks_from: unregister.yml
+
+- hosts: os_migrate_conv_dst
+  tasks:
+    - include_role:
+        name: os_migrate.os_migrate.conversion_host
+        tasks_from: unregister.yml
+
+- hosts: migrator
+  tasks:
+    - include_role:
+        name: os_migrate.os_migrate.conversion_host
         tasks_from: delete.yml
       vars:
         os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"

--- a/os_migrate/playbooks/delete_conversion_hosts.yml
+++ b/os_migrate/playbooks/delete_conversion_hosts.yml
@@ -3,14 +3,14 @@
     - include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: conv_hosts_inventory.yml
+      vars:
+        ignore_missing_conversion_hosts: true
 
-- hosts: os_migrate_conv_src
-  tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: unregister.yml
-
-- hosts: os_migrate_conv_dst
+- hosts: conversion_hosts
+  # Unregistration is best-effort. If the conversion hosts faced some
+  # issues and are unreachable, we don't want the host deletion to
+  # fail too.
+  ignore_unreachable: true
   tasks:
     - include_role:
         name: os_migrate.os_migrate.conversion_host

--- a/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
@@ -10,6 +10,15 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
   register: _server_info
 
+- name: fail when conversion host was not found
+  fail:
+    msg: >-
+      Nova server of name '{{ os_migrate_conversion_host_name }}' not
+      found, it was meant to be used as {{ inventory_name }}
+  when:
+    - _server_info.openstack_servers|length == 0
+    - not ignore_missing_conversion_hosts|default(false)|bool
+
 - name: add conversion host to inventory
   add_host:
     name: "{{ inventory_name }}"
@@ -22,3 +31,5 @@
     # Generally conversion hosts act as cloud-user, not as
     # root. E.g. link ssh keys need to be added to cloud-user.
     ansible_become: false
+  when:
+    - _server_info.openstack_servers|length > 0

--- a/os_migrate/roles/conversion_host/tasks/unregister.yml
+++ b/os_migrate/roles/conversion_host/tasks/unregister.yml
@@ -1,4 +1,10 @@
-- name: unregister rhel hosts from rhsm
+- name: unregister RHEL hosts from RHSM
   redhat_subscription:
     state: absent
-  when: ansible_distribution in ['RedHat']
+  vars:
+    # Unregistration gets stuck unless we explicitly run the module as root.
+    ansible_become: true
+    ansible_become_user: root
+  when:
+    - ansible_distribution is defined
+    - ansible_distribution in ['RedHat']

--- a/os_migrate/roles/conversion_host/tasks/unregister.yml
+++ b/os_migrate/roles/conversion_host/tasks/unregister.yml
@@ -1,0 +1,4 @@
+- name: unregister rhel hosts from rhsm
+  redhat_subscription:
+    state: absent
+  when: ansible_distribution in ['RedHat']

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -9,6 +9,23 @@
 - name: Deploy conversion hosts
   import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/deploy_conversion_hosts.yml"
 
+- name: Conversion host inventory
+  hosts: migrator
+  tasks:
+    - include_role:
+        name: os_migrate.os_migrate.conversion_host
+        tasks_from: conv_hosts_inventory.yml
+
+# Immediately unregister the conversion hosts to prevent dangling
+# subscriptions from CI in case the job crashes.
+- name: Unregister conversion hosts
+  hosts: conversion_hosts
+  ignore_unreachable: true
+  tasks:
+    - include_role:
+        name: os_migrate.os_migrate.conversion_host
+        tasks_from: unregister.yml
+
 - name: Migration tests
   hosts: migrator
   tasks:


### PR DESCRIPTION
This patch adds logic to unsubscribe systems from RHSM when using
RHEL as the OS for a conversion host.  The unsubscribe is called
for both the source and destination conversion hosts just before
they are deleted.