### PR TITLE
Chg: Pass through all RHSM parameters for conversion hosts

### DIFF
--- a/os_migrate/roles/conversion_host_content/defaults/main.yml
+++ b/os_migrate/roles/conversion_host_content/defaults/main.yml
@@ -1,5 +1,5 @@
 os_migrate_conversion_host_content_install: true
 # The following two variables must be
 # configured to set up properly the RHSM
-# os_migrate_conversion_host_content_rhsm_user: username
-# os_migrate_conversion_host_content_rhsm_password: password
+# os_migrate_conversion_rhsm_username: username
+# os_migrate_conversion_rhsm_password: password

--- a/os_migrate/roles/conversion_host_content/tasks/rhel.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/rhel.yml
@@ -1,12 +1,12 @@
 - name: register and auto-subscribe to available content.
   redhat_subscription:
     state: present
-    username: "{{ os_migrate_conversion_host_content_rhsm_user|default(omit) }}"
-    password: "{{ os_migrate_conversion_host_content_rhsm_password|default(omit) }}"
+    username: "{{ os_migrate_conversion_rhsm_username|default(omit) }}"
+    password: "{{ os_migrate_conversion_rhsm_password|default(omit) }}"
     auto_attach: true
   when:
-    - os_migrate_conversion_host_content_rhsm_user is defined
-    - os_migrate_conversion_host_content_rhsm_password is defined
+    - os_migrate_conversion_rhsm_username is defined
+    - os_migrate_conversion_rhsm_password is defined
 
 - name: update all packages
   yum:

--- a/os_migrate/roles/conversion_host_content/tasks/rhel.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/rhel.yml
@@ -1,12 +1,34 @@
 - name: register and auto-subscribe to available content.
   redhat_subscription:
     state: present
-    username: "{{ os_migrate_conversion_rhsm_username|default(omit) }}"
+    # These params have defaults specified:
+    auto_attach: "{{ os_migrate_conversion_rhsm_auto_attach|default(true) }}"
+    # These params default to omitting:
+    activationkey: "{{ os_migrate_conversion_rhsm_activationkey|default(omit) }}"
+    consumer_id: "{{ os_migrate_conversion_rhsm_consumer_id|default(omit) }}"
+    consumer_name: "{{ os_migrate_conversion_rhsm_consumer_name|default(omit) }}"
+    consumer_type: "{{ os_migrate_conversion_rhsm_consumer_type|default(omit) }}"
+    environment: "{{ os_migrate_conversion_rhsm_environment|default(omit) }}"
+    force_register: "{{ os_migrate_conversion_rhsm_force_register|default(omit) }}"
+    org_id: "{{ os_migrate_conversion_rhsm_org_id|default(omit) }}"
     password: "{{ os_migrate_conversion_rhsm_password|default(omit) }}"
-    auto_attach: true
+    pool: "{{ os_migrate_conversion_rhsm_pool|default(omit) }}"
+    pool_ids: "{{ os_migrate_conversion_rhsm_pool_ids|default(omit) }}"
+    release: "{{ os_migrate_conversion_rhsm_release|default(omit) }}"
+    rhsm_baseurl: "{{ os_migrate_conversion_rhsm_rhsm_baseurl|default(omit) }}"
+    rhsm_repo_ca_cert: "{{ os_migrate_conversion_rhsm_rhsm_repo_ca_cert|default(omit) }}"
+    server_hostname: "{{ os_migrate_conversion_rhsm_server_hostname|default(omit) }}"
+    server_insecure: "{{ os_migrate_conversion_rhsm_server_insecure|default(omit) }}"
+    server_proxy_hostname: "{{ os_migrate_conversion_rhsm_server_proxy_hostname|default(omit) }}"
+    server_proxy_password: "{{ os_migrate_conversion_rhsm_server_proxy_password|default(omit) }}"
+    server_proxy_port: "{{ os_migrate_conversion_rhsm_server_proxy_port|default(omit) }}"
+    server_proxy_user: "{{ os_migrate_conversion_rhsm_server_proxy_user|default(omit) }}"
+    syspurpose: "{{ os_migrate_conversion_rhsm_syspurpose|default(omit) }}"
+    username: "{{ os_migrate_conversion_rhsm_username|default(omit) }}"
   when:
-    - os_migrate_conversion_rhsm_username is defined
-    - os_migrate_conversion_rhsm_password is defined
+    - >-
+      os_migrate_conversion_rhsm_username is defined or
+      os_migrate_conversion_rhsm_org_id is defined
 
 - name: update all packages
   yum:


### PR DESCRIPTION
Chg: Shorter names for RHSM variables

The RHSM variables are renamed from previous pattern of
e.g. 'os_migrate_conversion_host_content_rhsm_user' to
e.g. 'os_migrate_conversion_rhsm_user' which is shorter but should
still be descriptive enough and not risk a naming collision.

The 'user' variable is also renamed to 'username' to match the
parameter naming on the redhat_subscription module.

------------

Chg: Pass through all RHSM parameters for conversion hosts

All parameters supported by the redhat_subscription Ansible module are
now exposed as variables for the conversion host content installation.