### PR TITLE
Chg: Don't feed availability_zone_hints into requests when empty 

### DIFF
--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -46,6 +46,9 @@ class Network(resource.Resource):
     sdk_params_from_refs = [
         'qos_policy_id',
     ]
+    skip_falsey_sdk_params = [
+        'availability_zone_hints',
+    ]
 
     @classmethod
     def from_sdk(cls, conn, sdk_resource):

--- a/os_migrate/plugins/module_utils/router.py
+++ b/os_migrate/plugins/module_utils/router.py
@@ -40,6 +40,9 @@ class Router(resource.Resource):
         'external_gateway_info',
         'flavor_id',
     ]
+    skip_falsey_sdk_params = [
+        'availability_zone_hints',
+    ]
 
     @classmethod
     def from_sdk(cls, conn, sdk_resource):

--- a/os_migrate/tests/unit/test_resource.py
+++ b/os_migrate/tests/unit/test_resource.py
@@ -15,11 +15,12 @@ class FakeResource(resource.Resource):
     sdk_class = dict
 
     info_from_sdk = ['id', 'info1', 'info2']
-    params_from_sdk = ['name', 'param1', 'readonly_param']
+    params_from_sdk = ['name', 'param1', 'readonly_param', 'skip_falsey']
     info_from_refs = ['param3id', 'param4id']
     params_from_refs = ['param3name', 'param4name']
     sdk_params_from_refs = ['param3id', 'param4id']
     readonly_sdk_params = ['readonly_param']
+    skip_falsey_sdk_params = ['skip_falsey']
     migration_param_defaults = {
         'migparam1': 'migval1',
     }
@@ -59,6 +60,7 @@ def valid_fakeresource_sdk():
         'name': 'nameval',
         'param1': 'param1val',
         'readonly_param': 'no_can_change',
+        'skip_falsey': ['truthy'],
         'param3id': 'param3idval',
         'param4id': 'param4idval',
         'id': 'idval',
@@ -72,6 +74,7 @@ def valid_fakeresource_sdk_creation_params():
         'name': 'nameval',
         'param1': 'param1val',
         'readonly_param': 'no_can_change',
+        'skip_falsey': ['truthy'],
         'param3id': 'param3idval',
         'param4id': 'param4idval',
     }
@@ -84,6 +87,7 @@ def valid_fakeresource_data():
             'name': 'nameval',
             'param1': 'param1val',
             'readonly_param': 'no_can_change',
+            'skip_falsey': ['truthy'],
             'param3name': 'param3nameval',
             'param4name': 'param4nameval',
         },
@@ -125,6 +129,16 @@ class TestResource(unittest.TestCase):
         refs = res._refs_from_ser(None)
         sdk_params = res._to_sdk_params(refs)
         self.assertEqual(sdk_params, valid_fakeresource_sdk_creation_params())
+
+    def test_to_sdk_params_skip_falsey(self):
+        res = FakeResource.from_data(valid_fakeresource_data())
+        res.params()['skip_falsey'] = []
+        # conn=None because the fake _refs_from_* methods don't need it
+        refs = res._refs_from_ser(None)
+        sdk_params = res._to_sdk_params(refs)
+        expected = valid_fakeresource_sdk_creation_params()
+        del expected['skip_falsey']
+        self.assertEqual(sdk_params, expected)
 
     def test_update_migration_params(self):
         res = FakeResource.from_data(valid_fakeresource_data())

--- a/tests/e2e/tenant/run_pre_workload.yml
+++ b/tests/e2e/tenant/run_pre_workload.yml
@@ -145,14 +145,6 @@
               'osm_router'].params.external_gateway_refinfo.network_ref.name\")) ==
               [os_migrate_src_osm_router_external_network | default('public')]"
 
-    # There is no availability_zone_hints in 16
-    - name: remove availability_zone_hints
-      lineinfile:
-        dest: "{{ os_migrate_data_dir }}/routers.yml"
-        regexp: 'availability_zone_hints'
-        state: absent
-      when: os_migrate_dst_release == 16
-
     - include_role:
         name: os_migrate.os_migrate.import_routers
 


### PR DESCRIPTION
Dev: Mechanism for skipping falsey params

Empty lists usually don't make sense to feed into the API requests as
parameters. Often the results of feeding an empty list vs. not
specifying the parameter can be the same, but it can matter in some
cases, e.g. if Neutron router availability zone extension is disabled,
the parameter must not be specified in the request.

--------

Chg: Don't feed availability_zone_hints into requests when empty

The availability_zone_hints parameter for routers and networks can
often be an empty list. Previously we've fed it as-is into the API
requests. However, if the extension for network/router availability
zones isn't enabled, this can cause the request to fail.

We now only use the availability_zone_hints parameter when its not
empty. This should have no effect on correctness, but it can prevent
false-alarm failures.

