### PR TITLE
New: Creation of Floating IPs on migrated workloads

### DIFF
--- a/os_migrate/plugins/module_utils/exc.py
+++ b/os_migrate/plugins/module_utils/exc.py
@@ -53,6 +53,16 @@ class UnexpectedValue(Exception):
         super().__init__(message)
 
 
+class UnexpectedChoice(Exception):
+    """Unexpected value of a variable which should be chosen from a list."""
+
+    msg_format = "Unexpected value of '{}': expected one of {} but got '{}'."
+
+    def __init__(self, var, choice_list, got):
+        message = self.msg_format.format(var, choice_list, got)
+        super().__init__(message)
+
+
 class Unsupported(Exception):
     """Unsupported action."""
 

--- a/os_migrate/plugins/module_utils/server_floating_ip.py
+++ b/os_migrate/plugins/module_utils/server_floating_ip.py
@@ -2,9 +2,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import openstack
+import time
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
-    import exc, const, resource
+    import exc, const, reference, resource
 
 
 def server_floating_ips(conn, server_ports):
@@ -31,30 +32,92 @@ class ServerFloatingIP(resource.Resource):
         'floating_network_id',
         'id',
         'port_id',
+        'qos_policy_id',
         'router_id',
+        'tags',
         'updated_at',
     ]
     params_from_sdk = [
+        'description',
+        'dns_domain',
+        'dns_name',
         'fixed_ip_address',
         'floating_ip_address',
-        'tags',
     ]
     params_from_refs = [
+        'floating_network_ref',
+        'qos_policy_ref',
     ]
     sdk_params_from_params = [
+        'description',
+        'dns_domain',
+        'dns_name',
         'fixed_ip_address',
-        'tags',
     ]
-    sdk_params_from_refs = []
+    sdk_params_from_refs = [
+        'floating_network_id',
+        'qos_policy_id',
+    ]
 
     def create_or_update(self, conn, filters=None):
         raise exc.Unsupported("Direct ServerFloatingIP.create_or_update call is unsupported.")
 
+    def create(self, conn, sdk_srv, mode):
+        mode_choices = ['auto', 'skip']
+        if mode not in mode_choices:
+            raise exc.UnexpectedChoice('floating_ip_mode', mode_choices, mode)
+
+        if mode == 'skip':
+            return None
+        elif mode == 'auto':
+            return self._create_auto(conn, sdk_srv)
+
+    def _create_auto(self, conn, sdk_srv):
+        my_port = self._find_my_server_port(conn, sdk_srv)
+        sdk_params = self._to_sdk_params(self._refs_from_ser(conn))
+        sdk_params['port_id'] = my_port['id']
+        return conn.network.create_ip(**sdk_params)
+
+    def _find_my_server_port(self, conn, sdk_srv, delay=5, retries=5):
+        params = self.params()
+        for try_number in range(retries):
+            srv_ports = conn.network.ports(device_id=sdk_srv['id'])
+            for port in srv_ports:
+                port_fixed_ips = [item['ip_address'] for item in port['fixed_ips']]
+                if params['fixed_ip_address'] in port_fixed_ips:
+                    return port
+
+            # wait and retry
+            time.sleep(delay)
+
+        # still failing after max retries
+        raise exc.CannotConverge(
+            "Floating IP for server '{0}' ('{1}') is meant to attach "
+            "to a port with fixed IP '{2}', but no such port was found "
+            "on that server.".format(
+                sdk_srv['name'],
+                sdk_srv['id'],
+                params['fixed_ip_address'],
+            )
+        )
+
     @staticmethod
     def _refs_from_sdk(conn, sdk_res):
         refs = {}
+        refs['floating_network_id'] = sdk_res['floating_network_id']
+        refs['floating_network_ref'] = reference.network_ref(
+            conn, sdk_res['floating_network_id'])
+        refs['qos_policy_id'] = sdk_res['qos_policy_id']
+        refs['qos_policy_ref'] = reference.qos_policy_ref(
+            conn, sdk_res['qos_policy_id'])
         return refs
 
     def _refs_from_ser(self, conn, filters=None):
         refs = {}
+        refs['floating_network_ref'] = self.params()['floating_network_ref']
+        refs['floating_network_id'] = reference.network_id(
+            conn, self.params()['floating_network_ref'])
+        refs['qos_policy_ref'] = self.params()['qos_policy_ref']
+        refs['qos_policy_id'] = reference.qos_policy_id(
+            conn, self.params()['qos_policy_ref'])
         return refs

--- a/os_migrate/tests/unit/test_server_floating_ip.py
+++ b/os_migrate/tests/unit/test_server_floating_ip.py
@@ -11,9 +11,13 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
 def sdk_server_floating_ip():
     return openstack.network.v2.floating_ip.FloatingIP(
         created_at="2020-11-25T15:26:15Z",
+        description="my FIP",
+        dns_domain="example.org",
+        dns_name="testname",
         floating_network_id="uuid-test-external-net",
         id="uuid-test-server-fip",
         port_id="uuid-test-server-port",
+        qos_policy_id="uuid-test-qos-policy",
         router_id="uuid-test-router",
         updated_at="2020-11-25T15:26:18Z",
         fixed_ip_address="192.168.20.7",
@@ -29,21 +33,38 @@ def serialized_server_floating_ip():
             "floating_network_id": "uuid-test-external-net",
             "id": "uuid-test-server-fip",
             "port_id": "uuid-test-server-port",
+            "qos_policy_id": "uuid-test-qos-policy",
             "router_id": "uuid-test-router",
             "updated_at": "2020-11-25T15:26:18Z",
+            "tags": [],
         },
         const.RES_MIGRATION_PARAMS: {},
         const.RES_PARAMS: {
+            "description": "my FIP",
+            "dns_domain": "example.org",
+            "dns_name": "testname",
             "fixed_ip_address": "192.168.20.7",
             "floating_ip_address": "172.20.9.135",
-            "tags": [],
         },
         const.RES_TYPE: "openstack.network.ServerFloatingIP",
     }
 
 
 def server_floating_ip_refs():
