### PR TITLE
Dev: Convert to fully qualified collection names

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -2,7 +2,7 @@ name: consistency-functional
 on:
   push:
     paths-ignore:
-      - 'docs/**'
+    - 'docs/**'
   pull_request:
 
 jobs:
@@ -17,58 +17,58 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          sudo locale-gen en_US.UTF-8
-          sudo dpkg-reconfigure locales
-          sudo python -m pip install --upgrade pip
-          sudo pip install tox
-          sudo apt install software-properties-common -y
-          sudo add-apt-repository -y ppa:projectatomic/ppa
-          sudo apt update -y
-          sudo apt install build-essential findutils -y
-          sudo apt install podman -y
-      - name: Print podman version
-        run: |
-          podman -v
-      - name: Configure podman to use cgroupfs as cgroup manager
-        run: |
-          mkdir -p ~/.config/containers
-          echo 'cgroup_manager = "cgroupfs"' > ~/.config/containers/libpod.conf
-      - name: Log into GitHub Container Registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-            podman login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-      - id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
-      - name: Build or reuse the toolbox container image
-        run: |
-          # The following array defines the expressions that
-          # when matching the container image for the toolbox
-          # will be created from scratch, otherwise we reuse
-          # it from the latest build.
-          check_list=('toolbox' 'Makefile' 'tests' 'scripts')
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo locale-gen en_US.UTF-8
+        sudo dpkg-reconfigure locales
+        sudo python -m pip install --upgrade pip
+        sudo pip install tox
+        sudo apt install software-properties-common -y
+        sudo add-apt-repository -y ppa:projectatomic/ppa
+        sudo apt update -y
+        sudo apt install build-essential findutils -y
+        sudo apt install podman -y
+    - name: Print podman version
+      run: |
+        podman -v
+    - name: Configure podman to use cgroupfs as cgroup manager
+      run: |
+        mkdir -p ~/.config/containers
+        echo 'cgroup_manager = "cgroupfs"' > ~/.config/containers/libpod.conf
+    - name: Log into GitHub Container Registry
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | \
+          podman login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+    - id: file_changes
+      uses: trilom/file-changes-action@v1.2.4
+    - name: Build or reuse the toolbox container image
+      run: |
+        # The following array defines the expressions that
+        # when matching the container image for the toolbox
+        # will be created from scratch, otherwise we reuse
+        # it from the latest build.
+        check_list=('toolbox' 'Makefile' 'tests' 'scripts')
 
-          REUSE=1
-          filez=( $(echo '${{ steps.file_changes.outputs.files }}' | jq -c '.[]') )
-          for file in "${filez[@]}"; do
-            for index in ${!check_list[*]}; do
-              if [[ "${file}" == *"${check_list[$index]}"* ]]; then
-                echo "We need to re-create the toolbox container image"
-                echo "${check_list[$index]} is in ${file}"
-                REUSE=0
-              fi
-            done
+        REUSE=1
+        filez=( $(echo '${{ steps.file_changes.outputs.files }}' | jq -c '.[]') )
+        for file in "${filez[@]}"; do
+          for index in ${!check_list[*]}; do
+            if [[ "${file}" == *"${check_list[$index]}"* ]]; then
+              echo "We need to re-create the toolbox container image"
+              echo "${check_list[$index]} is in ${file}"
+              REUSE=0
+            fi
           done
-          REUSE_TOOLBOX=$REUSE NO_VAGRANT=1 make toolbox-build
-      - name: Run all the tests non OpenStack dependant
-        run: |
-          ./toolbox/run make test-fast
+        done
+        REUSE_TOOLBOX=$REUSE NO_VAGRANT=1 make toolbox-build
+    - name: Run all the tests non OpenStack dependant
+      run: |
+        ./toolbox/run make test-fast
 
   functional:
     needs: build
@@ -81,7 +81,7 @@ jobs:
       rabbitmq:
         image: rabbitmq:latest
         ports:
-          - 5672:5672
+        - 5672:5672
         options: >-
           --health-cmd "rabbitmqctl node_health_check"
           --health-interval 10s
@@ -93,54 +93,54 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_ALLOW_EMPTY_PASSWORD: true
         ports:
-          - 3306:3306
+        - 3306:3306
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          sudo locale-gen en_US.UTF-8
-          sudo dpkg-reconfigure locales
-          # We use ppa:projectatomic repo to install podman
-          sudo add-apt-repository -y ppa:projectatomic/ppa
-          sudo apt install podman -y
-          sudo apt remove mysql-server mysql-server -y
-          # MySQL requirements
-          sudo apt install python3-mysqldb libmysqlclient-dev mysql-client -y
-          # Httplib2 requirements
-          # We need to install this library un purpose, if not the devstack
-          # installer will crash as pip is not able to determine if its
-          # installed or not
-          sudo apt install python3-httplib2 -y
-          # We need to be sure we use the latest versions of
-          # pip, virtualenv and setuptools
-          sudo python -m pip install --upgrade pip
-          sudo python -m pip install --upgrade virtualenv
-          sudo python -m pip install --upgrade setuptools
-      - name: Verify MySQL connection from container
-        run: >-
-          mysql \
-            --host 127.0.0.1 \
-            -P 3306 \
-            -uroot \
-            -proot \
-            -e "SHOW DATABASES"
-          mysql \
-            --host 127.0.0.1 \
-            -P 3306 \
-            -uroot \
-            -proot \
-            -e 'USE mysql;
-                DELETE FROM `user` WHERE `Host` != "%" AND `User`="root";
-                FLUSH PRIVILEGES;'
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo locale-gen en_US.UTF-8
+        sudo dpkg-reconfigure locales
+        # We use ppa:projectatomic repo to install podman
+        sudo add-apt-repository -y ppa:projectatomic/ppa
+        sudo apt install podman -y
+        sudo apt remove mysql-server mysql-server -y
+        # MySQL requirements
+        sudo apt install python3-mysqldb libmysqlclient-dev mysql-client -y
+        # Httplib2 requirements
+        # We need to install this library un purpose, if not the devstack
+        # installer will crash as pip is not able to determine if its
+        # installed or not
+        sudo apt install python3-httplib2 -y
+        # We need to be sure we use the latest versions of
+        # pip, virtualenv and setuptools
+        sudo python -m pip install --upgrade pip
+        sudo python -m pip install --upgrade virtualenv
+        sudo python -m pip install --upgrade setuptools
+    - name: Verify MySQL connection from container
+      run: >-
+        mysql \
+          --host 127.0.0.1 \
+          -P 3306 \
+          -uroot \
+          -proot \
+          -e "SHOW DATABASES"
+        mysql \
+          --host 127.0.0.1 \
+          -P 3306 \
+          -uroot \
+          -proot \
+          -e 'USE mysql;
+              DELETE FROM `user` WHERE `Host` != "%" AND `User`="root";
+              FLUSH PRIVILEGES;'
       # Devstack is not able to configure an external MySQL backend.
       # There is a mandatory DB server restart from the stack.sh script
       # that restart a service called mysql, even if the service is not
@@ -148,177 +148,177 @@ jobs:
       # In this case we configure the database to point to the external
       # database container and we mock a dummy service called "mysql"
       # to trick stack.sh and not fail.
-      - name: Create a dummy MySQL service to trick stack.sh
-        run: |
-          sudo tee /usr/mock.sh > /dev/null <<'EOF'
-          sleep 3600;
-          EOF
-          sudo chmod u+x /usr/mock.sh
-          sudo tee /lib/systemd/system/mysql.service > /dev/null <<'EOF'
-          [Unit]
-          Description=MySQL mock service
-          [Service]
-          Type=simple
-          ExecStart=/bin/bash /usr/mock.sh
-          [Install]
-          WantedBy=multi-user.target
-          EOF
-          sudo systemctl enable mysql.service
-          sudo systemctl start mysql.service
-          sudo systemctl restart mysql.service
-          sudo systemctl status mysql.service
+    - name: Create a dummy MySQL service to trick stack.sh
+      run: |
+        sudo tee /usr/mock.sh > /dev/null <<'EOF'
+        sleep 3600;
+        EOF
+        sudo chmod u+x /usr/mock.sh
+        sudo tee /lib/systemd/system/mysql.service > /dev/null <<'EOF'
+        [Unit]
+        Description=MySQL mock service
+        [Service]
+        Type=simple
+        ExecStart=/bin/bash /usr/mock.sh
+        [Install]
+        WantedBy=multi-user.target
+        EOF
+        sudo systemctl enable mysql.service
+        sudo systemctl start mysql.service
+        sudo systemctl restart mysql.service
+        sudo systemctl status mysql.service
       # there is a script inside devstack that checks to ensure rabbit is
       # enabled.  because we're using rabbit in a container and devstack cannot
       # manage it, we mock a service so it won't fail.
-      - name: Create a dummy rabbit service to trick devstack/lib/rpc_backend
-        run: |
-          sudo tee /usr/mock.sh > /dev/null <<'EOF'
-          sleep 3600;
-          EOF
-          sudo chmod u+x /usr/mock.sh
-          sudo tee /lib/systemd/system/rabbit.service > /dev/null <<'EOF'
-          [Unit]
-          Description=rabbit mock service
-          [Service]
-          Type=simple
-          ExecStart=/bin/bash /usr/mock.sh
-          [Install]
-          WantedBy=multi-user.target
-          EOF
-          sudo systemctl enable rabbit.service
-          sudo systemctl start rabbit.service
-          sudo systemctl restart rabbit.service
-          sudo systemctl status rabbit.service
-      - name: Configure podman to use cgroupfs as cgroup manager
-        run: |
-          mkdir -p ~/.config/containers
-          echo 'cgroup_manager = "cgroupfs"' > ~/.config/containers/libpod.conf
-      - name: Log into GitHub Container Registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-            podman login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-      - id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
-      - name: Build or reuse the toolbox container image
-        run: |
-          # The following array defines the expressions that
-          # when matching the container image for the toolbox
-          # will be created from scratch, otherwise we reuse
-          # it from the latest build.
-          check_list=('toolbox' 'Makefile' 'tests' 'scripts')
+    - name: Create a dummy rabbit service to trick devstack/lib/rpc_backend
+      run: |
+        sudo tee /usr/mock.sh > /dev/null <<'EOF'
+        sleep 3600;
+        EOF
+        sudo chmod u+x /usr/mock.sh
+        sudo tee /lib/systemd/system/rabbit.service > /dev/null <<'EOF'
+        [Unit]
+        Description=rabbit mock service
+        [Service]
+        Type=simple
+        ExecStart=/bin/bash /usr/mock.sh
+        [Install]
+        WantedBy=multi-user.target
+        EOF
+        sudo systemctl enable rabbit.service
+        sudo systemctl start rabbit.service
+        sudo systemctl restart rabbit.service
+        sudo systemctl status rabbit.service
+    - name: Configure podman to use cgroupfs as cgroup manager
+      run: |
+        mkdir -p ~/.config/containers
+        echo 'cgroup_manager = "cgroupfs"' > ~/.config/containers/libpod.conf
+    - name: Log into GitHub Container Registry
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | \
+          podman login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+    - id: file_changes
+      uses: trilom/file-changes-action@v1.2.4
+    - name: Build or reuse the toolbox container image
+      run: |
+        # The following array defines the expressions that
+        # when matching the container image for the toolbox
+        # will be created from scratch, otherwise we reuse
+        # it from the latest build.
+        check_list=('toolbox' 'Makefile' 'tests' 'scripts')
 
-          REUSE=1
-          filez=( $(echo '${{ steps.file_changes.outputs.files }}' | jq -c '.[]') )
-          for file in "${filez[@]}"; do
-            for index in ${!check_list[*]}; do
-              if [[ "${file}" == *"${check_list[$index]}"* ]]; then
-                echo "We need to re-create the toolbox container image"
-                echo "${check_list[$index]} is in ${file}"
-                REUSE=0
-              fi
-            done
+        REUSE=1
+        filez=( $(echo '${{ steps.file_changes.outputs.files }}' | jq -c '.[]') )
+        for file in "${filez[@]}"; do
+          for index in ${!check_list[*]}; do
+            if [[ "${file}" == *"${check_list[$index]}"* ]]; then
+              echo "We need to re-create the toolbox container image"
+              echo "${check_list[$index]} is in ${file}"
+              REUSE=0
+            fi
           done
-          REUSE_TOOLBOX=$REUSE NO_VAGRANT=1 make toolbox-build
+        done
+        REUSE_TOOLBOX=$REUSE NO_VAGRANT=1 make toolbox-build
       # We're hitting filesystem ownership issue on some GH Actions workers:
       # https://ubuntuforums.org/showthread.php?t=2406453
-      - name: Make sure filesystem ownership is correct
-        run: |
-          set -x
-          sudo chown root:root /
-          sudo chown root:root /bin
-      - name: Clone devstack
-        run: |
-          git clone https://opendev.org/openstack/devstack
-      - name: Configure devstack
-        run: |
-          DIR=$(pwd)
-          cd devstack
-          cat << EOF > local.conf
-          [[local|localrc]]
-          USE_PYTHON3=True
-          SERVICE_PASSWORD=devstack
-          ADMIN_PASSWORD=devstack
-          SERVICE_TOKEN=devstack
-          DATABASE_PASSWORD=root
-          DATABASE_TYPE=mysql
-          HOST_IP=127.0.0.1
-          SERVICE_HOST=127.0.0.1
-          DATABASE_HOST=127.0.0.1
-          RABBIT_HOST=127.0.0.1
-          RABBIT_USERID=guest
-          RABBIT_PASSWORD=guest
-          VIRT_DRIVER=fake
-          CELLSV2_SETUP="singleconductor"
-          OS_PLACEMENT_CONFIG_DIR=/etc/nova
-          # Pre-requisite
-          ENABLED_SERVICES=mysql,key
-          # Neutron
-          ENABLED_SERVICES+=,q-svc,q-dhcp,q-meta,q-l3,q-agt
-          # Nova
-          ENABLED_SERVICES+=,n-sproxy,n-api,n-cond
-          # Placement
-          ENABLED_SERVICES+=,placement,placement-api,placement-client
-          # Glance
-          ENABLED_SERVICES+=,g-api
-          [[post-config|/etc/nova/nova.conf]]
-          [placement]
-          auth_type = password
-          auth_url = http://127.0.0.1/identity
-          password = devstack
-          project_domain_name = Default
-          project_name = service
-          user_domain_name = Default
-          username = nova
-          [compute]
-          live_migration_wait_for_vif_plug=True
-          [libvirt]
-          live_migration_uri = qemu+ssh://root@%s/system
-          cpu_mode = host-passthrough
-          virt_type = qemu
-          EOF
-          cat local.conf
-          sudo ./tools/create-stack-user.sh
-          sudo mv $DIR/devstack /opt/stack/devstack
-          sudo chown -R stack: /opt/stack/devstack
-      - name: Start devstack
-        run: |
-          sudo -iu stack bash -c 'cd /opt/stack/devstack; ./stack.sh'
-      - name: Get debug data
-        if: failure()
-        run: |
-          echo ">>> Journal logs"
-          sudo journalctl --no-pager
-      - name: See "systemctl status placement-api.service" for details.
-        if: failure()
-        run: |
-          sudo systemctl status placement-api.service
-      - name: See "journalctl -xe" for details.
-        if: failure()
-        run: |
-          sudo journalctl -xe
-      - name: Run sanity checks
-        run: |
-          echo "- Get network and routers list"
-          openstack --os-cloud devstack-admin --os-region RegionOne network list
-          openstack --os-cloud devstack-admin --os-region RegionOne router list
-      - name: Check keystone
-        run: |
-          echo "- Get endpoints"
-          openstack --os-cloud devstack-admin --os-region RegionOne endpoint list
-      - name: Connect functional tests to devstack
-        run: |
-          cp /etc/openstack/clouds.yaml tests/clouds.yaml && \
-          ./toolbox/run ./scripts/auth-from-clouds.sh \
-              --config tests/clouds.yaml \
-              --src devstack \
-              --dst devstack-alt \
-              > tests/auth_tenant.yml && \
-          ./toolbox/run ./scripts/auth-from-clouds.sh \
-              --config tests/clouds.yaml \
-              --src devstack-admin \
-              --dst devstack-admin \
-              > tests/auth_admin.yml && \
-          rm tests/clouds.yaml
-      - name: Run functional tests
-        run: |
-          ./toolbox/run make test-func
+    - name: Make sure filesystem ownership is correct
+      run: |
+        set -x
+        sudo chown root:root /
+        sudo chown root:root /bin
+    - name: Clone devstack
+      run: |
+        git clone https://opendev.org/openstack/devstack
+    - name: Configure devstack
+      run: |
+        DIR=$(pwd)
+        cd devstack
+        cat << EOF > local.conf
+        [[local|localrc]]
+        USE_PYTHON3=True
+        SERVICE_PASSWORD=devstack
+        ADMIN_PASSWORD=devstack
+        SERVICE_TOKEN=devstack
+        DATABASE_PASSWORD=root
+        DATABASE_TYPE=mysql
+        HOST_IP=127.0.0.1
+        SERVICE_HOST=127.0.0.1
+        DATABASE_HOST=127.0.0.1
+        RABBIT_HOST=127.0.0.1
+        RABBIT_USERID=guest
+        RABBIT_PASSWORD=guest
+        VIRT_DRIVER=fake
+        CELLSV2_SETUP="singleconductor"
+        OS_PLACEMENT_CONFIG_DIR=/etc/nova
+        # Pre-requisite
+        ENABLED_SERVICES=mysql,key
+        # Neutron
+        ENABLED_SERVICES+=,q-svc,q-dhcp,q-meta,q-l3,q-agt
+        # Nova
+        ENABLED_SERVICES+=,n-sproxy,n-api,n-cond
+        # Placement
+        ENABLED_SERVICES+=,placement,placement-api,placement-client
+        # Glance
+        ENABLED_SERVICES+=,g-api
+        [[post-config|/etc/nova/nova.conf]]
+        [placement]
+        auth_type = password
+        auth_url = http://127.0.0.1/identity
+        password = devstack
+        project_domain_name = Default
+        project_name = service
+        user_domain_name = Default
+        username = nova
+        [compute]
+        live_migration_wait_for_vif_plug=True
+        [libvirt]
+        live_migration_uri = qemu+ssh://root@%s/system
+        cpu_mode = host-passthrough
+        virt_type = qemu
+        EOF
+        cat local.conf
+        sudo ./tools/create-stack-user.sh
+        sudo mv $DIR/devstack /opt/stack/devstack
+        sudo chown -R stack: /opt/stack/devstack
+    - name: Start devstack
+      run: |
+        sudo -iu stack bash -c 'cd /opt/stack/devstack; ./stack.sh'
+    - name: Get debug data
+      if: failure()
+      run: |
+        echo ">>> Journal logs"
+        sudo journalctl --no-pager
+    - name: See "systemctl status placement-api.service" for details.
+      if: failure()
+      run: |
+        sudo systemctl status placement-api.service
+    - name: See "journalctl -xe" for details.
+      if: failure()
+      run: |
+        sudo journalctl -xe
+    - name: Run sanity checks
+      run: |
+        echo "- Get network and routers list"
+        openstack --os-cloud devstack-admin --os-region RegionOne network list
+        openstack --os-cloud devstack-admin --os-region RegionOne router list
+    - name: Check keystone
+      run: |
+        echo "- Get endpoints"
+        openstack --os-cloud devstack-admin --os-region RegionOne endpoint list
+    - name: Connect functional tests to devstack
+      run: |
+        cp /etc/openstack/clouds.yaml tests/clouds.yaml && \
+        ./toolbox/run ./scripts/auth-from-clouds.sh \
+            --config tests/clouds.yaml \
+            --src devstack \
+            --dst devstack-alt \
+            > tests/auth_tenant.yml && \
+        ./toolbox/run ./scripts/auth-from-clouds.sh \
+            --config tests/clouds.yaml \
+            --src devstack-admin \
+            --dst devstack-admin \
+            > tests/auth_admin.yml && \
+        rm tests/clouds.yaml
+    - name: Run functional tests
+      run: |
+        ./toolbox/run make test-func

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -1,41 +1,40 @@
----
 name: container-image-build
 on:
   push:
     paths-ignore:
-      - 'doc/**'
+    - 'doc/**'
 jobs:
   push_to_reg:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: |
-          sudo locale-gen en_US.UTF-8
-          sudo dpkg-reconfigure locales
-          sudo python -m pip install --upgrade pip
-          sudo pip install tox
-          sudo apt install software-properties-common -y
-          sudo add-apt-repository -y ppa:projectatomic/ppa
-          sudo apt update -y
-          sudo apt install build-essential findutils -y
-          sudo apt install podman -y
-      - name: Build os-migrate image
-        run: |
-          # The default tag is localhost/os_migrate_toolbox:latest
-          make toolbox-build
-      - name: Log into GitHub Container Registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-            podman login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-      - name: Push os-migrate image to GitHub Container Registry
-        run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/os_migrate_toolbox
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          [ "$VERSION" == "master" ] && VERSION=latest
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          podman tag localhost/os_migrate_toolbox $IMAGE_ID:$VERSION
-          podman push $IMAGE_ID:$VERSION
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        sudo locale-gen en_US.UTF-8
+        sudo dpkg-reconfigure locales
+        sudo python -m pip install --upgrade pip
+        sudo pip install tox
+        sudo apt install software-properties-common -y
+        sudo add-apt-repository -y ppa:projectatomic/ppa
+        sudo apt update -y
+        sudo apt install build-essential findutils -y
+        sudo apt install podman -y
+    - name: Build os-migrate image
+      run: |
+        # The default tag is localhost/os_migrate_toolbox:latest
+        make toolbox-build
+    - name: Log into GitHub Container Registry
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | \
+          podman login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+    - name: Push os-migrate image to GitHub Container Registry
+      run: |
+        IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/os_migrate_toolbox
+        IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+        [ "$VERSION" == "master" ] && VERSION=latest
+        echo IMAGE_ID=$IMAGE_ID
+        echo VERSION=$VERSION
+        podman tag localhost/os_migrate_toolbox $IMAGE_ID:$VERSION
+        podman push $IMAGE_ID:$VERSION

--- a/.github/workflows/docs-build-pr.yml
+++ b/.github/workflows/docs-build-pr.yml
@@ -1,33 +1,32 @@
----
 name: docs-build-pr
 on:
   pull_request:
     branches:
-      - main
+    - main
     paths:
-      - 'docs/**'
+    - 'docs/**'
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Use checkout v2 with all git log available
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: |
-          sudo locale-gen en_US.UTF-8
-          sudo dpkg-reconfigure locales
-          sudo add-apt-repository -y ppa:projectatomic/ppa
-          sudo apt update -y
-          sudo apt install podman -y
-      - name: Fetch toolbox image
-        run: |
-          REUSE_TOOLBOX=1 NO_VAGRANT=1 make toolbox-build
-      - name: Render the documentation
-        run: |
-          ./toolbox/run make docs
-      - uses: actions/upload-artifact@v1
-        with:
-          name: DocumentationHTML
-          path: docs/src/_build/html/
+    - name: Use checkout v2 with all git log available
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Install dependencies
+      run: |
+        sudo locale-gen en_US.UTF-8
+        sudo dpkg-reconfigure locales
+        sudo add-apt-repository -y ppa:projectatomic/ppa
+        sudo apt update -y
+        sudo apt install podman -y
+    - name: Fetch toolbox image
+      run: |
+        REUSE_TOOLBOX=1 NO_VAGRANT=1 make toolbox-build
+    - name: Render the documentation
+      run: |
+        ./toolbox/run make docs
+    - uses: actions/upload-artifact@v1
+      with:
+        name: DocumentationHTML
+        path: docs/src/_build/html/

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,50 +1,49 @@
----
 name: docs-build
 on:
   push:
     branches:
