### PR TITLE
Update packages when deploying conversion hosts

### DIFF
--- a/os_migrate/roles/conversion_host_content/tasks/centos.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/centos.yml
@@ -3,6 +3,11 @@
     name: epel-release
     state: present
 
+- name: update all packages
+  yum:
+    name: '*'
+    state: latest
+
 - name: install content
   yum:
     name:

--- a/os_migrate/roles/conversion_host_content/tasks/main.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/main.yml
@@ -1,7 +1,10 @@
 - name: Conversion host content tasks
   block:
     - name: Display host os
-      debug: msg="Conversion Host OS is {{ ansible_distribution }}."
+      debug:
+        msg: >-
+          Conversion Host OS is
+          {{ ansible_distribution }} {{ ansible_distribution_version }}
 
     - name: Include CentOS tasks
       include_tasks: centos.yml

--- a/os_migrate/roles/conversion_host_content/tasks/rhel.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/rhel.yml
@@ -8,6 +8,11 @@
     - os_migrate_conversion_host_content_rhsm_user is defined
     - os_migrate_conversion_host_content_rhsm_password is defined
 
+- name: update all packages
+  yum:
+    name: '*'
+    state: latest
+
 - name: install content
   yum:
     name:


### PR DESCRIPTION
I ran into a bug when trying to migrate workloads, the volume export
step crashed with:

qemu-img: Unable to initialize gcrypt

It turns out there was desync in package versions, we were installing
latest qemu-img but libgcrypt was old. We need to update to latest
when deploying the conversion hosts.

Resolves: https://github.com/os-migrate/os-migrate/issues/322