### PR TITLE
Dev: Do not use cache when building toolbox image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ toolbox-build:
 	if [ "$${REUSE_TOOLBOX:-0}" -eq "0" ]; then \
 		echo "Building the toolbox container image"; \
 		cd toolbox && \
-		podman build --format docker --build-arg NO_VAGRANT=$(NO_VAGRANT) -t localhost/os_migrate_toolbox:latest . && \
+		podman build --no-cache --format docker --build-arg NO_VAGRANT=$(NO_VAGRANT) -t localhost/os_migrate_toolbox:latest . && \
 		podman tag localhost/os_migrate_toolbox:latest localhost/os_migrate_toolbox:$$(date "+%Y_%m_%d"); \
 	else \
 		echo "Reusing the toolbox container image"; \


### PR DESCRIPTION
When running `make toolbox-build` to refresh the toolbox image, the
build is typically skipped if the image has been already built locally
before. Make sure we always rebuild by using `--no-cache`.