### PR TITLE
New: Parallel installation of conversion hosts

### DIFF
--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -59,16 +59,7 @@
         tasks_from: link_insert_private_key.yml
       when: os_migrate_link_conversion_hosts|default(true)|bool
 
-- hosts: os_migrate_conv_src
-  tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host_content
-      when: os_migrate_conversion_host_content_install|default(true)|bool
-  vars:
-    ansible_become_user: root
-    ansible_become: true
-
-- hosts: os_migrate_conv_dst
+- hosts: conversion_hosts
   tasks:
     - include_role:
         name: os_migrate.os_migrate.conversion_host_content


### PR DESCRIPTION
The updating and installing of packages on conversion hosts can take
minutes. These actions were done in series until now (src then dst),
but now they're done in parallel, which should speed up execution of
the conversion host deployment playbook.

