### PR TITLE
Dev: Fix changelog generation in 'make docs'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/__pycache__
+
 /releases/*
 
 /docs/src/_build/*

--- a/scripts/docs-build.sh
+++ b/scripts/docs-build.sh
@@ -5,7 +5,7 @@ if [ -z "${VIRTUAL_ENV:-}" ]; then
     source /root/venv/bin/activate
 fi
 
-GITCHANGELOG_CONFIG_FILENAME=./scripts/gitchangelog.rc
+export GITCHANGELOG_CONFIG_FILENAME=./scripts/gitchangelog.rc
 gitchangelog > ./docs/src/changelog.rst
 
 cd ./docs/src


### PR DESCRIPTION
The changelog contained entries like merge commits because the
changelog generator config path variable wasn't exported. This is now
fixed.