-      - main
+    - main
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Use checkout v2 with all git log available
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: |
-          sudo locale-gen en_US.UTF-8
-          sudo dpkg-reconfigure locales
-          sudo add-apt-repository -y ppa:projectatomic/ppa
-          sudo apt update -y
-          sudo apt install podman -y
-      - name: Fetch toolbox image
-        run: |
-          REUSE_TOOLBOX=1 NO_VAGRANT=1 make toolbox-build
-      - name: Render the documentation
-        run: |
-          ./toolbox/run make docs
-      - uses: actions/upload-artifact@v1
-        with:
-          name: DocumentationHTML
-          path: docs/src/_build/html/
-      - name: Commit documentation changes
-        run: |
-          git clone https://github.com/os-migrate/os-migrate.git \
-            --branch gh-pages \
-            --single-branch gh-pages
-          cp -r docs/src/_build/html/* gh-pages/
-          cd gh-pages
-          touch .nojekyll
-          git config --local user.email "bot@os-migrate"
-          git config --local user.name "os-migrate bot"
-          git add .
-          git commit -m "Update documentation" -a || true
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          force: true
-          branch: gh-pages
-          directory: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Use checkout v2 with all git log available
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Install dependencies
+      run: |
+        sudo locale-gen en_US.UTF-8
+        sudo dpkg-reconfigure locales
+        sudo add-apt-repository -y ppa:projectatomic/ppa
+        sudo apt update -y
+        sudo apt install podman -y
+    - name: Fetch toolbox image
+      run: |
+        REUSE_TOOLBOX=1 NO_VAGRANT=1 make toolbox-build
+    - name: Render the documentation
+      run: |
+        ./toolbox/run make docs
+    - uses: actions/upload-artifact@v1
+      with:
+        name: DocumentationHTML
+        path: docs/src/_build/html/
+    - name: Commit documentation changes
+      run: |
+        git clone https://github.com/os-migrate/os-migrate.git \
+          --branch gh-pages \
+          --single-branch gh-pages
+        cp -r docs/src/_build/html/* gh-pages/
+        cd gh-pages
+        touch .nojekyll
+        git config --local user.email "bot@os-migrate"
+        git config --local user.name "os-migrate bot"
+        git add .
+        git commit -m "Update documentation" -a || true
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        force: true
+        branch: gh-pages
+        directory: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/os_migrate/galaxy.yml
+++ b/os_migrate/galaxy.yml
@@ -3,19 +3,19 @@ name: os_migrate
 version: 0.6.0
 readme: README.md
 authors:
-  - Jiri Stransky <jistr@redhat.com>
-  - Carlos Camacho <ccamacho@redhat.com>
-  - Ryan Brady <rbrady@redhat.com>
-  - Sagi Shnaidman <sshnaidm@redhat.com>
-  - Matthew Arnold <marnold@redhat.com>
+- Jiri Stransky <jistr@redhat.com>
+- Carlos Camacho <ccamacho@redhat.com>
+- Ryan Brady <rbrady@redhat.com>
+- Sagi Shnaidman <sshnaidm@redhat.com>
+- Matthew Arnold <marnold@redhat.com>
   # Keep this at the bottom
-  - os-migrate (https://github.com/os-migrate)
+- os-migrate (https://github.com/os-migrate)
 description: OpenStack tenant migration tooling
 license:
-  - Apache-2.0
+- Apache-2.0
 tags:
-  - openstack
-  - migrations
+- openstack
+- migrations
 dependencies: {}
 repository: 'https://github.com/os-migrate/os-migrate'
 homepage: 'https://github.com/os-migrate/os-migrate'

--- a/os_migrate/playbooks/delete_conversion_hosts.yml
+++ b/os_migrate/playbooks/delete_conversion_hosts.yml
@@ -1,45 +1,55 @@
 - hosts: migrator
   tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: conv_hosts_inventory.yml
-      vars:
-        ignore_missing_conversion_hosts: true
+  - vars:
+      ignore_missing_conversion_hosts: true
 
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+      tasks_from: conv_hosts_inventory.yml
 - hosts: conversion_hosts
   # Unregistration is best-effort. If the conversion hosts faced some
   # issues and are unreachable, we don't want the host deletion to
   # fail too.
   ignore_unreachable: true
   tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: unregister.yml
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+      tasks_from: unregister.yml
 
 - hosts: migrator
   tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: delete.yml
-      vars:
-        os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
-        os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-        os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
-        os_migrate_conversion_validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-        os_migrate_conversion_ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-        os_migrate_conversion_client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-        os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-      when: os_migrate_delete_src_conversion_host|default(true)|bool
+  - vars:
+      os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
+      os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit)\
+        \ }}"
+      os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit)\
+        \ }}"
+      os_migrate_conversion_validate_certs: "{{ os_migrate_src_validate_certs|default(omit)\
+        \ }}"
+      os_migrate_conversion_ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+      os_migrate_conversion_client_cert: "{{ os_migrate_src_client_cert|default(omit)\
+        \ }}"
+      os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit)\
+        \ }}"
+    when: os_migrate_delete_src_conversion_host|default(true)|bool
 
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: delete.yml
-      vars:
-        os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
-        os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
-        os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-        os_migrate_conversion_validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-        os_migrate_conversion_ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-        os_migrate_conversion_client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-        os_migrate_conversion_client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-      when: os_migrate_delete_dst_conversion_host|default(true)|bool
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+      tasks_from: delete.yml
+  - vars:
+      os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
+      os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit)\
+        \ }}"
+      os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit)\
+        \ }}"
+      os_migrate_conversion_validate_certs: "{{ os_migrate_dst_validate_certs|default(omit)\
+        \ }}"
+      os_migrate_conversion_ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+      os_migrate_conversion_client_cert: "{{ os_migrate_dst_client_cert|default(omit)\
+        \ }}"
+      os_migrate_conversion_client_key: "{{ os_migrate_dst_client_key|default(omit)\
+        \ }}"
+    when: os_migrate_delete_dst_conversion_host|default(true)|bool
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+      tasks_from: delete.yml

--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -1,69 +1,83 @@
 - hosts: migrator
   tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-      vars:
-        os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
-        os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-        os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
-        os_migrate_conversion_validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-        os_migrate_conversion_ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-        os_migrate_conversion_client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-        os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-        os_migrate_conversion_flavor_name:
-          "{{ os_migrate_src_conversion_flavor_name|default(omit) }}"
-        os_migrate_conversion_image_name: "{{ os_migrate_src_conversion_image_name|default(omit) }}"
-        os_migrate_conversion_external_network_name:
-          "{{ os_migrate_src_conversion_external_network_name }}"
-        os_migrate_conversion_net_mtu: "{{ os_migrate_src_conversion_net_mtu|default(omit) }}"
-        os_migrate_conversion_subnet_dns_nameservers:
-          "{{ os_migrate_src_conversion_subnet_dns_nameservers|default(omit) }}"
-      when: os_migrate_deploy_src_conversion_host|default(true)|bool
+  - vars:
+      os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
+      os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit)\
+        \ }}"
+      os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit)\
+        \ }}"
+      os_migrate_conversion_validate_certs: "{{ os_migrate_src_validate_certs|default(omit)\
+        \ }}"
+      os_migrate_conversion_ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+      os_migrate_conversion_client_cert: "{{ os_migrate_src_client_cert|default(omit)\
+        \ }}"
+      os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit)\
+        \ }}"
+      os_migrate_conversion_flavor_name: "{{ os_migrate_src_conversion_flavor_name|default(omit)\
+        \ }}"
+      os_migrate_conversion_image_name: "{{ os_migrate_src_conversion_image_name|default(omit)\
+        \ }}"
+      os_migrate_conversion_external_network_name: "{{ os_migrate_src_conversion_external_network_name\
+        \ }}"
+      os_migrate_conversion_net_mtu: "{{ os_migrate_src_conversion_net_mtu|default(omit)\
+        \ }}"
+      os_migrate_conversion_subnet_dns_nameservers: "{{ os_migrate_src_conversion_subnet_dns_nameservers|default(omit)\
+        \ }}"
+    when: os_migrate_deploy_src_conversion_host|default(true)|bool
 
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-      vars:
-        os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
-        os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
-        os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-        os_migrate_conversion_validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-        os_migrate_conversion_ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-        os_migrate_conversion_client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-        os_migrate_conversion_client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-        os_migrate_conversion_flavor_name:
-          "{{ os_migrate_dst_conversion_flavor_name|default(omit) }}"
-        os_migrate_conversion_image_name: "{{ os_migrate_dst_conversion_image_name|default(omit) }}"
-        os_migrate_conversion_external_network_name:
-          "{{ os_migrate_dst_conversion_external_network_name }}"
-        os_migrate_conversion_net_mtu: "{{ os_migrate_dst_conversion_net_mtu|default(omit) }}"
-        os_migrate_conversion_subnet_dns_nameservers:
-          "{{ os_migrate_dst_conversion_subnet_dns_nameservers|default(omit) }}"
-      when: os_migrate_deploy_dst_conversion_host|default(true)|bool
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+  - vars:
+      os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
+      os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit)\
+        \ }}"
+      os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit)\
+        \ }}"
+      os_migrate_conversion_validate_certs: "{{ os_migrate_dst_validate_certs|default(omit)\
+        \ }}"
+      os_migrate_conversion_ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+      os_migrate_conversion_client_cert: "{{ os_migrate_dst_client_cert|default(omit)\
+        \ }}"
+      os_migrate_conversion_client_key: "{{ os_migrate_dst_client_key|default(omit)\
+        \ }}"
+      os_migrate_conversion_flavor_name: "{{ os_migrate_dst_conversion_flavor_name|default(omit)\
+        \ }}"
+      os_migrate_conversion_image_name: "{{ os_migrate_dst_conversion_image_name|default(omit)\
+        \ }}"
+      os_migrate_conversion_external_network_name: "{{ os_migrate_dst_conversion_external_network_name\
+        \ }}"
+      os_migrate_conversion_net_mtu: "{{ os_migrate_dst_conversion_net_mtu|default(omit)\
+        \ }}"
+      os_migrate_conversion_subnet_dns_nameservers: "{{ os_migrate_dst_conversion_subnet_dns_nameservers|default(omit)\
+        \ }}"
+    when: os_migrate_deploy_dst_conversion_host|default(true)|bool
 
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: link_prepare.yml
-      when: os_migrate_link_conversion_hosts|default(true)|bool
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+  - when: os_migrate_link_conversion_hosts|default(true)|bool
 
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+      tasks_from: link_prepare.yml
 - hosts: os_migrate_conv_src
   tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: link_insert_authorized_key.yml
-      when: os_migrate_link_conversion_hosts|default(true)|bool
+  - when: os_migrate_link_conversion_hosts|default(true)|bool
 
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+      tasks_from: link_insert_authorized_key.yml
 - hosts: os_migrate_conv_dst
   tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: link_insert_private_key.yml
-      when: os_migrate_link_conversion_hosts|default(true)|bool
+  - when: os_migrate_link_conversion_hosts|default(true)|bool
 
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+      tasks_from: link_insert_private_key.yml
 - hosts: conversion_hosts
   tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host_content
-      when: os_migrate_conversion_host_content_install|default(true)|bool
+  - when: os_migrate_conversion_host_content_install|default(true)|bool
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host_content
   vars:
     ansible_become_user: root
     ansible_become: true

--- a/os_migrate/playbooks/export_flavors.yml
+++ b/os_migrate/playbooks/export_flavors.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_flavors
+  - os_migrate.os_migrate.export_flavors

--- a/os_migrate/playbooks/export_images.yml
+++ b/os_migrate/playbooks/export_images.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_images
+  - os_migrate.os_migrate.export_images

--- a/os_migrate/playbooks/export_keypairs.yml
+++ b/os_migrate/playbooks/export_keypairs.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_keypairs
+  - os_migrate.os_migrate.export_keypairs

--- a/os_migrate/playbooks/export_networks.yml
+++ b/os_migrate/playbooks/export_networks.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_networks
+  - os_migrate.os_migrate.export_networks

--- a/os_migrate/playbooks/export_projects.yml
+++ b/os_migrate/playbooks/export_projects.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_projects
+  - os_migrate.os_migrate.export_projects

--- a/os_migrate/playbooks/export_router_interfaces.yml
+++ b/os_migrate/playbooks/export_router_interfaces.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_router_interfaces
+  - os_migrate.os_migrate.export_router_interfaces

--- a/os_migrate/playbooks/export_routers.yml
+++ b/os_migrate/playbooks/export_routers.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_routers
+  - os_migrate.os_migrate.export_routers

--- a/os_migrate/playbooks/export_security_group_rules.yml
+++ b/os_migrate/playbooks/export_security_group_rules.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_security_group_rules
+  - os_migrate.os_migrate.export_security_group_rules

--- a/os_migrate/playbooks/export_security_groups.yml
+++ b/os_migrate/playbooks/export_security_groups.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_security_groups
+  - os_migrate.os_migrate.export_security_groups

--- a/os_migrate/playbooks/export_subnets.yml
+++ b/os_migrate/playbooks/export_subnets.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_subnets
+  - os_migrate.os_migrate.export_subnets

--- a/os_migrate/playbooks/export_users.yml
+++ b/os_migrate/playbooks/export_users.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_users
+  - os_migrate.os_migrate.export_users

--- a/os_migrate/playbooks/export_workloads.yml
+++ b/os_migrate/playbooks/export_workloads.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.export_workloads
+  - os_migrate.os_migrate.export_workloads

--- a/os_migrate/playbooks/import_flavors.yml
+++ b/os_migrate/playbooks/import_flavors.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_flavors
+  - os_migrate.os_migrate.import_flavors

--- a/os_migrate/playbooks/import_images.yml
+++ b/os_migrate/playbooks/import_images.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_images
+  - os_migrate.os_migrate.import_images

--- a/os_migrate/playbooks/import_keypairs.yml
+++ b/os_migrate/playbooks/import_keypairs.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_keypairs
+  - os_migrate.os_migrate.import_keypairs

--- a/os_migrate/playbooks/import_networks.yml
+++ b/os_migrate/playbooks/import_networks.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_networks
+  - os_migrate.os_migrate.import_networks

--- a/os_migrate/playbooks/import_projects.yml
+++ b/os_migrate/playbooks/import_projects.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_projects
+  - os_migrate.os_migrate.import_projects

--- a/os_migrate/playbooks/import_router_interfaces.yml
+++ b/os_migrate/playbooks/import_router_interfaces.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_router_interfaces
+  - os_migrate.os_migrate.import_router_interfaces

--- a/os_migrate/playbooks/import_routers.yml
+++ b/os_migrate/playbooks/import_routers.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_routers
+  - os_migrate.os_migrate.import_routers

--- a/os_migrate/playbooks/import_security_group_rules.yml
+++ b/os_migrate/playbooks/import_security_group_rules.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_security_group_rules
+  - os_migrate.os_migrate.import_security_group_rules

--- a/os_migrate/playbooks/import_security_groups.yml
+++ b/os_migrate/playbooks/import_security_groups.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_security_groups
+  - os_migrate.os_migrate.import_security_groups

--- a/os_migrate/playbooks/import_subnets.yml
+++ b/os_migrate/playbooks/import_subnets.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_subnets
+  - os_migrate.os_migrate.import_subnets

--- a/os_migrate/playbooks/import_users.yml
+++ b/os_migrate/playbooks/import_users.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_users
+  - os_migrate.os_migrate.import_users

--- a/os_migrate/playbooks/import_workloads.yml
+++ b/os_migrate/playbooks/import_workloads.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.import_workloads
+  - os_migrate.os_migrate.import_workloads

--- a/os_migrate/playbooks/validate_data_dir.yml
+++ b/os_migrate/playbooks/validate_data_dir.yml
@@ -1,3 +1,3 @@
 - hosts: migrator
   roles:
-    - os_migrate.os_migrate.validate_data_dir
+  - os_migrate.os_migrate.validate_data_dir

--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -4,12 +4,10 @@
 
 os_migrate_conversion_net_name: os_migrate_conv
 
-os_migrate_src_conversion_net_mtu: "{{
-  1400 if os_migrate_src_release > 10
-  else omit }}"
-os_migrate_dst_conversion_net_mtu: "{{
-  1400 if os_migrate_dst_release > 10
-  else omit }}"
+os_migrate_src_conversion_net_mtu: "{{ 1400 if os_migrate_src_release > 10 else omit\
+  \ }}"
+os_migrate_dst_conversion_net_mtu: "{{ 1400 if os_migrate_dst_release > 10 else omit\
+  \ }}"
 
 # If we install packages we need a DNS server working
 os_migrate_src_conversion_subnet_dns_nameservers: ['8.8.8.8']

--- a/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
@@ -1,5 +1,7 @@
 - name: discover conversion host
-  os_server_info:
+  register: _server_info
+
+  ansible.builtin.os_server_info:
     server: "{{ os_migrate_conversion_host_name }}*"
     auth: "{{ os_migrate_conversion_auth }}"
     auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
@@ -8,22 +10,22 @@
     ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
-  register: _server_info
-
 - name: fail when conversion host was not found
-  fail:
+  when:
+  - _server_info.openstack_servers|length == 0
+  - not ignore_missing_conversion_hosts|default(false)|bool
+
+  ansible.builtin.fail:
     msg: >-
       Nova server of name '{{ os_migrate_conversion_host_name }}' not
       found, it was meant to be used as {{ inventory_name }}
-  when:
-    - _server_info.openstack_servers|length == 0
-    - not ignore_missing_conversion_hosts|default(false)|bool
-
 - name: add conversion host to inventory
-  add_host:
+  when:
+  - _server_info.openstack_servers|length > 0
+  ansible.builtin.add_host:
     name: "{{ inventory_name }}"
     groups:
-      - conversion_hosts
+    - conversion_hosts
     ansible_ssh_host: "{{ _server_info.openstack_servers[0].accessIPv4 }}"
     ansible_ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
     ansible_ssh_private_key_file: "{{ os_migrate_conversion_keypair_private_path }}"
@@ -31,5 +33,3 @@
     # Generally conversion hosts act as cloud-user, not as
     # root. E.g. link ssh keys need to be added to cloud-user.
     ansible_become: false
-  when:
-    - _server_info.openstack_servers|length > 0

--- a/os_migrate/roles/conversion_host/tasks/conv_hosts_inventory.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_hosts_inventory.yml
@@ -1,28 +1,39 @@
 - name: add conversion hosts to inventory
-  include_tasks: conv_host_inventory.yml
   vars:
     inventory_name: "{{ item.inventory_name }}"
     os_migrate_conversion_auth: "{{ item.os_migrate_conversion_auth }}"
     os_migrate_conversion_auth_type: "{{ item.os_migrate_conversion_auth_type }}"
-    os_migrate_conversion_region_name: "{{ item.os_migrate_conversion_region_name }}"
-    os_migrate_conversion_validate_certs: "{{ item.os_migrate_conversion_validate_certs }}"
+    os_migrate_conversion_region_name: "{{ item.os_migrate_conversion_region_name\
+      \ }}"
+    os_migrate_conversion_validate_certs: "{{ item.os_migrate_conversion_validate_certs\
+      \ }}"
     os_migrate_conversion_ca_cert: "{{ item.os_migrate_conversion_ca_cert }}"
-    os_migrate_conversion_client_cert: "{{ item.os_migrate_conversion_client_cert }}"
+    os_migrate_conversion_client_cert: "{{ item.os_migrate_conversion_client_cert\
+      \ }}"
     os_migrate_conversion_client_key: "{{ item.os_migrate_conversion_client_key }}"
   loop:
-    - inventory_name: os_migrate_conv_src
-      os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
-      os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-      os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
-      os_migrate_conversion_validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      os_migrate_conversion_ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      os_migrate_conversion_client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - inventory_name: os_migrate_conv_dst
-      os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
-      os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
-      os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-      os_migrate_conversion_validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      os_migrate_conversion_ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      os_migrate_conversion_client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      os_migrate_conversion_client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+  - inventory_name: os_migrate_conv_src
+    os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
+    os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
+    os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit)\
+      \ }}"
+    os_migrate_conversion_validate_certs: "{{ os_migrate_src_validate_certs|default(omit)\
+      \ }}"
+    os_migrate_conversion_ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    os_migrate_conversion_client_cert: "{{ os_migrate_src_client_cert|default(omit)\
+      \ }}"
+    os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit)\
+      \ }}"
+  - inventory_name: os_migrate_conv_dst
+    os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
+    os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
+    os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit)\
+      \ }}"
+    os_migrate_conversion_validate_certs: "{{ os_migrate_dst_validate_certs|default(omit)\
+      \ }}"
+    os_migrate_conversion_ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    os_migrate_conversion_client_cert: "{{ os_migrate_dst_client_cert|default(omit)\
+      \ }}"
+    os_migrate_conversion_client_key: "{{ os_migrate_dst_client_key|default(omit)\
+      \ }}"
+  ansible.builtin.include_tasks: conv_host_inventory.yml

--- a/os_migrate/roles/conversion_host/tasks/delete.yml
+++ b/os_migrate/roles/conversion_host/tasks/delete.yml
@@ -1,5 +1,5 @@
 - name: delete os_migrate conversion host
-  os_server:
+  ansible.builtin.os_server:
     name: "{{ os_migrate_conversion_host_name }}"
     state: absent
     delete_fip: yes
@@ -13,7 +13,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion keypair
-  os_keypair:
+  ansible.builtin.os_keypair:
     name: "{{ os_migrate_conversion_keypair_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"
@@ -25,7 +25,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion security group
-  os_security_group:
+  ansible.builtin.os_security_group:
     name: "{{ os_migrate_conversion_secgroup_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"
@@ -37,7 +37,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion router
-  os_router:
+  ansible.builtin.os_router:
     name: "{{ os_migrate_conversion_router_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"
@@ -49,7 +49,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion subnet
-  os_subnet:
+  ansible.builtin.os_subnet:
     name: "{{ os_migrate_conversion_subnet_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"
@@ -61,7 +61,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion net
-  os_network:
+  ansible.builtin.os_network:
     name: "{{ os_migrate_conversion_net_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"

--- a/os_migrate/roles/conversion_host/tasks/generate_keypair.yml
+++ b/os_migrate/roles/conversion_host/tasks/generate_keypair.yml
@@ -1,8 +1,8 @@
 - name: create the keypair folder
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_conversion_keypair_private_path|dirname }}"
     state: directory
 
 - name: generate a keypair for the conversion host
-  openssh_keypair:
+  ansible.builtin.openssh_keypair:
     path: "{{ os_migrate_conversion_keypair_private_path }}"

--- a/os_migrate/roles/conversion_host/tasks/link_insert_authorized_key.yml
+++ b/os_migrate/roles/conversion_host/tasks/link_insert_authorized_key.yml
@@ -1,13 +1,14 @@
 - name: ensure .ssh exists
-  file:
+  ansible.builtin.file:
     path: "{{ ansible_env['HOME'] }}/.ssh"
     state: directory
     mode: 0700
 
 - name: insert conversion link public ssh key into authorized keys
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: "{{ ansible_env['HOME'] }}/.ssh/authorized_keys"
     marker: "# {mark} CONVERSION LINK KEY"
     create: yes
     mode: 0600
-    block: "{{ lookup('file', os_migrate_conversion_link_keypair_private_path + '.pub') }}"
+    block: "{{ lookup('file', os_migrate_conversion_link_keypair_private_path + '.pub')\
+      \ }}"

--- a/os_migrate/roles/conversion_host/tasks/link_insert_private_key.yml
+++ b/os_migrate/roles/conversion_host/tasks/link_insert_private_key.yml
@@ -1,11 +1,11 @@
 - name: ensure .ssh exists
-  file:
+  ansible.builtin.file:
     path: "{{ ansible_env['HOME'] }}/.ssh"
     state: directory
     mode: 0700
 
 - name: upload conversion link private ssh key
-  copy:
+  ansible.builtin.copy:
     dest: "{{ ansible_env['HOME'] }}/.ssh/id_rsa"
     src: "{{ os_migrate_conversion_link_keypair_private_path }}"
     mode: 0600

--- a/os_migrate/roles/conversion_host/tasks/link_prepare.yml
+++ b/os_migrate/roles/conversion_host/tasks/link_prepare.yml
@@ -1,17 +1,16 @@
 - name: add both conversion hosts to inventory
-  import_tasks: conv_hosts_inventory.yml
-
+  ansible.builtin.import_tasks: conv_hosts_inventory.yml
 - name: create folder for link keypairs
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_conversion_link_keypair_private_path|dirname }}"
     state: directory
 
 - name: generate a link keypair
-  openssh_keypair:
+  ansible.builtin.openssh_keypair:
     path: "{{ os_migrate_conversion_link_keypair_private_path }}"
 
 - name: wait for src conversion host reachability
-  wait_for:
+  ansible.builtin.wait_for:
     port: 22
     host: "{{ hostvars['os_migrate_conv_src']['ansible_ssh_host'] }}"
     search_regex: OpenSSH
@@ -19,7 +18,7 @@
     timeout: 600
 
 - name: wait for dst conversion host reachability
-  wait_for:
+  ansible.builtin.wait_for:
     port: 22
     host: "{{ hostvars['os_migrate_conv_dst']['ansible_ssh_host'] }}"
     search_regex: OpenSSH

--- a/os_migrate/roles/conversion_host/tasks/main.yml
+++ b/os_migrate/roles/conversion_host/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: generate os_migrate conversion keypair
-  include_tasks: generate_keypair.yml
   when: os_migrate_conversion_keypair_generate
 
+  ansible.builtin.include_tasks: generate_keypair.yml
 - name: create os_migrate conversion net
-  os_network:
+  ansible.builtin.os_network:
     name: "{{ os_migrate_conversion_net_name }}"
     mtu: "{{ os_migrate_conversion_net_mtu }}"
     auth: "{{ os_migrate_conversion_auth }}"
@@ -15,7 +15,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion subnet
-  os_subnet:
+  ansible.builtin.os_subnet:
     name: "{{ os_migrate_conversion_subnet_name }}"
     network_name: "{{ os_migrate_conversion_net_name }}"
     dns_nameservers: "{{ os_migrate_conversion_subnet_dns_nameservers }}"
@@ -31,13 +31,13 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion router
-  os_router:
+  ansible.builtin.os_router:
     name: "{{ os_migrate_conversion_router_name }}"
     network: "{{ os_migrate_conversion_external_network_name }}"
     interfaces:
-      - net: "{{ os_migrate_conversion_net_name }}"
-        subnet: "{{ os_migrate_conversion_subnet_name }}"
-        portip: "{{ os_migrate_conversion_router_ip }}"
+    - net: "{{ os_migrate_conversion_net_name }}"
+      subnet: "{{ os_migrate_conversion_subnet_name }}"
+      portip: "{{ os_migrate_conversion_router_ip }}"
     auth: "{{ os_migrate_conversion_auth }}"
     auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"
@@ -47,7 +47,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion security group
-  os_security_group:
+  ansible.builtin.os_security_group:
     name: "{{ os_migrate_conversion_secgroup_name }}"
     auth: "{{ os_migrate_conversion_auth }}"
     auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
@@ -58,7 +58,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: allow ssh in os_migrate conversion security group
-  os_security_group_rule:
+  ansible.builtin.os_security_group_rule:
     security_group: "{{ os_migrate_conversion_secgroup_name }}"
     remote_ip_prefix: 0.0.0.0/0
     protocol: tcp
@@ -73,7 +73,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: allow icmp in os_migrate conversion security group
-  os_security_group_rule:
+  ansible.builtin.os_security_group_rule:
     security_group: "{{ os_migrate_conversion_secgroup_name }}"
     remote_ip_prefix: 0.0.0.0/0
     protocol: icmp
@@ -86,7 +86,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion keypair
-  os_keypair:
+  ansible.builtin.os_keypair:
     name: "{{ os_migrate_conversion_keypair_name }}"
     public_key_file: "{{ os_migrate_conversion_keypair_private_path }}.pub"
     auth: "{{ os_migrate_conversion_auth }}"
@@ -98,14 +98,14 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion host
-  os_server:
+  ansible.builtin.os_server:
     name: "{{ os_migrate_conversion_host_name }}"
     flavor: "{{ os_migrate_conversion_flavor_name }}"
     image: "{{ os_migrate_conversion_image_name }}"
     key_name: "{{ os_migrate_conversion_keypair_name }}"
     network: "{{ os_migrate_conversion_net_name }}"
     security_groups:
-      - "{{ os_migrate_conversion_secgroup_name }}"
+    - "{{ os_migrate_conversion_secgroup_name }}"
     auto_ip: yes
     wait: yes
     timeout: 600

--- a/os_migrate/roles/conversion_host/tasks/unregister.yml
+++ b/os_migrate/roles/conversion_host/tasks/unregister.yml
@@ -1,10 +1,10 @@
 - name: unregister RHEL hosts from RHSM
-  redhat_subscription:
-    state: absent
   vars:
     # Unregistration gets stuck unless we explicitly run the module as root.
     ansible_become: true
     ansible_become_user: root
   when:
-    - ansible_distribution is defined
-    - ansible_distribution in ['RedHat']
+  - ansible_distribution is defined
+  - ansible_distribution in ['RedHat']
+  ansible.builtin.redhat_subscription:
+    state: absent

--- a/os_migrate/roles/conversion_host_content/tasks/centos.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/centos.yml
@@ -1,18 +1,18 @@
 - name: install epel release
-  yum:
+  ansible.builtin.yum:
     name: epel-release
     state: present
 
 - name: update all packages
-  yum:
+  ansible.builtin.yum:
     name: '*'
     state: latest
 
 - name: install content
-  yum:
+  ansible.builtin.yum:
     name:
-      - nbdkit
-      - nbdkit-basic-plugins
-      - qemu-img
-      - libguestfs-tools
+    - nbdkit
+    - nbdkit-basic-plugins
+    - qemu-img
+    - libguestfs-tools
     state: present

--- a/os_migrate/roles/conversion_host_content/tasks/main.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/main.yml
@@ -1,15 +1,15 @@
 - name: Conversion host content tasks
   block:
-    - name: Display host os
-      debug:
-        msg: >-
-          Conversion Host OS is
-          {{ ansible_distribution }} {{ ansible_distribution_version }}
+  - name: Display host os
+    ansible.builtin.debug:
+      msg: >-
+        Conversion Host OS is
+        {{ ansible_distribution }} {{ ansible_distribution_version }}
 
-    - name: Include CentOS tasks
-      include_tasks: centos.yml
-      when: ansible_distribution in ['CentOS']
+  - name: Include CentOS tasks
+    when: ansible_distribution in ['CentOS']
 
-    - name: Include RHEL tasks
-      include_tasks: rhel.yml
-      when: ansible_distribution in ['RedHat']
+    ansible.builtin.include_tasks: centos.yml
+  - name: Include RHEL tasks
+    when: ansible_distribution in ['RedHat']
+    ansible.builtin.include_tasks: rhel.yml

--- a/os_migrate/roles/conversion_host_content/tasks/rhel.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/rhel.yml
@@ -1,5 +1,10 @@
 - name: register and auto-subscribe to available content.
-  redhat_subscription:
+  when:
+  - >-
+    os_migrate_conversion_rhsm_username is defined or
+    os_migrate_conversion_rhsm_org_id is defined
+
+  ansible.builtin.redhat_subscription:
     state: present
     # These params have defaults specified:
     auto_attach: "{{ os_migrate_conversion_rhsm_auto_attach|default(true) }}"
@@ -16,30 +21,32 @@
     pool_ids: "{{ os_migrate_conversion_rhsm_pool_ids|default(omit) }}"
     release: "{{ os_migrate_conversion_rhsm_release|default(omit) }}"
     rhsm_baseurl: "{{ os_migrate_conversion_rhsm_rhsm_baseurl|default(omit) }}"
-    rhsm_repo_ca_cert: "{{ os_migrate_conversion_rhsm_rhsm_repo_ca_cert|default(omit) }}"
-    server_hostname: "{{ os_migrate_conversion_rhsm_server_hostname|default(omit) }}"
-    server_insecure: "{{ os_migrate_conversion_rhsm_server_insecure|default(omit) }}"
-    server_proxy_hostname: "{{ os_migrate_conversion_rhsm_server_proxy_hostname|default(omit) }}"
-    server_proxy_password: "{{ os_migrate_conversion_rhsm_server_proxy_password|default(omit) }}"
-    server_proxy_port: "{{ os_migrate_conversion_rhsm_server_proxy_port|default(omit) }}"
-    server_proxy_user: "{{ os_migrate_conversion_rhsm_server_proxy_user|default(omit) }}"
+    rhsm_repo_ca_cert: "{{ os_migrate_conversion_rhsm_rhsm_repo_ca_cert|default(omit)\
+      \ }}"
+    server_hostname: "{{ os_migrate_conversion_rhsm_server_hostname|default(omit)\
+      \ }}"
+    server_insecure: "{{ os_migrate_conversion_rhsm_server_insecure|default(omit)\
+      \ }}"
+    server_proxy_hostname: "{{ os_migrate_conversion_rhsm_server_proxy_hostname|default(omit)\
+      \ }}"
+    server_proxy_password: "{{ os_migrate_conversion_rhsm_server_proxy_password|default(omit)\
+      \ }}"
+    server_proxy_port: "{{ os_migrate_conversion_rhsm_server_proxy_port|default(omit)\
+      \ }}"
+    server_proxy_user: "{{ os_migrate_conversion_rhsm_server_proxy_user|default(omit)\
+      \ }}"
     syspurpose: "{{ os_migrate_conversion_rhsm_syspurpose|default(omit) }}"
     username: "{{ os_migrate_conversion_rhsm_username|default(omit) }}"
-  when:
-    - >-
-      os_migrate_conversion_rhsm_username is defined or
-      os_migrate_conversion_rhsm_org_id is defined
-
 - name: update all packages
-  yum:
+  ansible.builtin.yum:
     name: '*'
     state: latest
 
 - name: install content
-  yum:
+  ansible.builtin.yum:
     name:
-      - nbdkit
-      - nbdkit-basic-plugins
-      - qemu-img
-      - libguestfs-tools
+    - nbdkit
+    - nbdkit-basic-plugins
+    - qemu-img
+    - libguestfs-tools
     state: present

--- a/os_migrate/roles/export_flavors/defaults/main.yml
+++ b/os_migrate/roles/export_flavors/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_flavors_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_flavors/meta/main.yml
+++ b/os_migrate/roles/export_flavors/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_flavors/tasks/main.yml
+++ b/os_migrate/roles/export_flavors/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available flavors
-  os_flavor_info:
+  register: src_flavors_info
+
+  ansible.builtin.os_flavor_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -7,24 +9,19 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_flavors_info
-
 - name: create id-name pairs of flavors to export
-  set_fact:
-    export_flavors_ids_names: "{{ (
-      src_flavors_info.openstack_flavors
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_flavors_ids_names: "{{ (src_flavors_info.openstack_flavors | community.general.json_query('[*].{name:\
+      \ name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of flavors to export
-  set_fact:
-    export_flavors_ids_names: "{{ (
-      export_flavors_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_flavors_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_flavors_ids_names: "{{ ( export_flavors_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_flavors_filter,\
+      \ attribute='name') ) }}"
 
 - name: export flavor
-  os_migrate.os_migrate.export_flavor:
+  loop: "{{ export_flavors_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_flavor:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -34,4 +31,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_flavors_ids_names }}"

--- a/os_migrate/roles/export_images/defaults/main.yml
+++ b/os_migrate/roles/export_images/defaults/main.yml
@@ -1,4 +1,4 @@
 os_migrate_export_images_blobs: true
 os_migrate_images_filter:
-  - regex: .*
+- regex: .*
 os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"

--- a/os_migrate/roles/export_images/meta/main.yml
+++ b/os_migrate/roles/export_images/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_images/tasks/main.yml
+++ b/os_migrate/roles/export_images/tasks/main.yml
@@ -1,7 +1,9 @@
 # NOTE: os_image_info doesn't support os_migrate_src_filters, we apply
 # the filters manually below.
 - name: scan available images
-  os_image_info:
+  register: src_images_info
+
+  ansible.builtin.os_image_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -9,34 +11,29 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_images_info
-
 - name: create id-name pairs of images to export
-  set_fact:
-    export_images_ids_names: "{{ (
-      src_images_info.openstack_image
-        | json_query('[*].{name: name, id: id, owner: owner}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_images_ids_names: "{{ (src_images_info.openstack_image | community.general.json_query('[*].{name:\
+      \ name, id: id, owner: owner}') | sort(attribute='id') ) }}"
 
 - name: filter images to export by project
-  set_fact:
-    export_images_ids_names: "{{ (
-      export_images_ids_names
-        | json_query(\"[?owner=='\" + os_migrate_src_filters['project_id'] + \"']\")
-        | sort(attribute='id') ) }}"
   when:
-    - os_migrate_src_filters is defined
-    - os_migrate_src_filters['project_id'] is defined
+  - os_migrate_src_filters is defined
+  - os_migrate_src_filters['project_id'] is defined
 
+  ansible.builtin.set_fact:
+    export_images_ids_names: "{{ (export_images_ids_names | community.general.json_query(\"[?owner=='\"\
+      \ + os_migrate_src_filters['project_id'] + \"']\") | sort(attribute='id') )\
+      \ }}"
 - name: filter names of images to export
-  set_fact:
-    export_images_ids_names: "{{ (
-      export_images_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_images_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_images_ids_names: "{{ ( export_images_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_images_filter,\
+      \ attribute='name') ) }}"
 
 - name: export image metadata
-  os_migrate.os_migrate.export_image_meta:
+  loop: "{{ export_images_ids_names }}"
+
+  ansible.builtin.os_migrate.os_migrate.export_image_meta:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -46,24 +43,23 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_images_ids_names }}"
-
 - name: make sure image blob dir exists
-  file:
-    path: "{{ os_migrate_image_blobs_dir }}"
-    state: directory
   when: os_migrate_export_images_blobs
 
+  ansible.builtin.file:
+    path: "{{ os_migrate_image_blobs_dir }}"
+    state: directory
 - name: export image blobs
-  os_migrate.os_migrate.export_image_blob:
+  loop: "{{ export_images_ids_names }}"
+  when: os_migrate_export_images_blobs
+  ansible.builtin.os_migrate.os_migrate.export_image_blob:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
-    blob_path: "{{ os_migrate_image_blobs_dir }}/{{ item['id'] }}-{{ item['name'] }}"
+    blob_path: "{{ os_migrate_image_blobs_dir }}/{{ item['id'] }}-{{ item['name']\
+      \ }}"
     name: "{{ item['id'] }}"
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_images_ids_names }}"
-  when: os_migrate_export_images_blobs

--- a/os_migrate/roles/export_keypairs/defaults/main.yml
+++ b/os_migrate/roles/export_keypairs/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_keypairs_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_keypairs/meta/main.yml
+++ b/os_migrate/roles/export_keypairs/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_keypairs/tasks/main.yml
+++ b/os_migrate/roles/export_keypairs/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available keypairs
-  os_migrate.os_migrate.os_keypairs_info:
+  register: src_keypairs_info
+
+  ansible.builtin.os_migrate.os_migrate.os_keypairs_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -7,24 +9,19 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_keypairs_info
-
 - name: create id-name pairs of keypairs to export
-  set_fact:
-    export_keypairs_ids_names: "{{ (
-      src_keypairs_info.openstack_keypairs
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_keypairs_ids_names: "{{ (src_keypairs_info.openstack_keypairs | community.general.json_query('[*].{name:\
+      \ name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of keypairs to export
-  set_fact:
-    export_keypairs_ids_names: "{{ (
-      export_keypairs_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_keypairs_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_keypairs_ids_names: "{{ ( export_keypairs_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_keypairs_filter,\
+      \ attribute='name') ) }}"
 
 - name: export keypair
-  os_migrate.os_migrate.export_keypair:
+  loop: "{{ export_keypairs_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_keypair:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -34,4 +31,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_keypairs_ids_names }}"

--- a/os_migrate/roles/export_networks/defaults/main.yml
+++ b/os_migrate/roles/export_networks/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_networks_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_networks/meta/main.yml
+++ b/os_migrate/roles/export_networks/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_networks/tasks/main.yml
+++ b/os_migrate/roles/export_networks/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available networks
-  os_networks_info:
+  register: src_networks_info
+
+  ansible.builtin.os_networks_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -8,24 +10,19 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_networks_info
-
 - name: create id-name pairs of networks to export
-  set_fact:
-    export_networks_ids_names: "{{ (
-      src_networks_info.openstack_networks
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_networks_ids_names: "{{ (src_networks_info.openstack_networks | community.general.json_query('[*].{name:\
+      \ name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of networks to export
-  set_fact:
-    export_networks_ids_names: "{{ (
-      export_networks_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_networks_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_networks_ids_names: "{{ ( export_networks_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_networks_filter,\
+      \ attribute='name') ) }}"
 
 - name: export network
-  os_migrate.os_migrate.export_network:
+  loop: "{{ export_networks_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_network:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -35,4 +32,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_networks_ids_names }}"

--- a/os_migrate/roles/export_projects/defaults/main.yml
+++ b/os_migrate/roles/export_projects/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_projects_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_projects/meta/main.yml
+++ b/os_migrate/roles/export_projects/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_projects/tasks/main.yml
+++ b/os_migrate/roles/export_projects/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available projects
-  os_project_info:
+  register: src_projects_info
+
+  ansible.builtin.os_project_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -7,21 +9,15 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_projects_info
-
 - name: create id-name pairs of projects to export
-  set_fact:
-    export_projects_ids_names: "{{ (
-      src_projects_info.openstack_projects
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_projects_ids_names: "{{ (src_projects_info.openstack_projects | community.general.json_query('[*].{name:\
+      \ name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of projects to export
-  set_fact:
-    export_projects_ids_names: "{{ (
-      export_projects_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_projects_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_projects_ids_names: "{{ ( export_projects_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_projects_filter,\
+      \ attribute='name') ) }}"
 
 - name: export project
   os_migrate.os_migrate.export_project:

--- a/os_migrate/roles/export_router_interfaces/defaults/main.yml
+++ b/os_migrate/roles/export_router_interfaces/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_routers_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_router_interfaces/meta/main.yml
+++ b/os_migrate/roles/export_router_interfaces/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_router_interfaces/tasks/main.yml
+++ b/os_migrate/roles/export_router_interfaces/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available routers
-  os_migrate.os_migrate.os_routers_info:
+  register: src_routers_info
+
+  ansible.builtin.os_migrate.os_migrate.os_routers_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -8,24 +10,19 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_routers_info
-
 - name: create id-name pairs of routers to export
-  set_fact:
-    export_routers_ids_names: "{{ (
-      src_routers_info.openstack_routers
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_routers_ids_names: "{{ (src_routers_info.openstack_routers | community.general.json_query('[*].{name:\
+      \ name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of routers to export
-  set_fact:
-    export_routers_ids_names: "{{ (
-      export_routers_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_routers_ids_names: "{{ ( export_routers_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,\
+      \ attribute='name') ) }}"
 
 - name: export router interfaces
-  os_migrate.os_migrate.export_router_interfaces:
+  loop: "{{ export_routers_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_router_interfaces:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -35,4 +32,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_routers_ids_names }}"

--- a/os_migrate/roles/export_routers/defaults/main.yml
+++ b/os_migrate/roles/export_routers/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_routers_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_routers/meta/main.yml
+++ b/os_migrate/roles/export_routers/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_routers/tasks/main.yml
+++ b/os_migrate/roles/export_routers/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available routers
-  os_migrate.os_migrate.os_routers_info:
+  register: src_routers_info
+
+  ansible.builtin.os_migrate.os_migrate.os_routers_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -8,24 +10,19 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_routers_info
-
 - name: create id-name pairs of routers to export
-  set_fact:
-    export_routers_ids_names: "{{ (
-      src_routers_info.openstack_routers
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_routers_ids_names: "{{ (src_routers_info.openstack_routers | community.general.json_query('[*].{name:\
+      \ name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of routers to export
-  set_fact:
-    export_routers_ids_names: "{{ (
-      export_routers_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_routers_ids_names: "{{ ( export_routers_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,\
+      \ attribute='name') ) }}"
 
 - name: export router
-  os_migrate.os_migrate.export_router:
+  loop: "{{ export_routers_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_router:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -35,4 +32,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_routers_ids_names }}"

--- a/os_migrate/roles/export_security_group_rules/defaults/main.yml
+++ b/os_migrate/roles/export_security_group_rules/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_security_groups_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_security_group_rules/meta/main.yml
+++ b/os_migrate/roles/export_security_group_rules/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_security_group_rules/tasks/main.yml
+++ b/os_migrate/roles/export_security_group_rules/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available security groups
-  os_migrate.os_migrate.os_security_groups_info:
+  register: src_security_groups_info
+
+  ansible.builtin.os_migrate.os_migrate.os_security_groups_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -8,26 +10,21 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_security_groups_info
-
 - name: create id-name pairs of security groups to export
-  set_fact:
-    export_security_groups_ids_names: "{{ (
-      src_security_groups_info.openstack_security_groups
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_security_groups_ids_names: "{{ ( src_security_groups_info.openstack_security_groups\
+      \ | community.general.json_query('[*].{name: name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of security groups to export
-  set_fact:
-    export_security_groups_ids_names: "{{ (
-      export_security_groups_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_security_groups_ids_names: "{{ ( export_security_groups_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,\
+      \ attribute='name') ) }}"
 
 # In this case we will export all the security groups
 # rules for all the security groups filtered before
 - name: export security group rules
-  os_migrate.os_migrate.export_security_group_rules:
+  loop: "{{ export_security_groups_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_security_group_rules:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -37,4 +34,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_security_groups_ids_names }}"

--- a/os_migrate/roles/export_security_groups/defaults/main.yml
+++ b/os_migrate/roles/export_security_groups/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_security_groups_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_security_groups/meta/main.yml
+++ b/os_migrate/roles/export_security_groups/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_security_groups/tasks/main.yml
+++ b/os_migrate/roles/export_security_groups/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available security groups
-  os_migrate.os_migrate.os_security_groups_info:
+  register: src_security_groups_info
+
+  ansible.builtin.os_migrate.os_migrate.os_security_groups_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -8,24 +10,19 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_security_groups_info
-
 - name: create id-name pairs of security groups to export
-  set_fact:
-    export_security_groups_ids_names: "{{ (
-      src_security_groups_info.openstack_security_groups
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_security_groups_ids_names: "{{ ( src_security_groups_info.openstack_security_groups\
+      \ | community.general.json_query('[*].{name: name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of security groups to export
-  set_fact:
-    export_security_groups_ids_names: "{{ (
-      export_security_groups_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_security_groups_ids_names: "{{ ( export_security_groups_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,\
+      \ attribute='name') ) }}"
 
 - name: export security groups
-  os_migrate.os_migrate.export_security_group:
+  loop: "{{ export_security_groups_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_security_group:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -35,4 +32,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_security_groups_ids_names }}"

--- a/os_migrate/roles/export_subnets/defaults/main.yml
+++ b/os_migrate/roles/export_subnets/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_subnets_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_subnets/meta/main.yml
+++ b/os_migrate/roles/export_subnets/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_subnets/tasks/main.yml
+++ b/os_migrate/roles/export_subnets/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available subnets
-  os_subnets_info:
+  register: src_subnets_info
+
+  ansible.builtin.os_subnets_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -8,24 +10,19 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_subnets_info
-
 - name: create id-name pairs of subnets to export
-  set_fact:
-    export_subnets_ids_names: "{{ (
-      src_subnets_info.openstack_subnets
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_subnets_ids_names: "{{ (src_subnets_info.openstack_subnets | community.general.json_query('[*].{name:\
+      \ name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of subnets to export
-  set_fact:
-    export_subnets_ids_names: "{{ (
-      export_subnets_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_subnets_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_subnets_ids_names: "{{ ( export_subnets_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_subnets_filter,\
+      \ attribute='name') ) }}"
 
 - name: export subnet
-  os_migrate.os_migrate.export_subnet:
+  loop: "{{ export_subnets_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_subnet:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -35,4 +32,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_subnets_ids_names }}"

--- a/os_migrate/roles/export_users/defaults/main.yml
+++ b/os_migrate/roles/export_users/defaults/main.yml
@@ -1,2 +1,2 @@
 os_migrate_users_filter:
-  - regex: .*
+- regex: .*

--- a/os_migrate/roles/export_users/meta/main.yml
+++ b/os_migrate/roles/export_users/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_users/tasks/main.yml
+++ b/os_migrate/roles/export_users/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan available users
-  os_user_info:
+  register: src_users_info
+
+  ansible.builtin.os_user_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -7,24 +9,19 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_users_info
-
 - name: create id-name pairs of users to export
-  set_fact:
-    export_users_ids_names: "{{ (
-      src_users_info.openstack_users
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_users_ids_names: "{{ (src_users_info.openstack_users | community.general.json_query('[*].{name:\
+      \ name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of users to export
-  set_fact:
-    export_users_ids_names: "{{ (
-      export_users_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_users_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_users_ids_names: "{{ ( export_users_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_users_filter,\
+      \ attribute='name') ) }}"
 
 - name: export users
-  os_migrate.os_migrate.export_user:
+  loop: "{{ export_users_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_user:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -34,4 +31,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_users_ids_names }}"

--- a/os_migrate/roles/export_workloads/defaults/main.yml
+++ b/os_migrate/roles/export_workloads/defaults/main.yml
@@ -1,7 +1,7 @@
 os_migrate_workloads_filter:
-  - regex: .*
+- regex: .*
 
 # `null` means we let the Server class decide on defaults.
 # In case of boot_disk_copy, the default differs based on whether
 # the server was created as boot-from-volume or not.
-os_migrate_workloads_boot_disk_copy: null
+os_migrate_workloads_boot_disk_copy:

--- a/os_migrate/roles/export_workloads/meta/main.yml
+++ b/os_migrate/roles/export_workloads/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_workloads/tasks/main.yml
+++ b/os_migrate/roles/export_workloads/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: scan instances for workloads to export
-  os_server_info:
+  register: src_workloads_info
+
+  ansible.builtin.os_server_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -8,27 +10,22 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: src_workloads_info
-
-- debug:
+- ansible.builtin.debug:
     msg: "{{ src_workloads_info.openstack_servers }}"
 
 - name: create id-name pairs of workloads to export
-  set_fact:
-    export_workloads_ids_names: "{{ (
-      src_workloads_info.openstack_servers
-        | json_query('[*].{name: name, id: id}')
-        | sort(attribute='id') ) }}"
+  ansible.builtin.set_fact:
+    export_workloads_ids_names: "{{ (src_workloads_info.openstack_servers | community.general.json_query('[*].{name:\
+      \ name, id: id}') | sort(attribute='id') ) }}"
 
 - name: filter names of workloads to export
-  set_fact:
-    export_workloads_ids_names: "{{ (
-      export_workloads_ids_names
-        | os_migrate.os_migrate.stringfilter(os_migrate_workloads_filter,
-                                             attribute='name') ) }}"
+  ansible.builtin.set_fact:
+    export_workloads_ids_names: "{{ ( export_workloads_ids_names | os_migrate.os_migrate.stringfilter(os_migrate_workloads_filter,\
+      \ attribute='name') ) }}"
 
 - name: export workload
-  os_migrate.os_migrate.export_workload:
+  loop: "{{ export_workloads_ids_names }}"
+  ansible.builtin.os_migrate.os_migrate.export_workload:
     path: "{{ os_migrate_data_dir }}/workloads.yml"
     name: "{{ item['id'] }}"
     migration_params:
@@ -40,4 +37,3 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  loop: "{{ export_workloads_ids_names }}"

--- a/os_migrate/roles/import_flavors/meta/main.yml
+++ b/os_migrate/roles/import_flavors/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_flavors/tasks/main.yml
+++ b/os_migrate/roles/import_flavors/tasks/main.yml
@@ -1,22 +1,23 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/flavors.yml"
   register: flavors_file_validation
   when: import_flavors_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/flavors.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ flavors_file_validation.errors|join(' ') }}"
   when: not ( flavors_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ flavors_file_validation.errors|join(' ') }}"
 - name: read flavors resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/flavors.yml"
   register: read_flavors
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/flavors.yml"
 - name: import flavors
-  os_migrate.os_migrate.import_flavor:
+  loop: "{{ read_flavors.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_flavor:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -25,4 +26,3 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_flavors.resources }}"

--- a/os_migrate/roles/import_images/meta/main.yml
+++ b/os_migrate/roles/import_images/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_images/tasks/main.yml
+++ b/os_migrate/roles/import_images/tasks/main.yml
@@ -1,31 +1,32 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/images.yml"
   register: images_file_validation
   when: import_images_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/images.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ images_file_validation.errors|join(' ') }}"
   when: not ( images_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ images_file_validation.errors|join(' ') }}"
 - name: read images resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/images.yml"
   register: read_images
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/images.yml"
 - name: import images
-  os_migrate.os_migrate.import_image:
+  loop: "{{ read_images.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_image:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
     data: "{{ item }}"
     blob_path: >-
-      {{ os_migrate_image_blobs_dir }}/{{ item['_info']['id'] }}-{{ item['params']['name'] }}
+      {{ os_migrate_image_blobs_dir }}/{{ item['_info']['id'] }}-{{ item['params']['name']
+      }}
     filters: "{{ os_migrate_dst_filters }}"
     validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_images.resources }}"

--- a/os_migrate/roles/import_keypairs/meta/main.yml
+++ b/os_migrate/roles/import_keypairs/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_keypairs/tasks/main.yml
+++ b/os_migrate/roles/import_keypairs/tasks/main.yml
@@ -1,22 +1,23 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/keypairs.yml"
   register: keypairs_file_validation
   when: import_keypairs_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/keypairs.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ keypairs_file_validation.errors|join(' ') }}"
   when: not ( keypairs_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ keypairs_file_validation.errors|join(' ') }}"
 - name: read keypairs resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/keypairs.yml"
   register: read_keypairs
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/keypairs.yml"
 - name: import keypairs
-  os_migrate.os_migrate.import_keypair:
+  loop: "{{ read_keypairs.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_keypair:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -25,4 +26,3 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_keypairs.resources }}"

--- a/os_migrate/roles/import_networks/meta/main.yml
+++ b/os_migrate/roles/import_networks/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_networks/tasks/main.yml
+++ b/os_migrate/roles/import_networks/tasks/main.yml
@@ -1,22 +1,23 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/networks.yml"
   register: networks_file_validation
   when: import_networks_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/networks.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ networks_file_validation.errors|join(' ') }}"
   when: not ( networks_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ networks_file_validation.errors|join(' ') }}"
 - name: read networks resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/networks.yml"
   register: read_networks
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/networks.yml"
 - name: import networks
-  os_migrate.os_migrate.import_network:
+  loop: "{{ read_networks.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_network:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -26,4 +27,3 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_networks.resources }}"

--- a/os_migrate/roles/import_projects/meta/main.yml
+++ b/os_migrate/roles/import_projects/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_projects/tasks/main.yml
+++ b/os_migrate/roles/import_projects/tasks/main.yml
@@ -1,20 +1,20 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/projects.yml"
   register: projects_file_validation
   when: import_projects_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/projects.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ projects_file_validation.errors|join(' ') }}"
   when: not ( projects_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ projects_file_validation.errors|join(' ') }}"
 - name: read projects resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/projects.yml"
   register: read_projects
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/projects.yml"
 - name: import projects
   os_migrate.os_migrate.import_project:
     auth: "{{ os_migrate_dst_auth }}"

--- a/os_migrate/roles/import_router_interfaces/meta/main.yml
+++ b/os_migrate/roles/import_router_interfaces/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_router_interfaces/tasks/main.yml
+++ b/os_migrate/roles/import_router_interfaces/tasks/main.yml
@@ -1,22 +1,23 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/router_interfaces.yml"
   register: router_interfaces_file_validation
   when: import_router_interfaces_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/router_interfaces.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ router_interfaces_file_validation.errors|join(' ') }}"
   when: not ( router_interfaces_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ router_interfaces_file_validation.errors|join(' ') }}"
 - name: read router interfaces resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/router_interfaces.yml"
   register: read_router_interfaces
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/router_interfaces.yml"
 - name: import router interfaces
-  os_migrate.os_migrate.import_router_interface:
+  loop: "{{ read_router_interfaces.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_router_interface:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -26,4 +27,3 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_router_interfaces.resources }}"

--- a/os_migrate/roles/import_routers/meta/main.yml
+++ b/os_migrate/roles/import_routers/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_routers/tasks/main.yml
+++ b/os_migrate/roles/import_routers/tasks/main.yml
@@ -1,22 +1,23 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/routers.yml"
   register: routers_file_validation
   when: import_routers_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/routers.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ routers_file_validation.errors|join(' ') }}"
   when: not ( routers_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ routers_file_validation.errors|join(' ') }}"
 - name: read routers resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/routers.yml"
   register: read_routers
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/routers.yml"
 - name: import routers
-  os_migrate.os_migrate.import_router:
+  loop: "{{ read_routers.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_router:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -26,4 +27,3 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_routers.resources }}"

--- a/os_migrate/roles/import_security_group_rules/meta/main.yml
+++ b/os_migrate/roles/import_security_group_rules/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_security_group_rules/tasks/main.yml
+++ b/os_migrate/roles/import_security_group_rules/tasks/main.yml
@@ -1,22 +1,23 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/security_group_rules.yml"
   register: security_group_rules_file_validation
   when: import_security_group_rules_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/security_group_rules.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ security_group_rules_file_validation.errors|join(' ') }}"
   when: not ( security_group_rules_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ security_group_rules_file_validation.errors|join(' ') }}"
 - name: read security_group_rules resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/security_group_rules.yml"
   register: read_security_group_rules
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/security_group_rules.yml"
 - name: import security_group_rules
-  os_migrate.os_migrate.import_security_group_rule:
+  loop: "{{ read_security_group_rules.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_security_group_rule:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -26,4 +27,3 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_security_group_rules.resources }}"

--- a/os_migrate/roles/import_security_groups/meta/main.yml
+++ b/os_migrate/roles/import_security_groups/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_security_groups/tasks/main.yml
+++ b/os_migrate/roles/import_security_groups/tasks/main.yml
@@ -1,22 +1,23 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/security_groups.yml"
   register: security_groups_file_validation
   when: import_security_groups_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/security_groups.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ security_groups_file_validation.errors|join(' ') }}"
   when: not ( security_groups_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ security_groups_file_validation.errors|join(' ') }}"
 - name: read security groups resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/security_groups.yml"
   register: read_security_groups
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/security_groups.yml"
 - name: import security groups
-  os_migrate.os_migrate.import_security_group:
+  loop: "{{ read_security_groups.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_security_group:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -26,4 +27,3 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_security_groups.resources }}"

--- a/os_migrate/roles/import_subnets/meta/main.yml
+++ b/os_migrate/roles/import_subnets/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_subnets/tasks/main.yml
+++ b/os_migrate/roles/import_subnets/tasks/main.yml
@@ -1,22 +1,23 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/subnets.yml"
   register: subnets_file_validation
   when: import_subnets_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/subnets.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ subnets_file_validation.errors|join(' ') }}"
   when: not ( subnets_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ subnets_file_validation.errors|join(' ') }}"
 - name: read subnets resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/subnets.yml"
   register: read_networks
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/subnets.yml"
 - name: import subnets
-  os_migrate.os_migrate.import_subnet:
+  loop: "{{ read_networks.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_subnet:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -26,4 +27,3 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_networks.resources }}"

--- a/os_migrate/roles/import_users/meta/main.yml
+++ b/os_migrate/roles/import_users/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,9 +5,9 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_users/tasks/main.yml
+++ b/os_migrate/roles/import_users/tasks/main.yml
@@ -1,22 +1,23 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/users.yml"
   register: users_file_validation
   when: import_users_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/users.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ users_file_validation.errors|join(' ') }}"
   when: not ( users_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ users_file_validation.errors|join(' ') }}"
 - name: read users resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/users.yml"
   register: read_users
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/users.yml"
 - name: import users
-  os_migrate.os_migrate.import_user:
+  loop: "{{ read_users.resources }}"
+  ansible.builtin.os_migrate.os_migrate.import_user:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -25,4 +26,3 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_users.resources }}"

--- a/os_migrate/roles/import_workloads/meta/main.yml
+++ b/os_migrate/roles/import_workloads/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,10 +5,10 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies:
-  - role: os_migrate.os_migrate.prelude_src
-  - role: os_migrate.os_migrate.prelude_dst
+- role: os_migrate.os_migrate.prelude_src
+- role: os_migrate.os_migrate.prelude_dst

--- a/os_migrate/roles/import_workloads/tasks/main.yml
+++ b/os_migrate/roles/import_workloads/tasks/main.yml
@@ -1,27 +1,29 @@
 - name: validate loaded resources
-  os_migrate.os_migrate.validate_resource_files:
-    paths:
-      - "{{ os_migrate_data_dir }}/workloads.yml"
   register: workloads_file_validation
   when: import_workloads_validate_file
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths:
+    - "{{ os_migrate_data_dir }}/workloads.yml"
 - name: stop when errors found
-  fail:
-    msg: "{{ workloads_file_validation.errors|join(' ') }}"
   when: not ( workloads_file_validation.ok | bool )
 
+  ansible.builtin.fail:
+    msg: "{{ workloads_file_validation.errors|join(' ') }}"
 - name: read workloads resource file
-  os_migrate.os_migrate.read_resources:
-    path: "{{ os_migrate_data_dir }}/workloads.yml"
   register: read_workloads
 
+  ansible.builtin.os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/workloads.yml"
 - name: create directory for workload migration logs
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}/workload_logs"
     state: directory
 
 - name: get source conversion host address
-  os_migrate.os_migrate.os_conversion_host_info:
+  register: os_src_conversion_host_info
+
+  ansible.builtin.os_migrate.os_migrate.os_conversion_host_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -31,15 +33,15 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-  register: os_src_conversion_host_info
-
 - name: fail if source conversion host is not active
-  fail:
-    msg: The source conversion host is not running!
   when: os_src_conversion_host_info.openstack_conversion_host.status != "ACTIVE"
 
+  ansible.builtin.fail:
+    msg: The source conversion host is not running!
 - name: get destination conversion host address
-  os_migrate.os_migrate.os_conversion_host_info:
+  register: os_dst_conversion_host_info
+
+  ansible.builtin.os_migrate.os_migrate.os_conversion_host_info:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -49,19 +51,17 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: os_dst_conversion_host_info
-
 - name: fail if destination conversion is not active
-  fail:
-    msg: The destination conversion host is not running!
   when: os_dst_conversion_host_info.openstack_conversion_host.status != "ACTIVE"
 
 # Depending on the virtualization hypervisor,
 # the conversion host machines can take too
 # much time to start.
 
+  ansible.builtin.fail:
+    msg: The destination conversion host is not running!
 - name: Wait until the dst conversion host is reachable
-  wait_for:
+  ansible.builtin.wait_for:
     port: 22
     host: '{{ os_dst_conversion_host_info.openstack_conversion_host.address }}'
     search_regex: OpenSSH
@@ -69,7 +69,7 @@
     timeout: 600
 
 - name: Wait until the src conversion host is reachable
-  wait_for:
+  ansible.builtin.wait_for:
     port: 22
     host: '{{ os_src_conversion_host_info.openstack_conversion_host.address }}'
     search_regex: OpenSSH
@@ -77,5 +77,5 @@
     timeout: 600
 
 - name: import workloads
-  include_tasks: workload.yml
   loop: "{{ read_workloads.resources }}"
+  ansible.builtin.include_tasks: workload.yml

--- a/os_migrate/roles/import_workloads/tasks/workload.yml
+++ b/os_migrate/roles/import_workloads/tasks/workload.yml
@@ -1,6 +1,8 @@
 - block:
   - name: preliminary setup for workload import
-    os_migrate.os_migrate.import_workload_prelim:
+    register: prelim
+
+    ansible.builtin.os_migrate.os_migrate.import_workload_prelim:
       auth: "{{ os_migrate_dst_auth }}"
       auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
       region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -9,18 +11,16 @@
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
       dst_filters: "{{ os_migrate_dst_filters }}"
-      src_conversion_host:
-        "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+      src_conversion_host: "{{ os_src_conversion_host_info.openstack_conversion_host\
+        \ }}"
       log_dir: "{{ os_migrate_data_dir }}/workload_logs"
       data: "{{ item }}"
-    register: prelim
+  - when: prelim.changed
 
-  - debug:
+    ansible.builtin.debug:
       msg:
-        - "{{ prelim.server_name }} log file: {{ prelim.log_file }}"
-        - "{{ prelim.server_name }} progress file: {{ prelim.state_file }}"
-    when: prelim.changed
-
+      - "{{ prelim.server_name }} log file: {{ prelim.log_file }}"
+      - "{{ prelim.server_name }} progress file: {{ prelim.state_file }}"
   - name: perform required checks to ensure source workload is ready
     os_migrate.os_migrate.import_workload_source_check:
       auth: "{{ os_migrate_src_auth }}"
@@ -34,7 +34,10 @@
     when: prelim.changed
 
   - name: expose source volumes
-    os_migrate.os_migrate.import_workload_export_volumes:
+    register: exports
+    when: prelim.changed
+
+    ansible.builtin.os_migrate.os_migrate.import_workload_export_volumes:
       auth: "{{ os_migrate_src_auth }}"
       auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
       region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -42,18 +45,17 @@
       ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-      conversion_host:
-        "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+      conversion_host: "{{ os_src_conversion_host_info.openstack_conversion_host }}"
       data: "{{ item }}"
       log_file: "{{ prelim.log_file }}"
       state_file: "{{ prelim.state_file }}"
       ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
       ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
-    register: exports
+  - name: transfer volumes to destination
+    register: transfer
     when: prelim.changed
 
-  - name: transfer volumes to destination
-    os_migrate.os_migrate.import_workload_transfer_volumes:
+    ansible.builtin.os_migrate.os_migrate.import_workload_transfer_volumes:
       auth: "{{ os_migrate_dst_auth }}"
       auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
       region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -62,21 +64,20 @@
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
       data: "{{ item }}"
-      conversion_host:
-        "{{ os_dst_conversion_host_info.openstack_conversion_host }}"
+      conversion_host: "{{ os_dst_conversion_host_info.openstack_conversion_host }}"
       ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
       ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
       transfer_uuid: "{{ exports.transfer_uuid }}"
-      src_conversion_host_address:
-        "{{ os_src_conversion_host_info.openstack_conversion_host.address }}"
+      src_conversion_host_address: "{{ os_src_conversion_host_info.openstack_conversion_host.address\
+        \ }}"
       volume_map: "{{ exports.volume_map }}"
       log_file: "{{ prelim.log_file }}"
       state_file: "{{ prelim.state_file }}"
-    register: transfer
+  - name: create destination instance
+    register: os_migrate_destination_instance
     when: prelim.changed
 
-  - name: create destination instance
-    os_migrate.os_migrate.import_workload_create_instance:
+    ansible.builtin.os_migrate.os_migrate.import_workload_create_instance:
       auth: "{{ os_migrate_dst_auth }}"
       auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
       region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -86,11 +87,10 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
       data: "{{ item }}"
       block_device_mapping: "{{ transfer.block_device_mapping }}"
-    register: os_migrate_destination_instance
+  - name: clean up after migration
     when: prelim.changed
 
-  - name: clean up after migration
-    os_migrate.os_migrate.import_workload_cleanup:
+    ansible.builtin.os_migrate.os_migrate.import_workload_cleanup:
       auth: "{{ os_migrate_src_auth }}"
       auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
       region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -99,16 +99,13 @@
       client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
       data: "{{ item }}"
-      conversion_host:
-        "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+      conversion_host: "{{ os_src_conversion_host_info.openstack_conversion_host }}"
       ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
       ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
       transfer_uuid: "{{ exports.transfer_uuid }}"
       volume_map: "{{ exports.volume_map }}"
       log_file: "{{ prelim.log_file }}"
       state_file: "{{ prelim.state_file }}"
-    when: prelim.changed
-
   rescue:
-    - fail:
-        msg: "Failed to import {{ item.params.name }}!"
+  - ansible.builtin.fail:
+      msg: "Failed to import {{ item.params.name }}!"

--- a/os_migrate/roles/prelude_dst/meta/main.yml
+++ b/os_migrate/roles/prelude_dst/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,8 +5,8 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies: []

--- a/os_migrate/roles/prelude_dst/tasks/main.yml
+++ b/os_migrate/roles/prelude_dst/tasks/main.yml
@@ -1,20 +1,20 @@
 - name: set os_migrate_dst_project unless it was set explicitly
   when:
-    - os_migrate_dst_filter_current_project|default(true)|bool
+  - os_migrate_dst_filter_current_project|default(true)|bool
   block:
-    - name: fetch information about currently authenticated user/project
-      os_migrate.os_migrate.auth_info:
-        auth: "{{ os_migrate_dst_auth }}"
-        auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
-        region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-        validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-        ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-        client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-        client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-      register: _auth_info
+  - name: fetch information about currently authenticated user/project
+    register: _auth_info
 
-    - name: set os_migrate_dst_project_id and os_migrate_dst_filters
-      set_fact:
-        os_migrate_dst_project_id: "{{ _auth_info.auth_info.project_id }}"
-        os_migrate_dst_filters:
-          project_id: "{{ _auth_info.auth_info.project_id }}"
+    ansible.builtin.os_migrate.os_migrate.auth_info:
+      auth: "{{ os_migrate_dst_auth }}"
+      auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
+      region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
+      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+  - name: set os_migrate_dst_project_id and os_migrate_dst_filters
+    ansible.builtin.set_fact:
+      os_migrate_dst_project_id: "{{ _auth_info.auth_info.project_id }}"
+      os_migrate_dst_filters:
+        project_id: "{{ _auth_info.auth_info.project_id }}"

--- a/os_migrate/roles/prelude_src/meta/main.yml
+++ b/os_migrate/roles/prelude_src/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,8 +5,8 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies: []

--- a/os_migrate/roles/prelude_src/tasks/main.yml
+++ b/os_migrate/roles/prelude_src/tasks/main.yml
@@ -1,20 +1,20 @@
 - name: set os_migrate_src_project unless it was set explicitly
   when:
-    - os_migrate_src_filter_current_project|default(true)|bool
+  - os_migrate_src_filter_current_project|default(true)|bool
   block:
-    - name: fetch information about currently authenticated user/project
-      os_migrate.os_migrate.auth_info:
-        auth: "{{ os_migrate_src_auth }}"
-        auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-        region_name: "{{ os_migrate_src_region_name|default(omit) }}"
-        validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-        ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-        client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-        client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-      register: _auth_info
+  - name: fetch information about currently authenticated user/project
+    register: _auth_info
 
-    - name: set os_migrate_src_project_id and os_migrate_src_filters
-      set_fact:
-        os_migrate_src_project_id: "{{ _auth_info.auth_info.project_id }}"
-        os_migrate_src_filters:
-          project_id: "{{ _auth_info.auth_info.project_id }}"
+    ansible.builtin.os_migrate.os_migrate.auth_info:
+      auth: "{{ os_migrate_src_auth }}"
+      auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
+      region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - name: set os_migrate_src_project_id and os_migrate_src_filters
+    ansible.builtin.set_fact:
+      os_migrate_src_project_id: "{{ _auth_info.auth_info.project_id }}"
+      os_migrate_src_filters:
+        project_id: "{{ _auth_info.auth_info.project_id }}"

--- a/os_migrate/roles/validate_data_dir/meta/main.yml
+++ b/os_migrate/roles/validate_data_dir/meta/main.yml
@@ -1,4 +1,3 @@
----
 galaxy_info:
   author: os-migrate
   description: os-migrate resource
@@ -6,8 +5,8 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: Fedora
-      versions:
-        - 30
+  - name: Fedora
+    versions:
+    - 30
   galaxy_tags: ["os-migrate"]
 dependencies: []

--- a/os_migrate/roles/validate_data_dir/tasks/main.yml
+++ b/os_migrate/roles/validate_data_dir/tasks/main.yml
@@ -1,21 +1,21 @@
 - name: list resource files
-  find:
-    paths:
-      - "{{ os_migrate_data_dir }}"
-    patterns:
-      - "*.yml"
   register: resource_files_result
 
-- fail:
-    msg: No resource files found.
-  when: resource_files_result.files | count < 1
+  ansible.builtin.find:
+    paths:
+    - "{{ os_migrate_data_dir }}"
+    patterns:
+    - "*.yml"
+- when: resource_files_result.files | count < 1
 
+  ansible.builtin.fail:
+    msg: No resource files found.
 - name: validate resource files
-  os_migrate.os_migrate.validate_resource_files:
-    paths: "{{ resource_files_result.files | map(attribute='path') | list }}"
   register: validate_data_dir_result
 
+  ansible.builtin.os_migrate.os_migrate.validate_resource_files:
+    paths: "{{ resource_files_result.files | map(attribute='path') | list }}"
 - name: stop if errors found
-  fail:
-    msg: "{{ validate_data_dir_result.errors | join(' ') }}"
   when: not ( validate_data_dir_result.ok | bool )
+  ansible.builtin.fail:
+    msg: "{{ validate_data_dir_result.errors | join(' ') }}"

--- a/scripts/role-addition.yml
+++ b/scripts/role-addition.yml
@@ -1,5 +1,3 @@
-#!/usr/bin/env ansible-playbook
----
 # Copyright 2020 Red Hat, Inc.
 #
 # All Rights Reserved.
@@ -21,35 +19,35 @@
   connection: local
   gather_facts: false
   tasks:
-    - name: Check for role name
-      fail:
-        msg: >-
-          The required variable `role_name` is undefined. Check your settings.
-      when:
-        - role_name is undefined
+  - name: Check for role name
+    when:
+    - role_name is undefined
 
-    - name: Check for role name syntax
-      fail:
-        msg: >-
-          The role_name can only have letters and underscores
-      when: not role_name|regex_search('^[A-Za-z0-9_]+$')
+    ansible.builtin.fail:
+      msg: >-
+        The required variable `role_name` is undefined. Check your settings.
+  - name: Check for role name syntax
+    when: not role_name|regex_search('^[A-Za-z0-9_]+$')
 
-    - name: Create role
-      command: >-
-        ansible-galaxy init
-        --role-skeleton=_skeleton_role_
-        --init-path=../os_migrate/roles {{ role_name }}
-      args:
-        creates: "os_migrate/roles/{{ role_name }}"
+    ansible.builtin.fail:
+      msg: >-
+        The role_name can only have letters and underscores
+  - name: Create role
+    args:
+      creates: "os_migrate/roles/{{ role_name }}"
 
-    - name: Create role documentation
-      copy:
-        content: |
-          {% set opening = 'Role - ' ~ role_name %}
-          {{ '=' * (opening | length) }}
-          {{ opening }}
-          {{ '=' * (opening | length) }}
+    ansible.builtin.command: >-
+      ansible-galaxy init
+      --role-skeleton=_skeleton_role_
+      --init-path=../os_migrate/roles {{ role_name }}
+  - name: Create role documentation
+    ansible.builtin.copy:
+      content: |
+        {% set opening = 'Role - ' ~ role_name %}
+        {{ '=' * (opening | length) }}
+        {{ opening }}
+        {{ '=' * (opening | length) }}
 
-          .. ansibleautoplugin::
-            :role: os_migrate/roles/{{ role_name }}
-        dest: "../docs/src/roles/role-{{ role_name }}.rst"
+        .. ansibleautoplugin::
+          :role: os_migrate/roles/{{ role_name }}
+      dest: "../docs/src/roles/role-{{ role_name }}.rst"

--- a/tests/e2e/admin/scenario_variables.yml
+++ b/tests/e2e/admin/scenario_variables.yml
@@ -1,5 +1,5 @@
-os_migrate_src_validate_certs: False
-os_migrate_dst_validate_certs: False
+os_migrate_src_validate_certs: false
+os_migrate_dst_validate_certs: false
 
 os_migrate_src_release: 13
 os_migrate_dst_release: 13

--- a/tests/e2e/common/prep.yml
+++ b/tests/e2e/common/prep.yml
@@ -1,21 +1,21 @@
 # make sure no artifacts from prevoius test persisted
 - name: delete os_migrate_data_dir
-  file:
+  tags:
+  - test_prep
+
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}"
     state: absent
-  tags:
-    - test_prep
-
 - name: create os_migrate_tests_tmp_dir
-  file:
+  tags:
+  - test_prep
+
+  ansible.builtin.file:
     path: "{{ os_migrate_tests_tmp_dir }}"
     state: directory
-  tags:
-    - test_prep
-
 - name: create os_migrate_data_dir
-  file:
+  tags:
+  - test_prep
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}"
     state: directory
-  tags:
-    - test_prep

--- a/tests/e2e/tenant/clean_pre_workload.yml
+++ b/tests/e2e/tenant/clean_pre_workload.yml
@@ -1,18 +1,30 @@
 - name: Remove pre-workload test data
-  file:
+  loop:
+  - image_blobs
+  - images.yml
+  - networks.yml
+  - routers.yml
+  - security_group_rules.yml
+  - security_groups.yml
+  - subnets.yml
+
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}/{{ item }}"
     state: absent
-  loop:
-    - image_blobs
-    - images.yml
-    - networks.yml
-    - routers.yml
-    - security_group_rules.yml
-    - security_groups.yml
-    - subnets.yml
-
 - name: remove osm_image
-  os_image:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_image:
     auth: "{{ item.auth }}"
     name: osm_image
     state: absent
@@ -20,20 +32,20 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: remove osm_key keypair
-  os_keypair:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_keypair:
     auth: "{{ item.auth }}"
     state: absent
     name: osm_key
@@ -41,20 +53,20 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: remove osm_router
-  os_router:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_router:
     auth: "{{ item.auth }}"
     name: osm_router
     state: absent
@@ -63,20 +75,20 @@
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
     wait: yes
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: remove osm_server_port
-  os_port:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_port:
     auth: "{{ item.auth }}"
     name: osm_server_port_0
     network: osm_net
@@ -85,20 +97,20 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: remove osm_subnet
-  os_subnet:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_subnet:
     auth: "{{ item.auth }}"
     name: osm_subnet
     state: absent
@@ -106,20 +118,20 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: remove osm_net
-  os_network:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_network:
     auth: "{{ item.auth }}"
     name: osm_net
     state: absent
@@ -127,20 +139,20 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: remove osm_security_group
-  os_security_group:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_security_group:
     auth: "{{ item.auth }}"
     name: osm_security_group
     state: absent
@@ -148,20 +160,19 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: remove osm_security_group_rule
-  os_security_group_rule:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+  ansible.builtin.os_security_group_rule:
     auth: "{{ item.auth }}"
     security_group: osm_security_group
     state: absent
@@ -169,14 +180,3 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"

--- a/tests/e2e/tenant/clean_workload.yml
+++ b/tests/e2e/tenant/clean_workload.yml
@@ -1,14 +1,24 @@
 - name: Remove workload test data
-  file:
+  loop:
+  - osm_server.log
+  - osm_server.state
+  - workloads.yml
+
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}/{{ item }}"
     state: absent
-  loop:
-    - osm_server.log
-    - osm_server.state
-    - workloads.yml
-
 - name: Detach src volumes if still attached
-  os_server_volume:
+  loop:
+  - server: os_migrate_conv
+    volume: rhosp-migration-root-osm_server
+  - server: os_migrate_conv
+    volume: osm_volume
+  - server: osm_server
+    volume: osm_volume
+  # The module will fail if server or volume don't exist.
+  failed_when: false
+
+  ansible.builtin.os_server_volume:
     server: "{{ item.server }}"
     volume: "{{ item.volume }}"
     state: absent
@@ -17,18 +27,18 @@
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+- name: Detach dst volumes if still attached
   loop:
-    - server: os_migrate_conv
-      volume: rhosp-migration-root-osm_server
-    - server: os_migrate_conv
-      volume: osm_volume
-    - server: osm_server
-      volume: osm_volume
+  - server: os_migrate_conv
+    volume: rhosp-migration-root-osm_server
+  - server: os_migrate_conv
+    volume: osm_volume
+  - server: osm_server
+    volume: osm_volume
   # The module will fail if server or volume don't exist.
   failed_when: false
 
-- name: Detach dst volumes if still attached
-  os_server_volume:
+  ansible.builtin.os_server_volume:
     server: "{{ item.server }}"
     volume: "{{ item.volume }}"
     state: absent
@@ -37,18 +47,20 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop:
-    - server: os_migrate_conv
-      volume: rhosp-migration-root-osm_server
-    - server: os_migrate_conv
-      volume: osm_volume
-    - server: osm_server
-      volume: osm_volume
-  # The module will fail if server or volume don't exist.
-  failed_when: false
-
 - name: Remove osm_server
-  os_server:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_server:
     name: osm_server
     state: absent
     delete_fip: yes
@@ -58,20 +70,20 @@
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
     wait: yes
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: Remove osm_server boot volume
-  os_volume:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_volume:
     display_name: rhosp-migration-root-osm_server
     state: absent
     auth: "{{ item.auth }}"
@@ -79,20 +91,19 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: Remove osm_volume
-  os_volume:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+  ansible.builtin.os_volume:
     display_name: osm_volume
     state: absent
     auth: "{{ item.auth }}"
@@ -100,14 +111,3 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"

--- a/tests/e2e/tenant/run_pre_workload.yml
+++ b/tests/e2e/tenant/run_pre_workload.yml
@@ -6,200 +6,169 @@
 
 - name: Network tasks
   block:
-    - include_role:
-        name: os_migrate.os_migrate.export_networks
-      vars:
+  - vars:
         # This expression should export all osm_ workloads
         # skipping the universal conversion host (osm_uch)
         # which is used to move the VM's.
         # We create it on in seed.yml but we dont export it.
-        os_migrate_networks_filter:
-          - regex: '^osm_(?!uch)'
+      os_migrate_networks_filter:
+      - regex: '^osm_(?!uch)'
 
-    - name: load exported data
-      set_fact:
-        resources: "{{ (lookup('file',
-                               os_migrate_data_dir +
-                               '/networks.yml') | from_yaml)
-                       ['resources'] }}"
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.export_networks
+  - name: load exported data
+    ansible.builtin.set_fact:
+      resources: "{{ (lookup('file', os_migrate_data_dir + '/networks.yml') | from_yaml)\
+        \ ['resources'] }}"
 
-    - name: verify data contents
-      assert:
-        that:
-          - (resources |
-            json_query("[?params.name ==
-            'osm_net'].params.name")
-            == ['osm_net'])
+  - name: verify data contents
+    ansible.builtin.assert:
+      that:
+      - (resources | community.general.json_query("[?params.name == 'osm_net'].params.name") == ['osm_net'])
 
-    - include_role:
-        name: os_migrate.os_migrate.import_networks
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.import_networks
 
 - name: Subnet tasks
   block:
-    - include_role:
-        name: os_migrate.os_migrate.export_subnets
-      vars:
+  - vars:
         # This expression should export all osm_ workloads
         # skipping the universal conversion host (osm_uch)
         # which is used to move the VM's.
         # We create it on in seed.yml but we dont export it.
-        os_migrate_subnets_filter:
-          - regex: '^osm_(?!uch)'
+      os_migrate_subnets_filter:
+      - regex: '^osm_(?!uch)'
 
-    - name: load exported data
-      set_fact:
-        subnet_resources: "{{ (lookup('file',
-                                      os_migrate_data_dir +
-                                      '/subnets.yml') | from_yaml)
-                       ['resources'] }}"
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.export_subnets
+  - name: load exported data
+    ansible.builtin.set_fact:
+      subnet_resources: "{{ (lookup('file', os_migrate_data_dir + '/subnets.yml')\
+        \ | from_yaml) ['resources'] }}"
 
-    - name: verify data contents
-      assert:
-        that:
-          - (subnet_resources |
-            json_query("[?params.name ==
-            'osm_subnet'].params.cidr")
-            == ['192.168.20.0/24'])
+  - name: verify data contents
+    ansible.builtin.assert:
+      that:
+      - (subnet_resources | community.general.json_query("[?params.name == 'osm_subnet'].params.cidr")
+        == ['192.168.20.0/24'])
 
-    - include_role:
-        name: os_migrate.os_migrate.import_subnets
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.import_subnets
 
 - name: Security group tasks
   block:
-    - include_role:
-        name: os_migrate.os_migrate.export_security_groups
-      vars:
-        os_migrate_security_groups_filter:
-          - regex: '^osm_'
+  - vars:
+      os_migrate_security_groups_filter:
+      - regex: '^osm_'
 
-    - name: load exported data
-      set_fact:
-        security_group_resources: "{{ (lookup('file',
-                                              os_migrate_data_dir +
-                                              '/security_groups.yml') |
-                                              from_yaml)
-                       ['resources'] }}"
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.export_security_groups
+  - name: load exported data
+    ansible.builtin.set_fact:
+      security_group_resources: "{{ (lookup('file', os_migrate_data_dir + '/security_groups.yml')\
+        \ | from_yaml) ['resources'] }}"
 
-    - name: verify data contents
-      assert:
-        that:
-          - (security_group_resources |
-            json_query("[?params.name ==
-            'osm_security_group'].params.description")
-            == ['OSM security group'])
+  - name: verify data contents
+    ansible.builtin.assert:
+      that:
+      - (security_group_resources | community.general.json_query("[?params.name == 'osm_security_group'].params.description")
+        == ['OSM security group'])
 
-    - include_role:
-        name: os_migrate.os_migrate.import_security_groups
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.import_security_groups
 
 - name: Security group rules tasks
   block:
-    - include_role:
-        name: os_migrate.os_migrate.export_security_group_rules
-      vars:
-        os_migrate_security_groups_filter:
-          - regex: '^osm_'
+  - vars:
+      os_migrate_security_groups_filter:
+      - regex: '^osm_'
 
-    - name: load exported data
-      set_fact:
-        security_group_rule_resources: "{{ (lookup('file',
-                                               os_migrate_data_dir +
-                                               '/security_group_rules.yml') |
-                                               from_yaml)
-                       ['resources'] }}"
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.export_security_group_rules
+  - name: load exported data
+    ansible.builtin.set_fact:
+      security_group_rule_resources: "{{ (lookup('file', os_migrate_data_dir + '/security_group_rules.yml')\
+        \ | from_yaml) ['resources'] }}"
 
-    - name: verify data contents
-      assert:
-        that:
-          - (security_group_rule_resources |
-            json_query("[?params.security_group_ref.name ==
-            'osm_security_group'].params.remote_ip_prefix")
-            == ['0.0.0.0/0'])
+  - name: verify data contents
+    ansible.builtin.assert:
+      that:
+      - (security_group_rule_resources | community.general.json_query("[?params.security_group_ref.name
+        == 'osm_security_group'].params.remote_ip_prefix") == ['0.0.0.0/0'])
 
-    - include_role:
-        name: os_migrate.os_migrate.import_security_group_rules
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.import_security_group_rules
 
 - name: Router tasks
   block:
-    - include_role:
-        name: os_migrate.os_migrate.export_routers
-      vars:
+  - vars:
         # This expression should export all osm_ workloads
         # skipping the universal conversion host (osm_uch)
         # which is used to move the VM's.
         # We create it on in seed.yml but we dont export it.
-        os_migrate_routers_filter:
-          - regex: '^osm_(?!uch)'
+      os_migrate_routers_filter:
+      - regex: '^osm_(?!uch)'
 
-    - name: load exported data
-      set_fact:
-        router_resources: "{{ (lookup('file',
-                                      os_migrate_data_dir +
-                                      '/routers.yml') | from_yaml)
-                              ['resources'] }}"
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.export_routers
+  - name: load exported data
+    ansible.builtin.set_fact:
+      router_resources: "{{ (lookup('file', os_migrate_data_dir + '/routers.yml')\
+        \ | from_yaml) ['resources'] }}"
 
-    - name: verify data contents
-      assert:
-        that:
-          - "(router_resources |
-              json_query(\"[?params.name ==
-              'osm_router'].params.external_gateway_refinfo.network_ref.name\")) ==
-              [os_migrate_src_osm_router_external_network | default('public')]"
+  - name: verify data contents
+    ansible.builtin.assert:
+      that:
+      - "(router_resources | community.general.json_query(\"[?params.name == 'osm_router'].params.external_gateway_refinfo.network_ref.name\"\
+        )) == [os_migrate_src_osm_router_external_network | default('public')]"
 
-    - include_role:
-        name: os_migrate.os_migrate.import_routers
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.import_routers
 
 - name: Router interface tasks
   block:
-    - include_role:
-        name: os_migrate.os_migrate.export_router_interfaces
-      vars:
+  - vars:
         # This expression should export all osm_ workloads
         # skipping the universal conversion host (osm_uch)
         # which is used to move the VM's.
         # We create it on in seed.yml but we dont export it.
-        os_migrate_routers_filter:
-          - regex: '^osm_(?!uch)'
+      os_migrate_routers_filter:
+      - regex: '^osm_(?!uch)'
 
-    - name: load exported data
-      set_fact:
-        router_interface_resources: "{{ (lookup('file',
-                                         os_migrate_data_dir +
-                                         '/router_interfaces.yml') | from_yaml)
-                                         ['resources'] }}"
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.export_router_interfaces
+  - name: load exported data
+    ansible.builtin.set_fact:
+      router_interface_resources: "{{ (lookup('file', os_migrate_data_dir + '/router_interfaces.yml')\
+        \ | from_yaml) ['resources'] }}"
 
-    - name: verify data contents
-      assert:
-        that:
-          - "(router_interface_resources |
-              json_query(\"[?params.device_ref.name ==
-              'osm_router'].params.fixed_ips_refs[].subnet_ref.name\")) | sort ==
-              ['osm_subnet']"
+  - name: verify data contents
+    ansible.builtin.assert:
+      that:
+      - "(router_interface_resources | community.general.json_query(\"[?params.device_ref.name == 'osm_router'].params.fixed_ips_refs[].subnet_ref.name\"\
+        )) | sort == ['osm_subnet']"
 
-    - include_role:
-        name: os_migrate.os_migrate.import_router_interfaces
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.import_router_interfaces
 
 - name: Image tasks
   block:
-    - include_role:
-        name: os_migrate.os_migrate.export_images
-      vars:
-        os_migrate_images_filter:
-          - regex: '^osm_'
+  - vars:
+      os_migrate_images_filter:
+      - regex: '^osm_'
 
-    - name: load exported data
-      set_fact:
-        resources: "{{ (lookup('file',
-                               os_migrate_data_dir +
-                               '/images.yml') | from_yaml)
-                       ['resources'] }}"
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.export_images
+  - name: load exported data
+    ansible.builtin.set_fact:
+      resources: "{{ (lookup('file', os_migrate_data_dir + '/images.yml') | from_yaml)\
+        \ ['resources'] }}"
 
-    - name: verify data contents
-      assert:
-        that:
-          - (resources |
-            json_query("[?params.name ==
-            'osm_image'].params.min_ram")
-            == [128])
+  - name: verify data contents
+    ansible.builtin.assert:
+      that:
+      - (resources | community.general.json_query("[?params.name == 'osm_image'].params.min_ram") ==
+        [128])
 
-    - include_role:
-        name: os_migrate.os_migrate.import_images
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.import_images

--- a/tests/e2e/tenant/run_workload.yml
+++ b/tests/e2e/tenant/run_workload.yml
@@ -6,37 +6,32 @@
 
 - name: Workloads tasks
   block:
-    - include_role:
-        name: os_migrate.os_migrate.export_workloads
-      vars:
+  - vars:
         # This expression should export all osm_ workloads
         # skipping the universal conversion host (osm_uch)
         # which is used to move the VM's.
         # We create it on in seed.yml but we dont export it.
-        os_migrate_workloads_filter:
-          - regex: '^osm_(?!uch)'
+      os_migrate_workloads_filter:
+      - regex: '^osm_(?!uch)'
 
-    - name: set boot disk copy
-      replace:
-        path: "{{ os_migrate_data_dir }}/workloads.yml"
-        regexp: "boot_disk_copy: false"
-        replace: "boot_disk_copy: true"
-      when: set_boot_volume_copy|default(false)|bool
+    ansible.builtin.include_role:
+      name: os_migrate.os_migrate.export_workloads
+  - name: set boot disk copy
+    when: set_boot_volume_copy|default(false)|bool
 
-    - name: load exported data
-      set_fact:
-        resources: "{{ (lookup('file',
-                               os_migrate_data_dir +
-                               '/workloads.yml') | from_yaml)
-                       ['resources'] }}"
+    ansible.builtin.replace:
+      path: "{{ os_migrate_data_dir }}/workloads.yml"
+      regexp: "boot_disk_copy: false"
+      replace: "boot_disk_copy: true"
+  - name: load exported data
+    ansible.builtin.set_fact:
+      resources: "{{ (lookup('file', os_migrate_data_dir + '/workloads.yml') | from_yaml)\
+        \ ['resources'] }}"
 
-    - name: verify data contents
-      assert:
-        that:
-          - (resources |
-            json_query("[?params.name ==
-            'osm_server'].params.name")
-            == ['osm_server'])
+  - name: verify data contents
+    ansible.builtin.assert:
+      that:
+      - (resources | community.general.json_query("[?params.name == 'osm_server'].params.name") == ['osm_server'])
 
-    - include_role:
-        name: os_migrate.os_migrate.import_workloads
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.import_workloads

--- a/tests/e2e/tenant/scenario_variables.yml
+++ b/tests/e2e/tenant/scenario_variables.yml
@@ -18,8 +18,8 @@ os_migrate_dst_conversion_external_network_name: public
 os_migrate_dst_conversion_flavor_name: m1.medium
 os_migrate_dst_conversion_image_name: CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2
 
-os_migrate_src_validate_certs: False
-os_migrate_dst_validate_certs: False
+os_migrate_src_validate_certs: false
+os_migrate_dst_validate_certs: false
 
 os_migrate_src_release: 13
 os_migrate_dst_release: 13

--- a/tests/e2e/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tenant/seed_pre_workload.yml
@@ -1,50 +1,55 @@
 - name: create osm_net
-  os_network:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+
+  ansible.builtin.os_network:
     auth: "{{ item.auth }}"
     name: osm_net
     # Apparently description is an unsupported param in Ansible even
     # though OpenStack supports it.
     # description: osm_net test network
     state: present
-    mtu: "{{
-      omit if os_migrate_src_release == 10
-      else 1400 }}"
+    mtu: "{{ omit if os_migrate_src_release == 10 else 1400 }}"
     validate_certs: "{{ item.validate_certs }}"
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-
 - name: Create osm subnet
-  os_subnet:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+
+  ansible.builtin.os_subnet:
     auth: "{{ item.auth }}"
     state: present
     network_name: osm_net
     name: osm_subnet
     cidr: 192.168.20.0/24
     dns_nameservers:
-      - 10.11.5.19
+    - 10.11.5.19
     host_routes:
-      - destination: 192.168.20.0/24
-        nexthop: 192.168.20.1
+    - destination: 192.168.20.0/24
+      nexthop: 192.168.20.1
     validate_certs: "{{ item.validate_certs }}"
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-
 - name: Create security group
-  os_security_group:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+
+  ansible.builtin.os_security_group:
     auth: "{{ item.auth }}"
     state: present
     name: osm_security_group
@@ -53,15 +58,15 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-
 - name: Create security group rule
-  os_security_group_rule:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+
+  ansible.builtin.os_security_group_rule:
     auth: "{{ item.auth }}"
     security_group: osm_security_group
     remote_ip_prefix: 0.0.0.0/0
@@ -69,36 +74,29 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-
 - name: create osm_router
-  os_router:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+
+  ansible.builtin.os_router:
     auth: "{{ item.auth }}"
     name: osm_router
     state: present
     network: "{{ os_migrate_src_osm_router_external_network|default(omit) }}"
     interfaces:
-      - net: osm_net
-        subnet: osm_subnet
-        portip: 192.168.20.1
+    - net: osm_net
+      subnet: osm_subnet
+      portip: 192.168.20.1
     validate_certs: "{{ item.validate_certs }}"
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-
 - name: Create the key folder
-  file:
+  ansible.builtin.file:
     path: "{{ '~' | expanduser }}/ssh-ci"
     mode: 0700
     state: directory
@@ -106,11 +104,23 @@
 - name: Generate a keypair for the migration
   # This will not regenerate the key if
   # it already exists
-  openssh_keypair:
+  ansible.builtin.openssh_keypair:
     path: "{{ '~' | expanduser }}/ssh-ci/id_rsa"
 
 - name: Create new keypair as osm_key
-  os_keypair:
+  loop:
+  - auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  - auth: "{{ os_migrate_dst_auth }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+  ansible.builtin.os_keypair:
     auth: "{{ item.auth }}"
     state: present
     name: osm_key
@@ -119,30 +129,18 @@
     ca_cert: "{{ item.ca_cert }}"
     client_cert: "{{ item.client_cert }}"
     client_key: "{{ item.client_key }}"
-  loop:
-    - auth: "{{ os_migrate_src_auth }}"
-      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
-    - auth: "{{ os_migrate_dst_auth }}"
-      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
-      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
-      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
-      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-
 - name: make sure test_inputs dir exists
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_tests_tmp_dir }}/test_inputs"
     state: directory
 
 - name: fetch cirros image
-  get_url:
+  ansible.builtin.get_url:
     url: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
     dest: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
 
 - name: create osm_image
-  os_image:
+  ansible.builtin.os_image:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_image
     filename: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"

--- a/tests/e2e/tenant/seed_workload.yml
+++ b/tests/e2e/tenant/seed_workload.yml
@@ -1,5 +1,5 @@
 - name: Create osm_volume
-  os_volume:
+  ansible.builtin.os_volume:
     display_name: osm_volume
     size: 1
     auth: "{{ os_migrate_src_auth }}"
@@ -9,7 +9,7 @@
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
 
 - name: Create osm_server
-  os_server:
+  ansible.builtin.os_server:
     name: osm_server
     state: present
     flavor: "{{ os_migrate_src_osm_server_flavor|default(m1.small) }}"
@@ -18,7 +18,7 @@
     network: osm_net
     security_groups: osm_security_group
     volumes:
-      - osm_volume
+    - osm_volume
     # We get a floating IP
     # for the workload VM
     auto_ip: yes
@@ -32,7 +32,7 @@
 
 # In order to be able to migrate the VMS they must be turned off
 - name: Shutdown osm_server
-  os_server_action:
+  ansible.builtin.os_server_action:
     auth: "{{ os_migrate_src_auth }}"
     server: osm_server
     action: stop

--- a/tests/e2e/test_as_admin.yml
+++ b/tests/e2e/test_as_admin.yml
@@ -1,22 +1,21 @@
 - name: Test preparation
   hosts: migrator
   tasks:
-    - import_tasks: common/prep.yml
-
+  - ansible.builtin.import_tasks: common/prep.yml
 - name: Migration tests
   hosts: migrator
   tasks:
-    - include_tasks: admin/clean.yml
-      args:
-        apply:
-          tags: test_clean_before
-      tags: always
-    - import_tasks: admin/seed.yml
-    - import_tasks: admin/run.yml
-    - include_tasks: admin/clean.yml
-      args:
-        apply:
-          tags: test_clean_after
-      tags: always
+  - args:
+      apply:
+        tags: test_clean_before
+    tags: always
+    ansible.builtin.include_tasks: admin/clean.yml
+  - ansible.builtin.import_tasks: admin/seed.yml
+  - ansible.builtin.import_tasks: admin/run.yml
+  - args:
+      apply:
+        tags: test_clean_after
+    tags: always
+    ansible.builtin.include_tasks: admin/clean.yml
   tags:
-    - test_migration
+  - test_migration

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -1,20 +1,17 @@
 - name: Test preparation
   hosts: migrator
   tasks:
-    - import_tasks: common/prep.yml
-
+  - ansible.builtin.import_tasks: common/prep.yml
 - name: Make sure conversion hosts are cleaned up
-  import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/delete_conversion_hosts.yml"
-
+  ansible.builtin.import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/delete_conversion_hosts.yml"
 - name: Deploy conversion hosts
-  import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/deploy_conversion_hosts.yml"
-
+  ansible.builtin.import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/deploy_conversion_hosts.yml"
 - name: Conversion host inventory
   hosts: migrator
   tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: conv_hosts_inventory.yml
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+      tasks_from: conv_hosts_inventory.yml
 
 # Immediately unregister the conversion hosts to prevent dangling
 # subscriptions from CI in case the job crashes.
@@ -22,106 +19,106 @@
   hosts: conversion_hosts
   ignore_unreachable: true
   tasks:
-    - include_role:
-        name: os_migrate.os_migrate.conversion_host
-        tasks_from: unregister.yml
+  - ansible.builtin.include_role:
+      name: os_migrate.os_migrate.conversion_host
+      tasks_from: unregister.yml
 
 - name: Migration tests
   hosts: migrator
   tasks:
-    - include_tasks: tenant/clean_workload.yml
-      args:
-        apply:
-          tags:
-            - test_clean_before
-            - test_workload
-            - test_image_workload_boot_copy
-            - test_image_workload_boot_nocopy
-      tags: always
-    - include_tasks: tenant/clean_pre_workload.yml
-      args:
-        apply:
-          tags:
-            - test_clean_before
-            - test_pre_workload
-      tags: always
+  - args:
+      apply:
+        tags:
+        - test_clean_before
+        - test_workload
+        - test_image_workload_boot_copy
+        - test_image_workload_boot_nocopy
+    tags: always
+    ansible.builtin.include_tasks: tenant/clean_workload.yml
+  - args:
+      apply:
+        tags:
+        - test_clean_before
+        - test_pre_workload
+    tags: always
 
     # pre-workload seed & migrate
-    - include_tasks: tenant/seed_pre_workload.yml
-      args:
-        apply:
-          tags: test_pre_workload
-      tags: always
-    - include_tasks: tenant/run_pre_workload.yml
-      args:
-        apply:
-          tags: test_pre_workload
-      tags: always
+    ansible.builtin.include_tasks: tenant/clean_pre_workload.yml
+  - args:
+      apply:
+        tags: test_pre_workload
+    tags: always
+    ansible.builtin.include_tasks: tenant/seed_pre_workload.yml
+  - args:
+      apply:
+        tags: test_pre_workload
+    tags: always
 
     # server from image with attached volume
     # migration w/o boot volume copy
-    - include_tasks: tenant/seed_workload.yml
-      args:
-        apply:
-          tags:
-            - test_workload
-            - test_image_workload_boot_nocopy
-      tags: always
-    - include_tasks: tenant/run_workload.yml
-      args:
-        apply:
-          tags:
-            - test_workload
-            - test_image_workload_boot_nocopy
-      tags: always
-    - include_tasks: tenant/clean_workload.yml
-      args:
-        apply:
-          tags:
-            - test_workload
-            - test_image_workload_boot_nocopy
-            - test_image_workload_boot_nocopy_clean
-      tags: always
+    ansible.builtin.include_tasks: tenant/run_pre_workload.yml
+  - args:
+      apply:
+        tags:
+        - test_workload
+        - test_image_workload_boot_nocopy
+    tags: always
+    ansible.builtin.include_tasks: tenant/seed_workload.yml
+  - args:
+      apply:
+        tags:
+        - test_workload
+        - test_image_workload_boot_nocopy
+    tags: always
+    ansible.builtin.include_tasks: tenant/run_workload.yml
+  - args:
+      apply:
+        tags:
+        - test_workload
+        - test_image_workload_boot_nocopy
+        - test_image_workload_boot_nocopy_clean
+    tags: always
 
     # server from image with attached volume
     # migration with boot volume copy
-    - include_tasks: tenant/seed_workload.yml
-      args:
-        apply:
-          tags:
-            - test_workload
-            - test_image_workload_boot_copy
-      tags: always
-    - include_tasks: tenant/run_workload.yml
-      args:
-        apply:
-          tags:
-            - test_workload
-            - test_image_workload_boot_copy
-      tags: always
-      vars:
-        set_boot_volume_copy: true
-    - include_tasks: tenant/clean_workload.yml
-      args:
-        apply:
-          tags:
-            - test_clean_after
-            - test_workload
-            - test_image_workload_boot_copy
-            - test_image_workload_boot_copy_clean
-      tags: always
+    ansible.builtin.include_tasks: tenant/clean_workload.yml
+  - args:
+      apply:
+        tags:
+        - test_workload
+        - test_image_workload_boot_copy
+    tags: always
+    ansible.builtin.include_tasks: tenant/seed_workload.yml
+  - args:
+      apply:
+        tags:
+        - test_workload
+        - test_image_workload_boot_copy
+    tags: always
+    vars:
+      set_boot_volume_copy: true
+    ansible.builtin.include_tasks: tenant/run_workload.yml
+  - args:
+      apply:
+        tags:
+        - test_clean_after
+        - test_workload
+        - test_image_workload_boot_copy
+        - test_image_workload_boot_copy_clean
+    tags: always
 
     # pre-workload cleanup
-    - include_tasks: tenant/clean_pre_workload.yml
-      args:
-        apply:
-          tags:
-            - test_clean_after
-            - test_pre_workload
-      tags: always
+    ansible.builtin.include_tasks: tenant/clean_workload.yml
+  - args:
+      apply:
+        tags:
+        - test_clean_after
+        - test_pre_workload
+    tags: always
+    ansible.builtin.include_tasks: tenant/clean_pre_workload.yml
   tags:
-    - test_migration
+  - test_migration
 
 - name: Delete conversion hosts
-  import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/delete_conversion_hosts.yml"
   when: test_clean_conversion_hosts_after|default(true)|bool
+  ansible.builtin.import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/delete_conversion_hosts.yml"

--- a/tests/func/admin/clean/all.yml
+++ b/tests/func/admin/clean/all.yml
@@ -1,37 +1,37 @@
 - name: Include keypair tasks
-  include_tasks: keypair.yml
   args:
     apply:
       tags:
-        - test_keypair
-        - test_clean
+      - test_keypair
+      - test_clean
 
+  ansible.builtin.include_tasks: keypair.yml
 - name: Include user tasks
-  include_tasks: user.yml
   args:
     apply:
       tags:
-        - test_user
-        - test_clean
+      - test_user
+      - test_clean
   tags:
-    - always
+  - always
 
+  ansible.builtin.include_tasks: user.yml
 - name: Include project tasks
-  include_tasks: project.yml
   args:
     apply:
       tags:
-        - test_project
-        - test_clean
+      - test_project
+      - test_clean
   tags:
-    - always
+  - always
 
+  ansible.builtin.include_tasks: project.yml
 - name: Include flavor tasks
-  include_tasks: flavor.yml
   args:
     apply:
       tags:
-        - test_flavor
-        - test_clean
+      - test_flavor
+      - test_clean
   tags:
-    - always
+  - always
+  ansible.builtin.include_tasks: flavor.yml

--- a/tests/func/admin/clean/flavor.yml
+++ b/tests/func/admin/clean/flavor.yml
@@ -1,8 +1,8 @@
 - name: remove osm_flavor
-  os_nova_flavor:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_nova_flavor:
     auth: "{{ item }}"
     name: osm_flavor
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/admin/clean/keypair.yml
+++ b/tests/func/admin/clean/keypair.yml
@@ -1,8 +1,8 @@
 - name: remove osm_keypair
-  os_keypair:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_keypair:
     auth: "{{ item }}"
     name: osm_keypair
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/admin/clean/project.yml
+++ b/tests/func/admin/clean/project.yml
@@ -1,8 +1,8 @@
 - name: remove osm_project
-  os_project:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_project:
     auth: "{{ item }}"
     name: osm_project
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/admin/clean/user.yml
+++ b/tests/func/admin/clean/user.yml
@@ -1,8 +1,8 @@
 - name: remove osm_user
-  os_user:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_user:
     auth: "{{ item }}"
     name: osm_user
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/admin/idempotence/all.yml
+++ b/tests/func/admin/idempotence/all.yml
@@ -1,31 +1,31 @@
 - name: Include flavor tasks
-  include_tasks: flavor.yml
   args:
     apply:
       tags:
-        - test_flavor
+      - test_flavor
   tags: always
 
+  ansible.builtin.include_tasks: flavor.yml
 - name: Include keypair tasks
-  include_tasks: keypair.yml
   args:
     apply:
       tags:
-        - test_keypair
+      - test_keypair
   tags: always
 
+  ansible.builtin.include_tasks: keypair.yml
 - name: Include project tasks
-  include_tasks: project.yml
   args:
     apply:
       tags:
-        - test_project
+      - test_project
   tags: always
 
+  ansible.builtin.include_tasks: project.yml
 - name: Include flavor tasks
-  include_tasks: flavor.yml
   args:
     apply:
       tags:
-        - test_flavor
+      - test_flavor
   tags: always
+  ansible.builtin.include_tasks: flavor.yml

--- a/tests/func/admin/idempotence/flavor.yml
+++ b/tests/func/admin/idempotence/flavor.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_flavors
-  vars:
+- vars:
     os_migrate_flavors_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_flavors
 - name: re-load resources for idempotency test
-  set_fact:
-    flavor_resources_idem: "{{ (lookup('file',
-                                os_migrate_data_dir +
-                                '/flavors.yml') | from_yaml)
-                        ['resources'] }}"
+  ansible.builtin.set_fact:
+    flavor_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/flavors.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - flavor_resources_idem == flavor_resources
+    - flavor_resources_idem == flavor_resources
     fail_msg: |
       flavor_resources_idem:
       {{ flavor_resources_idem | to_nice_yaml }}
@@ -25,26 +23,25 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_flavor dst cloud
-  os_flavor_info:
-    auth: "{{ os_migrate_dst_auth }}"
-    name: "osm_flavor"
   register: flavor_import_idem_before
 
-- include_role:
+  ansible.builtin.os_flavor_info:
+    auth: "{{ os_migrate_dst_auth }}"
+    name: "osm_flavor"
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_flavors
 
 - name: look up osm_flavor in dst cloud again
-  os_flavor_info:
-    auth: "{{ os_migrate_dst_auth }}"
-    name: "osm_flavor"
   register: flavor_import_idem_after
 
+  ansible.builtin.os_flavor_info:
+    auth: "{{ os_migrate_dst_auth }}"
+    name: "osm_flavor"
 - name: ensure ram for osm_flavor did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - flavor_import_idem_before['openstack_flavors'][0].ram != None
-      - "flavor_import_idem_before['openstack_flavors'][0]['ram'] \
-         == flavor_import_idem_after['openstack_flavors'][0]['ram']"
+    - flavor_import_idem_before['openstack_flavors'][0].ram != None
+    - "flavor_import_idem_before['openstack_flavors'][0]['ram'] == flavor_import_idem_after['openstack_flavors'][0]['ram']"
     fail_msg: |
       flavor_import_idem_before ram:
       {{ flavor_import_idem_before['openstack_flavors'][0].ram }}

--- a/tests/func/admin/idempotence/keypair.yml
+++ b/tests/func/admin/idempotence/keypair.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_keypairs
-  vars:
+- vars:
     os_migrate_keypairs_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_keypairs
 - name: re-load resources for idempotency test
-  set_fact:
-    keypair_resources_idem: "{{ (lookup('file',
-                                os_migrate_data_dir +
-                                '/keypairs.yml') | from_yaml)
-                        ['resources'] }}"
+  ansible.builtin.set_fact:
+    keypair_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/keypairs.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - keypair_resources_idem == keypair_resources
+    - keypair_resources_idem == keypair_resources
     fail_msg: |
       keypair_resources_idem:
       {{ keypair_resources_idem | to_nice_yaml }}
@@ -26,24 +24,23 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_keypair dst cloud
-  os_migrate.os_migrate.os_keypairs_info:
-    auth: "{{ os_migrate_dst_auth }}"
   register: keypair_import_idem_before
 
-- include_role:
+  ansible.builtin.os_migrate.os_migrate.os_keypairs_info:
+    auth: "{{ os_migrate_dst_auth }}"
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_keypairs
 
 - name: look up osm_keypair in dst cloud again
-  os_migrate.os_migrate.os_keypairs_info:
-    auth: "{{ os_migrate_dst_auth }}"
   register: keypair_import_idem_after
 
+  ansible.builtin.os_migrate.os_migrate.os_keypairs_info:
+    auth: "{{ os_migrate_dst_auth }}"
 - name: ensure fingerprint for osm_keypair did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - keypair_import_idem_before['openstack_keypairs'][0].fingerprint != None
-      - "keypair_import_idem_before['openstack_keypairs'][0]['fingerprint'] \
-         == keypair_import_idem_after['openstack_keypairs'][0]['fingerprint']"
+    - keypair_import_idem_before['openstack_keypairs'][0].fingerprint != None
+    - "keypair_import_idem_before['openstack_keypairs'][0]['fingerprint'] == keypair_import_idem_after['openstack_keypairs'][0]['fingerprint']"
     fail_msg: |
       keypair_import_idem_before fingerprint:
       {{ keypair_import_idem_before['openstack_keypairs'][0].fingerprint }}

--- a/tests/func/admin/idempotence/project.yml
+++ b/tests/func/admin/idempotence/project.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_projects
-  vars:
+- vars:
     os_migrate_projects_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_projects
 - name: re-load project_resources for idempotency test
-  set_fact:
-    project_resources_idem: "{{ (lookup('file',
-                                os_migrate_data_dir +
-                                '/projects.yml') | from_yaml)
-                        ['resources'] }}"
+  ansible.builtin.set_fact:
+    project_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/projects.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - project_resources_idem == project_resources
+    - project_resources_idem == project_resources
     fail_msg: |
       project_resources_idem:
       {{ project_resources_idem | to_nice_yaml }}
@@ -26,28 +24,27 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_project dst cloud
-  os_project_info:
+  register: project_import_idem_before
+
+  ansible.builtin.os_project_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_project
-  register: project_import_idem_before
-
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_projects
 
 - name: look up osm_project in dst cloud again
-  os_project_info:
+  register: project_import_idem_after
+
+  ansible.builtin.os_project_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_project
-  register: project_import_idem_after
-
 - name: ensure is_enabled for osm_project did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - project_import_idem_before['openstack_projects'][0].is_enabled != None
-      - "project_import_idem_before['openstack_projects'][0]['is_enabled'] \
-         == project_import_idem_after['openstack_projects'][0]['is_enabled']"
+    - project_import_idem_before['openstack_projects'][0].is_enabled != None
+    - "project_import_idem_before['openstack_projects'][0]['is_enabled'] == project_import_idem_after['openstack_projects'][0]['is_enabled']"
     fail_msg: |
       project_import_idem_before is_enabled:
       {{ project_import_idem_before['openstack_projects'][0].is_enabled }}

--- a/tests/func/admin/run/all.yml
+++ b/tests/func/admin/run/all.yml
@@ -1,32 +1,32 @@
 - name: Include flavor tasks
-  include_tasks: flavor.yml
   args:
     apply:
       tags:
-        - test_flavor
+      - test_flavor
   tags: always
 
+  ansible.builtin.include_tasks: flavor.yml
 - name: Include keypair tasks
-  include_tasks: keypair.yml
   args:
     apply:
       tags:
-        - test_keypair
+      - test_keypair
   tags: always
 
+  ansible.builtin.include_tasks: keypair.yml
 - name: Include user tasks
-  include_tasks: user.yml
   args:
     apply:
       tags:
-        - test_user
+      - test_user
   tags: always
 
+  ansible.builtin.include_tasks: user.yml
 - name: Include project tasks
-  include_tasks: project.yml
   args:
     apply:
       tags:
-        - test_project
+      - test_project
   tags:
-    - always
+  - always
+  ansible.builtin.include_tasks: project.yml

--- a/tests/func/admin/run/flavor.yml
+++ b/tests/func/admin/run/flavor.yml
@@ -1,23 +1,19 @@
-- include_role:
-    name: os_migrate.os_migrate.export_flavors
-  vars:
+- vars:
     os_migrate_flavors_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_flavors
 - name: load exported data
-  set_fact:
-    flavor_resources: "{{ (lookup('file',
-                                  os_migrate_data_dir +
-                                  '/flavors.yml') | from_yaml)
-                    ['resources'] }}"
+  ansible.builtin.set_fact:
+    flavor_resources: "{{ (lookup('file', os_migrate_data_dir + '/flavors.yml') |\
+      \ from_yaml) ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - (flavor_resources |
-        json_query("[?params.name ==
-        'osm_flavor'].params.name")
-        == ['osm_flavor'])
+    - (flavor_resources | community.general.json_query("[?params.name == 'osm_flavor'].params.name")
+      == ['osm_flavor'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_flavors

--- a/tests/func/admin/run/keypair.yml
+++ b/tests/func/admin/run/keypair.yml
@@ -1,18 +1,16 @@
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_keypairs
 
 - name: load exported data
-  set_fact:
-    keypair_resources: "{{ (lookup('file',
-                                  os_migrate_data_dir +
-                                  '/keypairs.yml') | from_yaml)
-                   ['resources'] }}"
+  ansible.builtin.set_fact:
+    keypair_resources: "{{ (lookup('file', os_migrate_data_dir + '/keypairs.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - (keypair_resources | json_query("[?params.name ==
-                            'osm_keypair']._info.type") == ['ssh'])
+    - (keypair_resources | community.general.json_query("[?params.name == 'osm_keypair']._info.type")
+      == ['ssh'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_keypairs

--- a/tests/func/admin/run/project.yml
+++ b/tests/func/admin/run/project.yml
@@ -3,26 +3,22 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
-    name: os_migrate.os_migrate.export_projects
-  vars:
+- vars:
     os_migrate_projects_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_projects
 - name: load exported data
-  set_fact:
-    project_resources: "{{ (lookup('file',
-                           os_migrate_data_dir +
-                           '/projects.yml') | from_yaml)
-                   ['resources'] }}"
+  ansible.builtin.set_fact:
+    project_resources: "{{ (lookup('file', os_migrate_data_dir + '/projects.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - (project_resources |
-        json_query("[?params.name ==
-        'osm_project'].params.name")
-        == ['osm_project'])
+    - (project_resources | community.general.json_query("[?params.name == 'osm_project'].params.name")
+      == ['osm_project'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_projects

--- a/tests/func/admin/run/user.yml
+++ b/tests/func/admin/run/user.yml
@@ -1,23 +1,18 @@
-- include_role:
-    name: os_migrate.os_migrate.export_users
-  vars:
+- vars:
     os_migrate_users_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_users
 - name: load exported data
-  set_fact:
-    resources: "{{ (lookup('file',
-                           os_migrate_data_dir +
-                           '/users.yml') | from_yaml)
-                   ['resources'] }}"
+  ansible.builtin.set_fact:
+    resources: "{{ (lookup('file', os_migrate_data_dir + '/users.yml') | from_yaml)\
+      \ ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - (resources |
-        json_query("[?params.name ==
-        'osm_user'].params.name")
-        == ['osm_user'])
+    - (resources | community.general.json_query("[?params.name == 'osm_user'].params.name") == ['osm_user'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_users

--- a/tests/func/admin/seed/all.yml
+++ b/tests/func/admin/seed/all.yml
@@ -1,31 +1,31 @@
 - name: Include keypair tasks
-  include_tasks: keypair.yml
   args:
     apply:
       tags:
-        - test_keypair
+      - test_keypair
   tags: always
 
+  ansible.builtin.include_tasks: keypair.yml
 - name: Include user tasks
-  include_tasks: user.yml
   args:
     apply:
       tags:
-        - test_user
+      - test_user
   tags: always
 
+  ansible.builtin.include_tasks: user.yml
 - name: Include project tasks
-  include_tasks: project.yml
   args:
     apply:
       tags:
-        - test_project
+      - test_project
   tags: always
 
+  ansible.builtin.include_tasks: project.yml
 - name: Include flavor tasks
-  include_tasks: flavor.yml
   args:
     apply:
       tags:
-        - test_flavor
+      - test_flavor
   tags: always
+  ansible.builtin.include_tasks: flavor.yml

--- a/tests/func/admin/seed/flavor.yml
+++ b/tests/func/admin/seed/flavor.yml
@@ -1,5 +1,5 @@
 - name: create osm_flavor
-  os_nova_flavor:
+  ansible.builtin.os_nova_flavor:
     auth: "{{ os_migrate_src_auth }}"
     state: present
     name: osm_flavor

--- a/tests/func/admin/seed/keypair.yml
+++ b/tests/func/admin/seed/keypair.yml
@@ -1,5 +1,5 @@
 - name: create osm_keypair
-  os_keypair:
+  ansible.builtin.os_keypair:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_keypair
     state: present

--- a/tests/func/admin/seed/project.yml
+++ b/tests/func/admin/seed/project.yml
@@ -1,5 +1,5 @@
 - name: create osm_project
-  os_project:
+  ansible.builtin.os_project:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_project
     domain: default

--- a/tests/func/admin/seed/user.yml
+++ b/tests/func/admin/seed/user.yml
@@ -1,5 +1,5 @@
 - name: create osm_user
-  os_user:
+  ansible.builtin.os_user:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_user
     state: present

--- a/tests/func/admin/update/all.yml
+++ b/tests/func/admin/update/all.yml
@@ -1,7 +1,7 @@
 - name: Include project tasks
-  include_tasks: project.yml
   args:
     apply:
       tags:
-        - test_project
+      - test_project
   tags: always
+  ansible.builtin.include_tasks: project.yml

--- a/tests/func/admin/update/project.yml
+++ b/tests/func/admin/update/project.yml
@@ -1,44 +1,44 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/projects.yml"
     regexp: "    description: seeded"
     replace: "    description: 'osm_project_updated'"
     backup: yes
 
 - name: scan available projects after before test
-  os_project_info:
+  register: dst_projects_info_before
+
+  ansible.builtin.os_project_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_project
-  register: dst_projects_info_before
-
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
-      {{ dst_projects_info_before['openstack_projects'] | json_query(
+      {{ dst_projects_info_before['openstack_projects'] | community.general.json_query(
         "[?name=='osm_project'].description") }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_projects
 
 - name: scan available projects after update test
-  os_project_info:
+  register: dst_projects_info_after
+
+  ansible.builtin.os_project_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_project
-  register: dst_projects_info_after
-
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
-      {{ dst_projects_info_after['openstack_projects'] | json_query(
+      {{ dst_projects_info_after['openstack_projects'] | community.general.json_query(
         "[?name=='osm_project'].description") }}
 
 - name: ensure description for osm_project changed
-  assert:
+  ansible.builtin.assert:
     that:
-      - original_desc == ['seeded']
-      - changed_desc == ['osm_project_updated']
+    - original_desc == ['seeded']
+    - changed_desc == ['osm_project_updated']
     fail_msg: |
       dst_projects_info_before description:
       {{ original_desc }}

--- a/tests/func/global/prep.yml
+++ b/tests/func/global/prep.yml
@@ -1,24 +1,24 @@
 # make sure no artifacts from prevoius test persisted
 - name: delete os_migrate_data_dir
-  file:
+  tags:
+  - always
+  - test_prep
+
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}"
     state: absent
-  tags:
-    - always
-    - test_prep
-
 - name: create os_migrate_tests_tmp_dir
-  file:
+  tags:
+  - always
+  - test_prep
+
+  ansible.builtin.file:
     path: "{{ os_migrate_tests_tmp_dir }}"
     state: directory
-  tags:
-    - always
-    - test_prep
-
 - name: create os_migrate_data_dir
-  file:
+  tags:
+  - always
+  - test_prep
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}"
     state: directory
-  tags:
-    - always
-    - test_prep

--- a/tests/func/tenant/clean/all.yml
+++ b/tests/func/tenant/clean/all.yml
@@ -1,58 +1,58 @@
 - name: Include image tasks
-  include_tasks: image.yml
   args:
     apply:
       tags:
-        - test_image
-        - test_clean
+      - test_image
+      - test_clean
   tags: always
 
+  ansible.builtin.include_tasks: image.yml
 - name: Include router tasks
-  include_tasks: router.yml
   args:
     apply:
       tags:
-        - test_router
-        - test_clean
+      - test_router
+      - test_clean
   tags:
-    - always
+  - always
 
+  ansible.builtin.include_tasks: router.yml
 - name: Include subnet tasks
-  include_tasks: subnet.yml
   args:
     apply:
       tags:
-        - test_subnet
-        - test_clean
+      - test_subnet
+      - test_clean
   tags:
-    - always
+  - always
 
+  ansible.builtin.include_tasks: subnet.yml
 - name: Include network tasks
-  include_tasks: network.yml
   args:
     apply:
       tags:
-        - test_network
-        - test_clean
+      - test_network
+      - test_clean
   tags:
-    - always
+  - always
 
+  ansible.builtin.include_tasks: network.yml
 - name: Include security group rule tasks
-  include_tasks: security_group_rule.yml
   args:
     apply:
       tags:
-        - test_security_group_rule
-        - test_clean
+      - test_security_group_rule
+      - test_clean
   tags:
-    - always
+  - always
 
+  ansible.builtin.include_tasks: security_group_rule.yml
 - name: Include security group tasks
-  include_tasks: security_group.yml
   args:
     apply:
       tags:
-        - test_security_group
-        - test_clean
+      - test_security_group
+      - test_clean
   tags:
-    - always
+  - always
+  ansible.builtin.include_tasks: security_group.yml

--- a/tests/func/tenant/clean/image.yml
+++ b/tests/func/tenant/clean/image.yml
@@ -1,8 +1,8 @@
 - name: remove osm_image
-  os_image:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_image:
     auth: "{{ item }}"
     name: osm_image
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/tenant/clean/network.yml
+++ b/tests/func/tenant/clean/network.yml
@@ -1,8 +1,8 @@
 - name: remove osm_net
-  os_network:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_network:
     auth: "{{ item }}"
     name: osm_net
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/tenant/clean/router.yml
+++ b/tests/func/tenant/clean/router.yml
@@ -1,8 +1,8 @@
 - name: remove osm_router
-  os_router:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_router:
     auth: "{{ item }}"
     name: osm_router
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/tenant/clean/security_group.yml
+++ b/tests/func/tenant/clean/security_group.yml
@@ -1,8 +1,8 @@
 - name: remove osm_security_group
-  os_security_group:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_security_group:
     auth: "{{ item }}"
     name: osm_security_group
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/tenant/clean/security_group_rule.yml
+++ b/tests/func/tenant/clean/security_group_rule.yml
@@ -1,8 +1,8 @@
 - name: remove osm_security_group_rule
-  os_security_group_rule:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_security_group_rule:
     auth: "{{ item }}"
     security_group: osm_security_group
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/tenant/clean/subnet.yml
+++ b/tests/func/tenant/clean/subnet.yml
@@ -1,17 +1,17 @@
 - name: remove osm_subnet
-  os_subnet:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+
+  ansible.builtin.os_subnet:
     auth: "{{ item }}"
     name: osm_subnet
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"
-
 - name: remove osm_router_subnet
-  os_subnet:
+  loop:
+  - "{{ os_migrate_src_auth }}"
+  - "{{ os_migrate_dst_auth }}"
+  ansible.builtin.os_subnet:
     auth: "{{ item }}"
     name: osm_router_subnet
     state: absent
-  loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"

--- a/tests/func/tenant/data/validate_data_dir/invalid/networks-duplicate.yml
+++ b/tests/func/tenant/data/validate_data_dir/invalid/networks-duplicate.yml
@@ -1,30 +1,30 @@
 os_migrate_version: 0.6.0
 resources:
-  - _info:
-      availability_zones: []
-      created_at: '2020-02-17T16:02:56Z'
-      id: ee2f0425-d87f-4173-90e5-b8993665a033
-      project_id: fc4098dfdf564598812a2a73c49c46df
-      qos_policy_id: null
-      revision_number: 1
-      status: ACTIVE
-      subnet_ids: []
-      updated_at: '2020-02-17T16:02:56Z'
-    params:
-      availability_zone_hints: []
-      description: osm_net test network
-      dns_domain: null
-      is_admin_state_up: true
-      is_default: null
-      is_port_security_enabled: true
-      is_router_external: false
-      is_shared: false
-      is_vlan_transparent: null
-      mtu: 1450
-      name: osm_net
-      provider_network_type: null
-      provider_physical_network: null
-      provider_segmentation_id: null
-      qos_policy_name: null
-      segments: null
-    type: openstack.network.Network
+- _info:
+    availability_zones: []
+    created_at: '2020-02-17T16:02:56Z'
+    id: ee2f0425-d87f-4173-90e5-b8993665a033
+    project_id: fc4098dfdf564598812a2a73c49c46df
+    qos_policy_id:
+    revision_number: 1
+    status: ACTIVE
+    subnet_ids: []
+    updated_at: '2020-02-17T16:02:56Z'
+  params:
+    availability_zone_hints: []
+    description: osm_net test network
+    dns_domain:
+    is_admin_state_up: true
+    is_default:
+    is_port_security_enabled: true
+    is_router_external: false
+    is_shared: false
+    is_vlan_transparent:
+    mtu: 1450
+    name: osm_net
+    provider_network_type:
+    provider_physical_network:
+    provider_segmentation_id:
+    qos_policy_name:
+    segments:
+  type: openstack.network.Network

--- a/tests/func/tenant/data/validate_data_dir/invalid/networks.yml
+++ b/tests/func/tenant/data/validate_data_dir/invalid/networks.yml
@@ -1,30 +1,30 @@
 os_migrate_version: 0.6.0
 resources:
-  - _info:
-      availability_zones: []
-      created_at: '2020-02-17T16:02:56Z'
-      id: ee2f0425-d87f-4173-90e5-b8993665a033
-      project_id: fc4098dfdf564598812a2a73c49c46df
-      qos_policy_id: null
-      revision_number: 1
-      status: ACTIVE
-      subnet_ids: []
-      updated_at: '2020-02-17T16:02:56Z'
-    params:
-      availability_zone_hints: []
-      description: osm_net test network
-      dns_domain: null
-      is_admin_state_up: true
-      is_default: null
-      is_port_security_enabled: true
-      is_router_external: false
-      is_shared: false
-      is_vlan_transparent: null
-      mtu: 1450
-      name: osm_net
-      provider_network_type: null
-      provider_physical_network: null
-      provider_segmentation_id: null
-      qos_policy_name: null
-      segments: null
-    type: openstack.network.Network
+- _info:
+    availability_zones: []
+    created_at: '2020-02-17T16:02:56Z'
+    id: ee2f0425-d87f-4173-90e5-b8993665a033
+    project_id: fc4098dfdf564598812a2a73c49c46df
+    qos_policy_id:
+    revision_number: 1
+    status: ACTIVE
+    subnet_ids: []
+    updated_at: '2020-02-17T16:02:56Z'
+  params:
+    availability_zone_hints: []
+    description: osm_net test network
+    dns_domain:
+    is_admin_state_up: true
+    is_default:
+    is_port_security_enabled: true
+    is_router_external: false
+    is_shared: false
+    is_vlan_transparent:
+    mtu: 1450
+    name: osm_net
+    provider_network_type:
+    provider_physical_network:
+    provider_segmentation_id:
+    qos_policy_name:
+    segments:
+  type: openstack.network.Network

--- a/tests/func/tenant/data/validate_data_dir/valid/networks.yml
+++ b/tests/func/tenant/data/validate_data_dir/valid/networks.yml
@@ -1,30 +1,30 @@
 os_migrate_version: 0.6.0
 resources:
-  - _info:
-      availability_zones: []
-      created_at: '2020-02-17T16:02:56Z'
-      id: ee2f0425-d87f-4173-90e5-b8993665a033
-      project_id: fc4098dfdf564598812a2a73c49c46df
-      qos_policy_id: null
-      revision_number: 1
-      status: ACTIVE
-      subnet_ids: []
-      updated_at: '2020-02-17T16:02:56Z'
-    params:
-      availability_zone_hints: []
-      description: osm_net test network
-      dns_domain: null
-      is_admin_state_up: true
-      is_default: null
-      is_port_security_enabled: true
-      is_router_external: false
-      is_shared: false
-      is_vlan_transparent: null
-      mtu: 1450
-      name: osm_net
-      provider_network_type: null
-      provider_physical_network: null
-      provider_segmentation_id: null
-      qos_policy_name: null
-      segments: null
-    type: openstack.network.Network
+- _info:
+    availability_zones: []
+    created_at: '2020-02-17T16:02:56Z'
+    id: ee2f0425-d87f-4173-90e5-b8993665a033
+    project_id: fc4098dfdf564598812a2a73c49c46df
+    qos_policy_id:
+    revision_number: 1
+    status: ACTIVE
+    subnet_ids: []
+    updated_at: '2020-02-17T16:02:56Z'
+  params:
+    availability_zone_hints: []
+    description: osm_net test network
+    dns_domain:
+    is_admin_state_up: true
+    is_default:
+    is_port_security_enabled: true
+    is_router_external: false
+    is_shared: false
+    is_vlan_transparent:
+    mtu: 1450
+    name: osm_net
+    provider_network_type:
+    provider_physical_network:
+    provider_segmentation_id:
+    qos_policy_name:
+    segments:
+  type: openstack.network.Network

--- a/tests/func/tenant/idempotence/all.yml
+++ b/tests/func/tenant/idempotence/all.yml
@@ -1,54 +1,54 @@
 - name: Include network tasks
-  include_tasks: network.yml
   args:
     apply:
       tags:
-        - test_network
+      - test_network
   tags: always
 
+  ansible.builtin.include_tasks: network.yml
 - name: Include subnet tasks
-  include_tasks: subnet.yml
   args:
     apply:
       tags:
-        - test_subnet
+      - test_subnet
   tags: always
 
+  ansible.builtin.include_tasks: subnet.yml
 - name: Include security group tasks
-  include_tasks: security_group.yml
   args:
     apply:
       tags:
-        - test_security_group
+      - test_security_group
   tags: always
 
+  ansible.builtin.include_tasks: security_group.yml
 - name: Include router tasks
-  include_tasks: router.yml
   args:
     apply:
       tags:
-        - test_router
+      - test_router
 
+  ansible.builtin.include_tasks: router.yml
 - name: Include security group rule tasks
-  include_tasks: security_group_rule.yml
   args:
     apply:
       tags:
-        - test_security_group_rule
+      - test_security_group_rule
   tags: always
 
+  ansible.builtin.include_tasks: security_group_rule.yml
 - name: Include router interface tasks
-  include_tasks: router_interface.yml
   args:
     apply:
       tags:
-        - test_router_interface
+      - test_router_interface
   tags: always
 
+  ansible.builtin.include_tasks: router_interface.yml
 - name: Include image tasks
-  include_tasks: image.yml
   args:
     apply:
       tags:
-        - test_image
+      - test_image
   tags: always
+  ansible.builtin.include_tasks: image.yml

--- a/tests/func/tenant/idempotence/image.yml
+++ b/tests/func/tenant/idempotence/image.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_images
-  vars:
+- vars:
     os_migrate_images_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_images
 - name: re-load image_resources for idempotency test
-  set_fact:
-    image_resources_idem: "{{ (lookup('file',
-                                  os_migrate_data_dir +
-                                  '/images.yml') | from_yaml)
-                              ['resources'] }}"
+  ansible.builtin.set_fact:
+    image_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/images.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - image_resources_idem == image_resources
+    - image_resources_idem == image_resources
     fail_msg: |
       image_resources_idem:
       {{ image_resources_idem | to_nice_yaml }}
@@ -26,26 +24,25 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_image dst cloud
-  os_image_info:
-    auth: "{{ os_migrate_dst_auth }}"
-    image: osm_image
   register: image_import_idem_before
 
-- include_role:
+  ansible.builtin.os_image_info:
+    auth: "{{ os_migrate_dst_auth }}"
+    image: osm_image
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_images
 
 - name: look up osm_image in dst cloud again
-  os_image_info:
-    auth: "{{ os_migrate_dst_auth }}"
-    image: osm_image
   register: image_import_idem_after
 
+  ansible.builtin.os_image_info:
+    auth: "{{ os_migrate_dst_auth }}"
+    image: osm_image
 - name: ensure updated_at for osm_image did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - image_import_idem_before['openstack_image'].updated_at != None
-      - "image_import_idem_before['openstack_image']['updated_at'] \
-         == image_import_idem_after['openstack_image']['updated_at']"
+    - image_import_idem_before['openstack_image'].updated_at != None
+    - "image_import_idem_before['openstack_image']['updated_at'] == image_import_idem_after['openstack_image']['updated_at']"
     fail_msg: |
       image_import_idem_before updated_at:
       {{ image_import_idem_before['openstack_image'].updated_at }}

--- a/tests/func/tenant/idempotence/network.yml
+++ b/tests/func/tenant/idempotence/network.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_networks
-  vars:
+- vars:
     os_migrate_networks_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_networks
 - name: re-load network_resources for idempotency test
-  set_fact:
-    network_resources_idem: "{{ (lookup('file',
-                                os_migrate_data_dir +
-                                '/networks.yml') | from_yaml)
-                        ['resources'] }}"
+  ansible.builtin.set_fact:
+    network_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/networks.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - network_resources_idem == network_resources
+    - network_resources_idem == network_resources
     fail_msg: |
       network_resources_idem:
       {{ network_resources_idem | to_nice_yaml }}
@@ -26,28 +24,27 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_net dst cloud
-  os_networks_info:
+  register: network_import_idem_before
+
+  ansible.builtin.os_networks_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_net
-  register: network_import_idem_before
-
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_networks
 
 - name: look up osm_net in dst cloud again
-  os_networks_info:
+  register: network_import_idem_after
+
+  ansible.builtin.os_networks_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_net
-  register: network_import_idem_after
-
 - name: ensure updated_at for osm_net did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - network_import_idem_before['openstack_networks'][0].updated_at != None
-      - "network_import_idem_before['openstack_networks'][0]['updated_at'] \
-         == network_import_idem_after['openstack_networks'][0]['updated_at']"
+    - network_import_idem_before['openstack_networks'][0].updated_at != None
+    - "network_import_idem_before['openstack_networks'][0]['updated_at'] == network_import_idem_after['openstack_networks'][0]['updated_at']"
     fail_msg: |
       network_import_idem_before updated_at:
       {{ network_import_idem_before['openstack_networks'][0].updated_at }}

--- a/tests/func/tenant/idempotence/router.yml
+++ b/tests/func/tenant/idempotence/router.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_routers
-  vars:
+- vars:
     os_migrate_routers_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_routers
 - name: re-load resources for idempotency test
-  set_fact:
-    router_resources_idem: "{{ (lookup('file',
-                                os_migrate_data_dir +
-                                '/routers.yml') | from_yaml)
-                        ['resources'] }}"
+  ansible.builtin.set_fact:
+    router_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/routers.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - router_resources_idem == router_resources
+    - router_resources_idem == router_resources
     fail_msg: |
       router_resources_idem:
       {{ router_resources_idem | to_nice_yaml }}
@@ -26,28 +24,27 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_router dst cloud
-  os_migrate.os_migrate.os_routers_info:
+  register: router_import_idem_before
+
+  ansible.builtin.os_migrate.os_migrate.os_routers_info:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-  register: router_import_idem_before
-
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_routers
 
 - name: look up osm_router in dst cloud again
-  os_migrate.os_migrate.os_routers_info:
+  register: router_import_idem_after
+
+  ansible.builtin.os_migrate.os_migrate.os_routers_info:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-  register: router_import_idem_after
-
 - name: ensure updated_at for osm_router did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - router_import_idem_before['openstack_routers'][0].updated_at != None
-      - "router_import_idem_before['openstack_routers'][0]['updated_at'] \
-         == router_import_idem_after['openstack_routers'][0]['updated_at']"
+    - router_import_idem_before['openstack_routers'][0].updated_at != None
+    - "router_import_idem_before['openstack_routers'][0]['updated_at'] == router_import_idem_after['openstack_routers'][0]['updated_at']"
     fail_msg: |
       router_import_idem_before updated_at:
       {{ router_import_idem_before['openstack_routers'][0].updated_at }}

--- a/tests/func/tenant/idempotence/router_interface.yml
+++ b/tests/func/tenant/idempotence/router_interface.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_router_interfaces
-  vars:
+- vars:
     os_migrate_routers_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_router_interfaces
 - name: re-load resources for idempotency test
-  set_fact:
-    router_interface_resources_idem: "{{ (lookup('file',
-                                os_migrate_data_dir +
-                                '/router_interfaces.yml') | from_yaml)
-                        ['resources'] }}"
+  ansible.builtin.set_fact:
+    router_interface_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/router_interfaces.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - router_interface_resources_idem == router_interface_resources
+    - router_interface_resources_idem == router_interface_resources
     fail_msg: |
       router_interface_resources_idem:
       {{ router_interface_resources_idem | to_nice_yaml }}
@@ -26,28 +24,27 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_router dst cloud
-  os_migrate.os_migrate.os_routers_info:
+  register: ri_import_idem_before
+
+  ansible.builtin.os_migrate.os_migrate.os_routers_info:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-  register: ri_import_idem_before
-
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_router_interfaces
 
 - name: look up osm_router in dst cloud again
-  os_migrate.os_migrate.os_routers_info:
+  register: ri_import_idem_after
+
+  ansible.builtin.os_migrate.os_migrate.os_routers_info:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-  register: ri_import_idem_after
-
 - name: ensure updated_at for osm_router did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - ri_import_idem_before['openstack_routers'][0].updated_at != None
-      - "ri_import_idem_before['openstack_routers'][0]['updated_at'] \
-         == ri_import_idem_after['openstack_routers'][0]['updated_at']"
+    - ri_import_idem_before['openstack_routers'][0].updated_at != None
+    - "ri_import_idem_before['openstack_routers'][0]['updated_at'] == ri_import_idem_after['openstack_routers'][0]['updated_at']"
     fail_msg: |
       ri_import_idem_before updated_at:
       {{ ri_import_idem_before['openstack_routers'][0].updated_at }}

--- a/tests/func/tenant/idempotence/security_group.yml
+++ b/tests/func/tenant/idempotence/security_group.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_security_groups
-  vars:
+- vars:
     os_migrate_security_groups_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_security_groups
 - name: re-load resources for idempotency test
-  set_fact:
-    sec_group_resources_idem: "{{ (lookup('file',
-                                   os_migrate_data_dir +
-                                   '/security_groups.yml') | from_yaml)
-                                   ['resources'] }}"
+  ansible.builtin.set_fact:
+    sec_group_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/security_groups.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - sec_group_resources_idem == security_group_resources
+    - sec_group_resources_idem == security_group_resources
     fail_msg: |
       sec_group_resources_idem:
       {{ sec_group_resources_idem | to_nice_yaml }}
@@ -26,28 +24,27 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_security_group dst cloud
-  os_migrate.os_migrate.os_security_groups_info:
+  register: sg_import_idem_before
+
+  ansible.builtin.os_migrate.os_migrate.os_security_groups_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_security_group
-  register: sg_import_idem_before
-
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_groups
 
 - name: look up osm_security_group in dst cloud again
-  os_migrate.os_migrate.os_security_groups_info:
+  register: sg_import_idem_after
+
+  ansible.builtin.os_migrate.os_migrate.os_security_groups_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_security_group
-  register: sg_import_idem_after
-
 - name: ensure updated_at for osm_security_group did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - sg_import_idem_before['openstack_security_groups'][0].updated_at != None
-      - "sg_import_idem_before['openstack_security_groups'][0]['updated_at'] \
-         == sg_import_idem_after['openstack_security_groups'][0]['updated_at']"
+    - sg_import_idem_before['openstack_security_groups'][0].updated_at != None
+    - "sg_import_idem_before['openstack_security_groups'][0]['updated_at'] == sg_import_idem_after['openstack_security_groups'][0]['updated_at']"
     fail_msg: |
       sg_import_idem_before updated_at:
       {{ sg_import_idem_before['openstack_security_groups'][0].updated_at }}

--- a/tests/func/tenant/idempotence/security_group_rule.yml
+++ b/tests/func/tenant/idempotence/security_group_rule.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_security_group_rules
-  vars:
+- vars:
     os_migrate_security_groups_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_security_group_rules
 - name: re-load resources for idempotency test
-  set_fact:
-    sgr_resources_idem: "{{ (lookup('file',
-                                os_migrate_data_dir +
-                                '/security_group_rules.yml') | from_yaml)
-                        ['resources'] }}"
+  ansible.builtin.set_fact:
+    sgr_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/security_group_rules.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - sgr_resources_idem == security_group_rule_resources
+    - sgr_resources_idem == security_group_rule_resources
     fail_msg: |
       sgr_resources_idem:
       {{ sgr_resources_idem | to_nice_yaml }}
@@ -26,29 +24,27 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_security_group dst cloud
-  os_migrate.os_migrate.os_security_groups_info:
+  register: sgr_import_idem_before
+
+  ansible.builtin.os_migrate.os_migrate.os_security_groups_info:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-  register: sgr_import_idem_before
-
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_group_rules
 
 - name: look up osm_security_group dst cloud again
-  os_migrate.os_migrate.os_security_groups_info:
+  register: sgr_import_idem_after
+
+  ansible.builtin.os_migrate.os_migrate.os_security_groups_info:
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
-  register: sgr_import_idem_after
-
 - name: ensure updated_at for osm_security_group did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - "sgr_import_idem_before['openstack_security_groups'][0].updated_at
-        != None"
-      - "sgr_import_idem_before['openstack_security_groups'][0]['updated_at'] \
-         == sgr_import_idem_after['openstack_security_groups'][0]['updated_at']"
+    - "sgr_import_idem_before['openstack_security_groups'][0].updated_at != None"
+    - "sgr_import_idem_before['openstack_security_groups'][0]['updated_at'] == sgr_import_idem_after['openstack_security_groups'][0]['updated_at']"
     fail_msg: |
       sgr_import_idem_before updated_at:
       {{ sgr_import_idem_before['openstack_security_groups'][0].updated_at }}

--- a/tests/func/tenant/idempotence/subnet.yml
+++ b/tests/func/tenant/idempotence/subnet.yml
@@ -1,22 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
-    name: os_migrate.os_migrate.export_subnets
-  vars:
+- vars:
     os_migrate_subnets_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_subnets
 - name: re-load resources for idempotency test
-  set_fact:
-    subnet_resources_idem: "{{ (lookup('file',
-                                os_migrate_data_dir +
-                                '/subnets.yml') | from_yaml)
-                        ['resources'] }}"
+  ansible.builtin.set_fact:
+    subnet_resources_idem: "{{ (lookup('file', os_migrate_data_dir + '/subnets.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - subnet_resources_idem == subnet_resources
+    - subnet_resources_idem == subnet_resources
     fail_msg: |
       subnet_resources_idem:
       {{ subnet_resources_idem | to_nice_yaml }}
@@ -26,28 +24,27 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_subnet dst cloud
-  os_subnets_info:
+  register: subnet_import_idem_before
+
+  ansible.builtin.os_subnets_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_subnet
-  register: subnet_import_idem_before
-
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_subnets
 
 - name: look up osm_subnet in dst cloud again
-  os_subnets_info:
+  register: subnet_import_idem_after
+
+  ansible.builtin.os_subnets_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_subnet
-  register: subnet_import_idem_after
-
 - name: ensure updated_at for osm_subnet did not change
-  assert:
+  ansible.builtin.assert:
     that:
-      - subnet_import_idem_before['openstack_subnets'][0].updated_at != None
-      - "subnet_import_idem_before['openstack_subnets'][0]['updated_at'] \
-         == subnet_import_idem_after['openstack_subnets'][0]['updated_at']"
+    - subnet_import_idem_before['openstack_subnets'][0].updated_at != None
+    - "subnet_import_idem_before['openstack_subnets'][0]['updated_at'] == subnet_import_idem_after['openstack_subnets'][0]['updated_at']"
     fail_msg: |
       subnet_import_idem_before updated_at:
       {{ subnet_import_idem_before['openstack_subnets'][0].updated_at }}

--- a/tests/func/tenant/independent/all.yml
+++ b/tests/func/tenant/independent/all.yml
@@ -1,6 +1,6 @@
 - name: Include validate data dir tasks
-  include_tasks: validate_data_dir.yml
   args:
     apply:
       tags:
-        - test_validate_data_dir
+      - test_validate_data_dir
+  ansible.builtin.include_tasks: validate_data_dir.yml

--- a/tests/func/tenant/independent/validate_data_dir.yml
+++ b/tests/func/tenant/independent/validate_data_dir.yml
@@ -1,27 +1,27 @@
 - name: validate valid dir
   changed_when: true
-  shell: |
+  ansible.builtin.shell: |
     OS_MIGRATE="$HOME/.ansible/collections/ansible_collections/os_migrate/os_migrate"
     OS_MIGRATE_DATA="{{ playbook_dir }}/tenant/data/validate_data_dir/valid"
     ansible-playbook -v \
         -i $OS_MIGRATE/localhost_inventory.yml \
         -e "os_migrate_data_dir=$OS_MIGRATE_DATA" \
         $OS_MIGRATE/playbooks/validate_data_dir.yml
-
 - name: validate invalid dir
   changed_when: true
-  shell: |
+  failed_when: false
+  register: validate_data_dir_invalid_result
+
+  ansible.builtin.shell: |
     OS_MIGRATE="$HOME/.ansible/collections/ansible_collections/os_migrate/os_migrate"
     OS_MIGRATE_DATA="{{ playbook_dir }}/tenant/data/validate_data_dir/invalid"
     ansible-playbook -v \
         -i $OS_MIGRATE/localhost_inventory.yml \
         -e "os_migrate_data_dir=$OS_MIGRATE_DATA" \
         $OS_MIGRATE/playbooks/validate_data_dir.yml
-  failed_when: false
-  register: validate_data_dir_invalid_result
-
 - name: assert invalid dir validation failed
-  fail:
+  when: validate_data_dir_invalid_result.rc == 0
+  ansible.builtin.fail:
     msg: |
       =======
       STDOUT:
@@ -31,4 +31,3 @@
       STDERR:
       =======
       {{ validate_data_dir_invalid_result.stderr }}
-  when: validate_data_dir_invalid_result.rc == 0

--- a/tests/func/tenant/run/all.yml
+++ b/tests/func/tenant/run/all.yml
@@ -1,55 +1,55 @@
 - name: Include network tasks
-  include_tasks: network.yml
   args:
     apply:
       tags:
-        - test_network
+      - test_network
   tags: always
 
+  ansible.builtin.include_tasks: network.yml
 - name: Include subnet tasks
-  include_tasks: subnet.yml
   args:
     apply:
       tags:
-        - test_subnet
+      - test_subnet
   tags: always
 
+  ansible.builtin.include_tasks: subnet.yml
 - name: Include security group tasks
-  include_tasks: security_group.yml
   args:
     apply:
       tags:
-        - test_security_group
+      - test_security_group
   tags: always
 
+  ansible.builtin.include_tasks: security_group.yml
 - name: Include security group rules tasks
-  include_tasks: security_group_rule.yml
   args:
     apply:
       tags:
-        - test_security_group_rule
+      - test_security_group_rule
   tags: always
 
+  ansible.builtin.include_tasks: security_group_rule.yml
 - name: Include router tasks
-  include_tasks: router.yml
   args:
     apply:
       tags:
-        - test_router
+      - test_router
   tags: always
 
+  ansible.builtin.include_tasks: router.yml
 - name: Include router interface tasks
-  include_tasks: router_interface.yml
   args:
     apply:
       tags:
-        - test_router
+      - test_router
   tags: always
 
+  ansible.builtin.include_tasks: router_interface.yml
 - name: Include image tasks
-  include_tasks: image.yml
   args:
     apply:
       tags:
-        - test_image
+      - test_image
   tags: always
+  ansible.builtin.include_tasks: image.yml

--- a/tests/func/tenant/run/image.yml
+++ b/tests/func/tenant/run/image.yml
@@ -3,26 +3,22 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
-    name: os_migrate.os_migrate.export_images
-  vars:
+- vars:
     os_migrate_images_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_images
 - name: load exported data
-  set_fact:
-    image_resources: "{{ (lookup('file',
-                           os_migrate_data_dir +
-                           '/images.yml') | from_yaml)
-                   ['resources'] }}"
+  ansible.builtin.set_fact:
+    image_resources: "{{ (lookup('file', os_migrate_data_dir + '/images.yml') | from_yaml)\
+      \ ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - (image_resources |
-        json_query("[?params.name ==
-        'osm_image'].params.min_ram")
-        == [128])
+    - (image_resources | community.general.json_query("[?params.name == 'osm_image'].params.min_ram")
+      == [128])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_images

--- a/tests/func/tenant/run/network.yml
+++ b/tests/func/tenant/run/network.yml
@@ -3,26 +3,22 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
-    name: os_migrate.os_migrate.export_networks
-  vars:
+- vars:
     os_migrate_networks_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_networks
 - name: load exported data
-  set_fact:
-    network_resources: "{{ (lookup('file',
-                           os_migrate_data_dir +
-                           '/networks.yml') | from_yaml)
-                   ['resources'] }}"
+  ansible.builtin.set_fact:
+    network_resources: "{{ (lookup('file', os_migrate_data_dir + '/networks.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - (network_resources |
-        json_query("[?params.name ==
-        'osm_net'].params.name")
-        == ['osm_net'])
+    - (network_resources | community.general.json_query("[?params.name == 'osm_net'].params.name") ==
+      ['osm_net'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_networks

--- a/tests/func/tenant/run/router.yml
+++ b/tests/func/tenant/run/router.yml
@@ -3,26 +3,22 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
-    name: os_migrate.os_migrate.export_routers
-  vars:
+- vars:
     os_migrate_routers_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_routers
 - name: load exported data
-  set_fact:
-    router_resources: "{{ (lookup('file',
-                                  os_migrate_data_dir +
-                                  '/routers.yml') | from_yaml)
-                          ['resources'] }}"
+  ansible.builtin.set_fact:
+    router_resources: "{{ (lookup('file', os_migrate_data_dir + '/routers.yml') |\
+      \ from_yaml) ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - "(router_resources |
-          json_query(\"[?params.name ==
-          'osm_router'].params.external_gateway_refinfo.network_ref.name\")) ==
-          [test_router_external_network | default('public')]"
+    - "(router_resources | community.general.json_query(\"[?params.name == 'osm_router'].params.external_gateway_refinfo.network_ref.name\"\
+      )) == [test_router_external_network | default('public')]"
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_routers

--- a/tests/func/tenant/run/router_interface.yml
+++ b/tests/func/tenant/run/router_interface.yml
@@ -3,30 +3,24 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
-    name: os_migrate.os_migrate.export_router_interfaces
-  vars:
+- vars:
     os_migrate_routers_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_router_interfaces
 - name: load exported data
-  set_fact:
-    router_interface_resources: "{{ (lookup('file',
-                                     os_migrate_data_dir +
-                                     '/router_interfaces.yml') | from_yaml)
-                                     ['resources'] }}"
+  ansible.builtin.set_fact:
+    router_interface_resources: "{{ (lookup('file', os_migrate_data_dir + '/router_interfaces.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - "(router_interface_resources |
-          json_query(\"[?params.device_ref.name ==
-          'osm_router'].params.fixed_ips_refs[].ip_address\")) | sort ==
-          ['192.168.0.10', '192.168.10.10']"
-      - "(router_interface_resources |
-          json_query(\"[?params.device_ref.name ==
-          'osm_router'].params.fixed_ips_refs[].subnet_ref.name\")) | sort ==
-          ['osm_router_subnet', 'osm_subnet']"
+    - "(router_interface_resources | community.general.json_query(\"[?params.device_ref.name == 'osm_router'].params.fixed_ips_refs[].ip_address\"\
+      )) | sort == ['192.168.0.10', '192.168.10.10']"
+    - "(router_interface_resources | community.general.json_query(\"[?params.device_ref.name == 'osm_router'].params.fixed_ips_refs[].subnet_ref.name\"\
+      )) | sort == ['osm_router_subnet', 'osm_subnet']"
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_router_interfaces

--- a/tests/func/tenant/run/security_group.yml
+++ b/tests/func/tenant/run/security_group.yml
@@ -3,27 +3,22 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
-    name: os_migrate.os_migrate.export_security_groups
-  vars:
+- vars:
     os_migrate_security_groups_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_security_groups
 - name: load exported data
-  set_fact:
-    security_group_resources: "{{ (lookup('file',
-                                          os_migrate_data_dir +
-                                          '/security_groups.yml') |
-                                          from_yaml)
-                   ['resources'] }}"
+  ansible.builtin.set_fact:
+    security_group_resources: "{{ (lookup('file', os_migrate_data_dir + '/security_groups.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - (security_group_resources |
-        json_query("[?params.name ==
-        'osm_security_group'].params.description")
-        == ['OSM security group'])
+    - (security_group_resources | community.general.json_query("[?params.name == 'osm_security_group'].params.description")
+      == ['OSM security group'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_groups

--- a/tests/func/tenant/run/security_group_rule.yml
+++ b/tests/func/tenant/run/security_group_rule.yml
@@ -3,27 +3,22 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
-    name: os_migrate.os_migrate.export_security_group_rules
-  vars:
+- vars:
     os_migrate_security_groups_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_security_group_rules
 - name: load exported data
-  set_fact:
-    security_group_rule_resources: "{{ (lookup('file',
-                                               os_migrate_data_dir +
-                                               '/security_group_rules.yml') |
-                                               from_yaml)
-                   ['resources'] }}"
+  ansible.builtin.set_fact:
+    security_group_rule_resources: "{{ (lookup('file', os_migrate_data_dir + '/security_group_rules.yml')\
+      \ | from_yaml) ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - (security_group_rule_resources |
-        json_query("[?params.security_group_ref.name ==
-        'osm_security_group'].params.protocol")
-        == ['tcp'])
+    - (security_group_rule_resources | community.general.json_query("[?params.security_group_ref.name
+      == 'osm_security_group'].params.protocol") == ['tcp'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_group_rules

--- a/tests/func/tenant/run/subnet.yml
+++ b/tests/func/tenant/run/subnet.yml
@@ -3,26 +3,22 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
-    name: os_migrate.os_migrate.export_subnets
-  vars:
+- vars:
     os_migrate_subnets_filter:
-      - regex: '^osm_'
+    - regex: '^osm_'
 
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.export_subnets
 - name: load exported data
-  set_fact:
-    subnet_resources: "{{ (lookup('file',
-                                  os_migrate_data_dir +
-                                  '/subnets.yml') | from_yaml)
-                   ['resources'] }}"
+  ansible.builtin.set_fact:
+    subnet_resources: "{{ (lookup('file', os_migrate_data_dir + '/subnets.yml') |\
+      \ from_yaml) ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
-      - (subnet_resources |
-        json_query("[?params.name ==
-        'osm_subnet'].params.cidr")
-        == ['192.168.0.0/24'])
+    - (subnet_resources | community.general.json_query("[?params.name == 'osm_subnet'].params.cidr")
+      == ['192.168.0.0/24'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_subnets

--- a/tests/func/tenant/seed/all.yml
+++ b/tests/func/tenant/seed/all.yml
@@ -1,47 +1,47 @@
 - name: Include network tasks
-  include_tasks: network.yml
   args:
     apply:
       tags:
-        - test_network
+      - test_network
   tags: always
 
+  ansible.builtin.include_tasks: network.yml
 - name: Include subnet tasks
-  include_tasks: subnet.yml
   args:
     apply:
       tags:
-        - test_subnet
+      - test_subnet
   tags: always
 
+  ansible.builtin.include_tasks: subnet.yml
 - name: Include security group tasks
-  include_tasks: security_group.yml
   args:
     apply:
       tags:
-        - test_security_group
+      - test_security_group
   tags: always
 
+  ansible.builtin.include_tasks: security_group.yml
 - name: Include security group rule tasks
-  include_tasks: security_group_rule.yml
   args:
     apply:
       tags:
-        - test_security_group_rule
+      - test_security_group_rule
   tags: always
 
+  ansible.builtin.include_tasks: security_group_rule.yml
 - name: Include router tasks
-  include_tasks: router.yml
   args:
     apply:
       tags:
-        - test_router
+      - test_router
   tags: always
 
+  ansible.builtin.include_tasks: router.yml
 - name: Include image tasks
-  include_tasks: image.yml
   args:
     apply:
       tags:
-        - test_image
+      - test_image
   tags: always
+  ansible.builtin.include_tasks: image.yml

--- a/tests/func/tenant/seed/image.yml
+++ b/tests/func/tenant/seed/image.yml
@@ -1,15 +1,15 @@
 - name: make sure test_inputs dir exists
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_tests_tmp_dir }}/test_inputs"
     state: directory
 
 - name: fetch cirros image
-  get_url:
+  ansible.builtin.get_url:
     url: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
     dest: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
 
 - name: create osm_image
-  os_image:
+  ansible.builtin.os_image:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_image
     filename: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"

--- a/tests/func/tenant/seed/network.yml
+++ b/tests/func/tenant/seed/network.yml
@@ -1,5 +1,5 @@
 - name: create osm_net
-  os_network:
+  ansible.builtin.os_network:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_net
     # Apparently description is an unsupported param in Ansible even

--- a/tests/func/tenant/seed/router.yml
+++ b/tests/func/tenant/seed/router.yml
@@ -1,13 +1,13 @@
 - name: create osm_router
-  os_router:
+  ansible.builtin.os_router:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_router
     state: present
     network: "{{ test_router_external_network|default('public') }}"
     interfaces:
-      - net: osm_net
-        subnet: osm_subnet
-        portip: 192.168.0.10
-      - net: osm_net
-        subnet: osm_router_subnet
-        portip: 192.168.10.10
+    - net: osm_net
+      subnet: osm_subnet
+      portip: 192.168.0.10
+    - net: osm_net
+      subnet: osm_router_subnet
+      portip: 192.168.10.10

--- a/tests/func/tenant/seed/security_group.yml
+++ b/tests/func/tenant/seed/security_group.yml
@@ -1,5 +1,5 @@
 - name: Create security group
-  os_security_group:
+  ansible.builtin.os_security_group:
     auth: "{{ os_migrate_src_auth }}"
     state: present
     name: osm_security_group

--- a/tests/func/tenant/seed/security_group_rule.yml
+++ b/tests/func/tenant/seed/security_group_rule.yml
@@ -1,5 +1,5 @@
 - name: Create security group rule
-  os_security_group_rule:
+  ansible.builtin.os_security_group_rule:
     auth: "{{ os_migrate_src_auth }}"
     security_group: osm_security_group
     protocol: tcp

--- a/tests/func/tenant/seed/subnet.yml
+++ b/tests/func/tenant/seed/subnet.yml
@@ -1,21 +1,21 @@
 - name: Create subnet
-  os_subnet:
+  ansible.builtin.os_subnet:
     auth: "{{ os_migrate_src_auth }}"
     state: present
     network_name: osm_net
     name: osm_subnet
     cidr: 192.168.0.0/24
     dns_nameservers:
-      - 8.8.8.7
-      - 8.8.8.8
+    - 8.8.8.7
+    - 8.8.8.8
     host_routes:
-      - destination: 0.0.0.0/0
-        nexthop: 12.34.56.78
-      - destination: 192.168.0.0/24
-        nexthop: 192.168.0.1
+    - destination: 0.0.0.0/0
+      nexthop: 12.34.56.78
+    - destination: 192.168.0.0/24
+      nexthop: 192.168.0.1
 
 - name: Create a 2nd subnet for router testing
-  os_subnet:
+  ansible.builtin.os_subnet:
     auth: "{{ os_migrate_src_auth }}"
     state: present
     network_name: osm_net

--- a/tests/func/tenant/update/all.yml
+++ b/tests/func/tenant/update/all.yml
@@ -1,39 +1,39 @@
 - name: Include router tasks
-  include_tasks: router.yml
   args:
     apply:
       tags:
-        - test_router
+      - test_router
   tags: always
 
+  ansible.builtin.include_tasks: router.yml
 - name: Include network tasks
-  include_tasks: network.yml
   args:
     apply:
       tags:
-        - test_network
+      - test_network
   tags: always
 
+  ansible.builtin.include_tasks: network.yml
 - name: Include subnet tasks
-  include_tasks: subnet.yml
   args:
     apply:
       tags:
-        - test_subnet
+      - test_subnet
   tags: always
 
+  ansible.builtin.include_tasks: subnet.yml
 - name: Include security group tasks
-  include_tasks: security_group.yml
   args:
     apply:
       tags:
-        - test_security_group
+      - test_security_group
   tags: always
 
+  ansible.builtin.include_tasks: security_group.yml
 - name: Include image tasks
-  include_tasks: image.yml
   args:
     apply:
       tags:
-        - test_image
+      - test_image
   tags: always
+  ansible.builtin.include_tasks: image.yml

--- a/tests/func/tenant/update/image.yml
+++ b/tests/func/tenant/update/image.yml
@@ -1,12 +1,14 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/images.yml"
     regexp: "    min_disk: 1"
     replace: "    min_disk: 2"
     backup: yes
 
 - name: scan image before update test
-  os_image_info:
+  register: dst_images_info_before
+
+  ansible.builtin.os_image_info:
     image: osm_image
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -15,18 +17,18 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_images_info_before
-
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
       {{ dst_images_info_before['openstack_image']['min_disk'] }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_images
 
 - name: scan available images after update test
-  os_image_info:
+  register: dst_images_info_after
+
+  ansible.builtin.os_image_info:
     image: osm_image
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -35,18 +37,16 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_images_info_after
-
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
       {{ dst_images_info_after['openstack_image']['min_disk'] }}
 
 - name: ensure min_disk for osm_image changed
-  assert:
+  ansible.builtin.assert:
     that:
-      - original_desc == "1"
-      - changed_desc == "2"
+    - original_desc == "1"
+    - changed_desc == "2"
     fail_msg: |
       dst_images_info_before min_disk:
       {{ original_desc }}

--- a/tests/func/tenant/update/network.yml
+++ b/tests/func/tenant/update/network.yml
@@ -1,12 +1,14 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/networks.yml"
     regexp: "    description: ''"
     replace: "    description: 'osm_net_updated'"
     backup: yes
 
 - name: scan available networks after before test
-  os_networks_info:
+  register: dst_networks_info_before
+
+  ansible.builtin.os_networks_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -15,19 +17,19 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_networks_info_before
-
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
-      {{ dst_networks_info_before['openstack_networks'] | json_query(
+      {{ dst_networks_info_before['openstack_networks'] | community.general.json_query(
         "[?name=='osm_net'].description") }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_networks
 
 - name: scan available networks after update test
-  os_networks_info:
+  register: dst_networks_info_after
+
+  ansible.builtin.os_networks_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -36,19 +38,17 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_networks_info_after
-
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
-      {{ dst_networks_info_after['openstack_networks'] | json_query(
+      {{ dst_networks_info_after['openstack_networks'] | community.general.json_query(
         "[?name=='osm_net'].description") }}
 
 - name: ensure description for osm_net changed
-  assert:
+  ansible.builtin.assert:
     that:
-      - original_desc == ['']
-      - changed_desc == ['osm_net_updated']
+    - original_desc == ['']
+    - changed_desc == ['osm_net_updated']
     fail_msg: |
       dst_networks_info_before description:
       {{ original_desc }}

--- a/tests/func/tenant/update/router.yml
+++ b/tests/func/tenant/update/router.yml
@@ -1,12 +1,14 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/routers.yml"
     regexp: "    description: ''"
     replace: "    description: 'osm_router_updated'"
     backup: yes
 
 - name: scan available routers after before test
-  os_migrate.os_migrate.os_routers_info:
+  register: dst_routers_info_before
+
+  ansible.builtin.os_migrate.os_migrate.os_routers_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -15,13 +17,13 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_routers_info_before
-
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_routers
 
 - name: scan available routers after update test
-  os_migrate.os_migrate.os_routers_info:
+  register: dst_routers_info_after
+
+  ansible.builtin.os_migrate.os_migrate.os_routers_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -30,14 +32,11 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_routers_info_after
-
 - name: ensure description for osm_router changed
-  assert:
+  ansible.builtin.assert:
     that:
-      - dst_routers_info_before['openstack_routers'][0].description != None
-      - "dst_routers_info_before['openstack_routers'][0]['description'] \
-         != dst_routers_info_after['openstack_routers'][0]['description']"
+    - dst_routers_info_before['openstack_routers'][0].description != None
+    - "dst_routers_info_before['openstack_routers'][0]['description'] != dst_routers_info_after['openstack_routers'][0]['description']"
     fail_msg: |
       dst_routers_info_before description:
       {{ dst_routers_info_before['openstack_routers'][0].description }}

--- a/tests/func/tenant/update/security_group.yml
+++ b/tests/func/tenant/update/security_group.yml
@@ -1,12 +1,14 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/security_groups.yml"
     regexp: "    description: OSM security group"
     replace: "    description: 'OSM security group updated'"
     backup: yes
 
 - name: scan available security_groups after before test
-  os_migrate.os_migrate.os_security_groups_info:
+  register: dst_sg_info_before
+
+  ansible.builtin.os_migrate.os_migrate.os_security_groups_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -15,19 +17,19 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_sg_info_before
-
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
-      {{ dst_sg_info_before['openstack_security_groups'] | json_query(
+      {{ dst_sg_info_before['openstack_security_groups'] | community.general.json_query(
         "[?name=='osm_security_group'].description") }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_groups
 
 - name: scan available security_groups after update test
-  os_migrate.os_migrate.os_security_groups_info:
+  register: dst_sg_info_after
+
+  ansible.builtin.os_migrate.os_migrate.os_security_groups_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -36,19 +38,17 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_sg_info_after
-
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
-      {{ dst_sg_info_after['openstack_security_groups'] | json_query(
+      {{ dst_sg_info_after['openstack_security_groups'] | community.general.json_query(
         "[?name=='osm_security_group'].description") }}
 
 - name: ensure description for osm_security_group changed
-  assert:
+  ansible.builtin.assert:
     that:
-      - original_desc[0] == 'OSM security group'
-      - changed_desc[0] == 'OSM security group updated'
+    - original_desc[0] == 'OSM security group'
+    - changed_desc[0] == 'OSM security group updated'
     fail_msg: |
       original description: {{ original_desc[0] }}
       changed_description: {{ changed_desc[0] }}

--- a/tests/func/tenant/update/subnet.yml
+++ b/tests/func/tenant/update/subnet.yml
@@ -1,12 +1,14 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/subnets.yml"
     regexp: "    description: ''"
     replace: "    description: 'osm_subnet_updated'"
     backup: yes
 
 - name: scan available subnets after before test
-  os_subnets_info:
+  register: dst_subnets_info_before
+
+  ansible.builtin.os_subnets_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -15,19 +17,19 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_subnets_info_before
-
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
-      {{ dst_subnets_info_before['openstack_subnets'] | json_query(
+      {{ dst_subnets_info_before['openstack_subnets'] | community.general.json_query(
         "[?name=='osm_subnet'].description") }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_subnets
 
 - name: scan available subnets after update test
-  os_subnets_info:
+  register: dst_subnets_info_after
+
+  ansible.builtin.os_subnets_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -36,19 +38,17 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  register: dst_subnets_info_after
-
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
-      {{ dst_subnets_info_after['openstack_subnets'] | json_query(
+      {{ dst_subnets_info_after['openstack_subnets'] | community.general.json_query(
         "[?name=='osm_subnet'].description") }}
 
 - name: ensure description for osm_subnet changed
-  assert:
+  ansible.builtin.assert:
     that:
-      - original_desc == ['']
-      - changed_desc == ['osm_subnet_updated']
+    - original_desc == ['']
+    - changed_desc == ['osm_subnet_updated']
     fail_msg: |
       dst_subnets_info_before description:
       {{ original_desc }}

--- a/tests/func/test_as_admin.yml
+++ b/tests/func/test_as_admin.yml
@@ -1,20 +1,20 @@
 - name: Migration tests
   hosts: migrator
   tasks:
-    - import_tasks: global/prep.yml
-    - include_tasks: admin/clean/all.yml
-      args:
-        apply:
-          tags: test_clean_before
-      tags: always
-    - import_tasks: admin/seed/all.yml
-    - import_tasks: admin/run/all.yml
-    - import_tasks: admin/idempotence/all.yml
-    - import_tasks: admin/update/all.yml
-    - include_tasks: admin/clean/all.yml
-      args:
-        apply:
-          tags: test_clean_after
-      tags: always
+  - ansible.builtin.import_tasks: global/prep.yml
+  - args:
+      apply:
+        tags: test_clean_before
+    tags: always
+    ansible.builtin.include_tasks: admin/clean/all.yml
+  - ansible.builtin.import_tasks: admin/seed/all.yml
+  - ansible.builtin.import_tasks: admin/run/all.yml
+  - ansible.builtin.import_tasks: admin/idempotence/all.yml
+  - ansible.builtin.import_tasks: admin/update/all.yml
+  - args:
+      apply:
+        tags: test_clean_after
+    tags: always
+    ansible.builtin.include_tasks: admin/clean/all.yml
   tags:
-    - test_migration
+  - test_migration

--- a/tests/func/test_as_tenant.yml
+++ b/tests/func/test_as_tenant.yml
@@ -1,27 +1,27 @@
 - name: Independent tests
   hosts: migrator
   tasks:
-    - import_tasks: tenant/independent/all.yml
+  - ansible.builtin.import_tasks: tenant/independent/all.yml
   tags:
-    - test_independent
+  - test_independent
 
 - name: Migration tests
   hosts: migrator
   tasks:
-    - import_tasks: global/prep.yml
-    - include_tasks: tenant/clean/all.yml
-      args:
-        apply:
-          tags: test_clean_before
-      tags: always
-    - import_tasks: tenant/seed/all.yml
-    - import_tasks: tenant/run/all.yml
-    - import_tasks: tenant/idempotence/all.yml
-    - import_tasks: tenant/update/all.yml
-    - include_tasks: tenant/clean/all.yml
-      args:
-        apply:
-          tags: test_clean_after
-      tags: always
+  - ansible.builtin.import_tasks: global/prep.yml
+  - args:
+      apply:
+        tags: test_clean_before
+    tags: always
+    ansible.builtin.include_tasks: tenant/clean/all.yml
+  - ansible.builtin.import_tasks: tenant/seed/all.yml
+  - ansible.builtin.import_tasks: tenant/run/all.yml
+  - ansible.builtin.import_tasks: tenant/idempotence/all.yml
+  - ansible.builtin.import_tasks: tenant/update/all.yml
+  - args:
+      apply:
+        tags: test_clean_after
+    tags: always
+    ansible.builtin.include_tasks: tenant/clean/all.yml
   tags:
-    - test_migration
+  - test_migration

--- a/toolbox/vagrant/ansible/configure.yml
+++ b/toolbox/vagrant/ansible/configure.yml
@@ -2,4 +2,4 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
   roles:
-    - devstack
+  - devstack

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
@@ -1,15 +1,15 @@
 - name: clone devstack
-  git:
+  become: true
+  become_user: stack
+
+  ansible.builtin.git:
     repo: https://opendev.org/openstack/devstack
     version: master
     dest: /home/stack/devstack
     update: no
+- name: write devstack config
   become: true
   become_user: stack
-
-- name: write devstack config
-  template:
+  ansible.builtin.template:
     src: local.conf.j2
     dest: /home/stack/devstack/local.conf
-  become: true
-  become_user: stack

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/main.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/main.yml
@@ -1,3 +1,3 @@
-- include: prereqs.yml
-- include: config.yml
-- include: start.yml
+- ansible.builtin.include: prereqs.yml
+- ansible.builtin.include: config.yml
+- ansible.builtin.include: start.yml

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
@@ -1,24 +1,24 @@
 - name: install packages for devstack
-  package:
+  ansible.builtin.package:
     name:
-      - git
-      - python2
-      - python3-devel
-      - tmux
+    - git
+    - python2
+    - python3-devel
+    - tmux
     state: present
 
 - name: remove packages which devstack does not like
-  package:
+  ansible.builtin.package:
     name:
-      - python3-pyyaml
+    - python3-pyyaml
     state: absent
 
 - name: create stack user
-  user:
+  ansible.builtin.user:
     name: stack
 
 - name: create sudoers entry for stack
-  copy:
+  ansible.builtin.copy:
     dest: /etc/sudoers.d/stack
     content: |
       stack ALL=(ALL) NOPASSWD:ALL

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/start.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/start.yml
@@ -1,7 +1,7 @@
 - name: start devstack
   changed_when: true
-  shell: |
-    cd /home/stack/devstack
-    LOGFILE=/home/stack/devstack.log ./stack.sh 2>&1
   become: true
   become_user: stack
+  ansible.builtin.shell: |
+    cd /home/stack/devstack
+    LOGFILE=/home/stack/devstack.log ./stack.sh 2>&1


### PR DESCRIPTION
Starting on Ansible 2.9 all tasks can use
the fully defined collection name the builtin
runtime is specified in:
https://github.com/ansible/ansible/blob/devel/lib/ansible/config/ansible_builtin_runtime.yml