### PR TITLE
Dev: use 'make docs' to generate docs in Github Actions

### DIFF
--- a/.github/workflows/docs-build-pr.yml
+++ b/.github/workflows/docs-build-pr.yml
@@ -14,30 +14,19 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Render the changelog file
+      - name: Install dependencies
         run: |
-          sudo pip install gitchangelog
-          GITCHANGELOG_CONFIG_FILENAME=./scripts/gitchangelog.rc \
-          gitchangelog \
-          > ./docs/src/changelog.rst
-      - uses: ammaraskar/sphinx-action@master
-        with:
-          pre-build-command: |
-            apt-get update -y && \
-            apt install build-essential -y && \
-            apt install gcc -y && \
-            touch /tmp/sphinx-log && \
-            pip3 install --upgrade pip && \
-            pip3 install --upgrade virtualenv && \
-            pip3 install --upgrade setuptools && \
-            pip3 install -r toolbox/build/venv-requirements.txt && \
-            pip3 install --upgrade ruamel.yaml && \
-            pip3 install --upgrade sphinx-rtd-theme && \
-            ansible-galaxy collection build os_migrate -v --force --output-path . && \
-            LATEST=$(ls os_migrate-os_migrate*.tar.gz | grep -v latest | sort -V | tail -n1) && \
-            ln -sf $LATEST os_migrate-os_migrate-latest.tar.gz && \
-            ansible-galaxy collection install --force os_migrate-os_migrate-latest.tar.gz
-          docs-folder: "docs/src/"
+          sudo locale-gen en_US.UTF-8
+          sudo dpkg-reconfigure locales
+          sudo add-apt-repository -y ppa:projectatomic/ppa
+          sudo apt update -y
+          sudo apt install podman -y
+      - name: Fetch toolbox image
+        run: |
+          REUSE_TOOLBOX=1 NO_VAGRANT=1 make toolbox-build
+      - name: Render the documentation
+        run: |
+          ./toolbox/run make docs
       - uses: actions/upload-artifact@v1
         with:
           name: DocumentationHTML

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,31 +12,19 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Render the changelog file
+      - name: Install dependencies
         run: |
-          sudo pip install gitchangelog
-          GITCHANGELOG_CONFIG_FILENAME=./scripts/gitchangelog.rc \
-          gitchangelog \
-          > ./docs/src/changelog.rst
-          cat ./docs/src/changelog.rst
-      - uses: ammaraskar/sphinx-action@master
-        with:
-          pre-build-command: |
-            apt-get update -y && \
-            apt install build-essential -y && \
-            apt install gcc -y && \
-            touch /tmp/sphinx-log && \
-            pip3 install --upgrade pip && \
-            pip3 install --upgrade virtualenv && \
-            pip3 install --upgrade setuptools && \
-            pip3 install -r toolbox/build/venv-requirements.txt && \
-            pip3 install --upgrade ruamel.yaml && \
-            pip3 install --upgrade sphinx-rtd-theme && \
-            ansible-galaxy collection build os_migrate -v --force --output-path . && \
-            LATEST=$(ls os_migrate-os_migrate*.tar.gz | grep -v latest | sort -V | tail -n1) && \
-            ln -sf $LATEST os_migrate-os_migrate-latest.tar.gz && \
-            ansible-galaxy collection install --force os_migrate-os_migrate-latest.tar.gz
-          docs-folder: "docs/src/"
+          sudo locale-gen en_US.UTF-8
+          sudo dpkg-reconfigure locales
+          sudo add-apt-repository -y ppa:projectatomic/ppa
+          sudo apt update -y
+          sudo apt install podman -y
+      - name: Fetch toolbox image
+        run: |
+          REUSE_TOOLBOX=1 NO_VAGRANT=1 make toolbox-build
+      - name: Render the documentation
+        run: |
+          ./toolbox/run make docs
       - uses: actions/upload-artifact@v1
         with:
           name: DocumentationHTML

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test-unit: reinstall
 
 # DOCS
 
-docs: build
+docs: reinstall
 	./scripts/docs-build.sh
 
 


### PR DESCRIPTION
Instead of using the modules which are specific to Github
Actions, let's use 'make docs' to build documentation, be it locally by a
contributor, or in CI.