### PR TITLE
Fix functional CI by pinning pip version

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -122,7 +122,9 @@ jobs:
           sudo apt install python3-httplib2 -y
           # We need to be sure we use the latest versions of
           # pip, virtualenv and setuptools
-          sudo python -m pip install --upgrade pip
+          # FIXME: `git revert` the pip version constraint when devstack is fixed for new pip
+          #        https://github.com/os-migrate/os-migrate/issues/317
+          sudo python -m pip install --upgrade "pip<20.3"
           sudo python -m pip install --upgrade virtualenv
           sudo python -m pip install --upgrade setuptools
       - name: Verify MySQL connection from container
@@ -229,6 +231,14 @@ jobs:
       - name: Clone devstack
         run: |
           git clone https://opendev.org/openstack/devstack
+      # FIXME: `git revert` the pip version constraint when devstack is fixed for new pip
+      #        https://github.com/os-migrate/os-migrate/issues/317
+      # yamllint disable
+      - name: Devstack pin for pip version until devstack is fixed
+        run: |
+          sed -i -e 's/sudo -H -E python\${PYTHON3_VERSION} \$LOCAL_PIP/sudo -H -E python\${PYTHON3_VERSION} \$LOCAL_PIP "pip<20.3"/' \
+            devstack/tools/install_pip.sh
+      # yamllint enable
       - name: Configure devstack
         run: |
           DIR=$(pwd)


### PR DESCRIPTION
It looks like devstack can't work with new pip version 20.3, which got
released a few hours ago:

    Using python 3.6 to install /opt/stack/keystone
    + inc/python:pip_install:193               :   sudo -H LC_ALL=en_US.UTF-8 SETUPTOOLS_USE_DISTUTILS=stdlib http_proxy= https_proxy= no_proxy= PIP_FIND_LINKS= SETUPTOOLS_SYS_PATH_TECHNIQUE=rewrite python3.6 -m pip install -c /opt/stack/requirements/upper-constraints.txt -e /opt/stack/keystone
    DEPRECATION: Constraints are only allowed to take the form of a package name and a version specifier. Other forms were originally permitted as an accident of the implementation, but were undocumented. The new implementation of the resolver no longer supports these forms. A possible replacement is replacing the constraint with a requirement.. You can find discussion regarding this at https://github.com/pypa/pip/issues/8210.
    ERROR: Links are not allowed as constraints

Pip version 20.3 brings a new stricter dependency resolver, which
might be triggering this issue.

https://pypi.org/project/pip/20.3/

Resolves: https://github.com/os-migrate/os-migrate/issues/317