### PR TITLE
Dev: Add time profiling into CI logs

### DIFF
--- a/tests/e2e/ansible.cfg
+++ b/tests/e2e/ansible.cfg
@@ -1,3 +1,3 @@
 [defaults]
 stdout_callback = yaml
-callback_whitelist = profile_json
+callback_whitelist = profile_json,profile_tasks

--- a/tests/func/ansible.cfg
+++ b/tests/func/ansible.cfg
@@ -1,3 +1,3 @@
 [defaults]
 stdout_callback = yaml
-callback_whitelist = profile_json
+callback_whitelist = profile_json,profile_tasks


### PR DESCRIPTION
This should let us inspect how much time is consumed by individual
tasks.