-    return {}
+    return {
+        'floating_network_id': 'uuid-test-external-net',
+        'floating_network_ref': {
+            'domain': None,
+            'project': None,
+            'name': 'test-external-net',
+        },
+        'qos_policy_id': 'uuid-test-qos-policy',
+        'qos_policy_ref': {
+            'domain': None,
+            'project': None,
+            'name': 'test-qos-policy',
+        },
+    }
 
 
 # "Disconnected" variant of ServerFloatingIP resource where we make sure not to
@@ -66,14 +87,19 @@ class TestServerFloatingIP(unittest.TestCase):
         params, info = net.params_and_info()
 
         self.assertEqual(net.type(), 'openstack.network.ServerFloatingIP')
+        self.assertEqual(params['description'], 'my FIP')
+        self.assertEqual(params['dns_domain'], 'example.org')
+        self.assertEqual(params['dns_name'], 'testname')
         self.assertEqual(params['fixed_ip_address'], '192.168.20.7')
         self.assertEqual(params['floating_ip_address'], '172.20.9.135')
-        self.assertEqual(params['tags'], [])
+        self.assertEqual(params['floating_network_ref']['name'], 'test-external-net')
+        self.assertEqual(params['qos_policy_ref']['name'], 'test-qos-policy')
         self.assertEqual(info['created_at'], '2020-11-25T15:26:15Z')
         self.assertEqual(info['floating_network_id'], 'uuid-test-external-net')
         self.assertEqual(info['id'], 'uuid-test-server-fip')
         self.assertEqual(info['port_id'], 'uuid-test-server-port')
         self.assertEqual(info['router_id'], 'uuid-test-router')
+        self.assertEqual(info['tags'], [])
         self.assertEqual(info['updated_at'], '2020-11-25T15:26:18Z')
 
     def test_server_floating_ip_sdk_params(self):
@@ -81,5 +107,14 @@ class TestServerFloatingIP(unittest.TestCase):
         refs = net._refs_from_ser(None)  # conn=None
         sdk_params = net._to_sdk_params(refs)
 
-        self.assertEqual(sdk_params['fixed_ip_address'], '192.168.20.7')
-        self.assertEqual(sdk_params['tags'], [])
+        self.assertEqual(
+            sdk_params,
+            {
+                'description': 'my FIP',
+                'dns_domain': 'example.org',
+                'dns_name': 'testname',
+                'fixed_ip_address': '192.168.20.7',
+                'floating_network_id': 'uuid-test-external-net',
+                'qos_policy_id': 'uuid-test-qos-policy',
+            }
+        )

--- a/tests/e2e/tenant/run_pre_workload.yml
+++ b/tests/e2e/tenant/run_pre_workload.yml
@@ -156,6 +156,36 @@
     - include_role:
         name: os_migrate.os_migrate.import_routers
 
+- name: Router interface tasks
+  block:
+    - include_role:
+        name: os_migrate.os_migrate.export_router_interfaces
+      vars:
+        # This expression should export all osm_ workloads
+        # skipping the universal conversion host (osm_uch)
+        # which is used to move the VM's.
+        # We create it on in seed.yml but we dont export it.
+        os_migrate_routers_filter:
+          - regex: '^osm_(?!uch)'
+
+    - name: load exported data
+      set_fact:
+        router_interface_resources: "{{ (lookup('file',
+                                         os_migrate_data_dir +
+                                         '/router_interfaces.yml') | from_yaml)
+                                         ['resources'] }}"
+
+    - name: verify data contents
+      assert:
+        that:
+          - "(router_interface_resources |
+              json_query(\"[?params.device_ref.name ==
+              'osm_router'].params.fixed_ips_refs[].subnet_ref.name\")) | sort ==
+              ['osm_subnet']"
+
+    - include_role:
+        name: os_migrate.os_migrate.import_router_interfaces
+
 - name: Image tasks
   block:
     - include_role:


### PR DESCRIPTION
    New: Creation of Floating IPs on migrated workloads
    
    A new migration parameter 'floating_ip_mode' is added into the
    workload serialization. The current possible values are 'auto' and
    'skip'.
    
    * 'auto' means that floating IP creation is attempted for the VM, if
      the source VM had floating IP(s). The floating IP info is already
      being exported with the workload.
    
      Currently we only support auto-assignment of the floating IP
      address. (Exact assignment is typically not allowed by policy for
      tenants, but this should be investigated too.)
    
      Each floating IP serialization has a 'floating_network_ref'
      reference, which specifies the network where the floating IP should
      be created. The 'fixed_ip_address' parameter controls which
      port/address will the floating IP attach to.
    
    * 'skip' means that even if the workload serialization does include
      serialized floating IP subresources, their creation in destination
      cloud will not be attempted.
    
    The 'floating_ip_mode' parameter defaults to 'auto'.