### PR TITLE
Dev: Convert to fully qualified collection names

### DIFF
--- a/os_migrate/galaxy.yml
+++ b/os_migrate/galaxy.yml
@@ -16,7 +16,10 @@ license:
 tags:
   - openstack
   - migrations
-dependencies: {}
+dependencies:
+  community.crypto: '>=1.4.0'
+  community.general: '>=1.3.4'
+  openstack.cloud: '>=1.2.1'
 repository: 'https://github.com/os-migrate/os-migrate'
 homepage: 'https://github.com/os-migrate/os-migrate'
 issues: 'https://github.com/os-migrate/os-migrate/issues'

--- a/os_migrate/playbooks/delete_conversion_hosts.yml
+++ b/os_migrate/playbooks/delete_conversion_hosts.yml
@@ -1,6 +1,7 @@
 - hosts: migrator
   tasks:
-    - include_role:
+    - name: delete the conversion hosts inventory
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: conv_hosts_inventory.yml
       vars:
@@ -12,13 +13,15 @@
   # fail too.
   ignore_unreachable: true
   tasks:
-    - include_role:
+    - name: unregister the conversion hosts
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: unregister.yml
 
 - hosts: migrator
   tasks:
-    - include_role:
+    - name: delete the src conversion host
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: delete.yml
       vars:
@@ -31,7 +34,8 @@
         os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit) }}"
       when: os_migrate_delete_src_conversion_host|default(true)|bool
 
-    - include_role:
+    - name: delete the dst conversion host
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: delete.yml
       vars:

--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -1,6 +1,7 @@
 - hosts: migrator
   tasks:
-    - include_role:
+    - name: deploy the src conversion host inventory
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
       vars:
         os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
@@ -20,7 +21,8 @@
           "{{ os_migrate_src_conversion_subnet_dns_nameservers|default(omit) }}"
       when: os_migrate_deploy_src_conversion_host|default(true)|bool
 
-    - include_role:
+    - name: deploy the dst conversion host inventory
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
       vars:
         os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
@@ -40,28 +42,32 @@
           "{{ os_migrate_dst_conversion_subnet_dns_nameservers|default(omit) }}"
       when: os_migrate_deploy_dst_conversion_host|default(true)|bool
 
-    - include_role:
+    - name: prepare the conversion host link
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: link_prepare.yml
       when: os_migrate_link_conversion_hosts|default(true)|bool
 
 - hosts: os_migrate_conv_src
   tasks:
-    - include_role:
+    - name: insert the auth keys in src
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: link_insert_authorized_key.yml
       when: os_migrate_link_conversion_hosts|default(true)|bool
 
 - hosts: os_migrate_conv_dst
   tasks:
-    - include_role:
+    - name: insert the auth keys in dst
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: link_insert_private_key.yml
       when: os_migrate_link_conversion_hosts|default(true)|bool
 
 - hosts: conversion_hosts
   tasks:
-    - include_role:
+    - name: install the conversion host content
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host_content
       when: os_migrate_conversion_host_content_install|default(true)|bool
   vars:

--- a/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
@@ -1,5 +1,5 @@
 - name: discover conversion host
-  os_server_info:
+  openstack.cloud.server_info:
     server: "{{ os_migrate_conversion_host_name }}*"
     auth: "{{ os_migrate_conversion_auth }}"
     auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
@@ -11,7 +11,7 @@
   register: _server_info
 
 - name: fail when conversion host was not found
-  fail:
+  ansible.builtin.fail:
     msg: >-
       Nova server of name '{{ os_migrate_conversion_host_name }}' not
       found, it was meant to be used as {{ inventory_name }}
@@ -20,7 +20,7 @@
     - not ignore_missing_conversion_hosts|default(false)|bool
 
 - name: add conversion host to inventory
-  add_host:
+  ansible.builtin.add_host:
     name: "{{ inventory_name }}"
     groups:
       - conversion_hosts

--- a/os_migrate/roles/conversion_host/tasks/conv_hosts_inventory.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_hosts_inventory.yml
@@ -1,5 +1,5 @@
 - name: add conversion hosts to inventory
-  include_tasks: conv_host_inventory.yml
+  ansible.builtin.include_tasks: conv_host_inventory.yml
   vars:
     inventory_name: "{{ item.inventory_name }}"
     os_migrate_conversion_auth: "{{ item.os_migrate_conversion_auth }}"

--- a/os_migrate/roles/conversion_host/tasks/delete.yml
+++ b/os_migrate/roles/conversion_host/tasks/delete.yml
@@ -1,5 +1,5 @@
 - name: delete os_migrate conversion host
-  os_server:
+  openstack.cloud.server:
     name: "{{ os_migrate_conversion_host_name }}"
     state: absent
     delete_fip: yes
@@ -13,7 +13,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion keypair
-  os_keypair:
+  openstack.cloud.keypair:
     name: "{{ os_migrate_conversion_keypair_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"
@@ -25,7 +25,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion security group
-  os_security_group:
+  openstack.cloud.security_group:
     name: "{{ os_migrate_conversion_secgroup_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"
@@ -37,7 +37,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion router
-  os_router:
+  openstack.cloud.router:
     name: "{{ os_migrate_conversion_router_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"
@@ -49,7 +49,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion subnet
-  os_subnet:
+  openstack.cloud.subnet:
     name: "{{ os_migrate_conversion_subnet_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"
@@ -61,7 +61,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: delete os_migrate conversion net
-  os_network:
+  openstack.cloud.network:
     name: "{{ os_migrate_conversion_net_name }}"
     state: absent
     auth: "{{ os_migrate_conversion_auth }}"

--- a/os_migrate/roles/conversion_host/tasks/generate_keypair.yml
+++ b/os_migrate/roles/conversion_host/tasks/generate_keypair.yml
@@ -1,8 +1,8 @@
 - name: create the keypair folder
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_conversion_keypair_private_path|dirname }}"
     state: directory
 
 - name: generate a keypair for the conversion host
-  openssh_keypair:
+  community.crypto.openssh_keypair:
     path: "{{ os_migrate_conversion_keypair_private_path }}"

--- a/os_migrate/roles/conversion_host/tasks/link_insert_authorized_key.yml
+++ b/os_migrate/roles/conversion_host/tasks/link_insert_authorized_key.yml
@@ -1,11 +1,11 @@
 - name: ensure .ssh exists
-  file:
+  ansible.builtin.file:
     path: "{{ ansible_env['HOME'] }}/.ssh"
     state: directory
     mode: 0700
 
 - name: insert conversion link public ssh key into authorized keys
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: "{{ ansible_env['HOME'] }}/.ssh/authorized_keys"
     marker: "# {mark} CONVERSION LINK KEY"
     create: yes

--- a/os_migrate/roles/conversion_host/tasks/link_insert_private_key.yml
+++ b/os_migrate/roles/conversion_host/tasks/link_insert_private_key.yml
@@ -1,11 +1,11 @@
 - name: ensure .ssh exists
-  file:
+  ansible.builtin.file:
     path: "{{ ansible_env['HOME'] }}/.ssh"
     state: directory
     mode: 0700
 
 - name: upload conversion link private ssh key
-  copy:
+  ansible.builtin.copy:
     dest: "{{ ansible_env['HOME'] }}/.ssh/id_rsa"
     src: "{{ os_migrate_conversion_link_keypair_private_path }}"
     mode: 0600

--- a/os_migrate/roles/conversion_host/tasks/link_prepare.yml
+++ b/os_migrate/roles/conversion_host/tasks/link_prepare.yml
@@ -1,17 +1,17 @@
 - name: add both conversion hosts to inventory
-  import_tasks: conv_hosts_inventory.yml
+  ansible.builtin.import_tasks: conv_hosts_inventory.yml
 
 - name: create folder for link keypairs
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_conversion_link_keypair_private_path|dirname }}"
     state: directory
 
 - name: generate a link keypair
-  openssh_keypair:
+  community.crypto.openssh_keypair:
     path: "{{ os_migrate_conversion_link_keypair_private_path }}"
 
 - name: wait for src conversion host reachability
-  wait_for:
+  ansible.builtin.wait_for:
     port: 22
     host: "{{ hostvars['os_migrate_conv_src']['ansible_ssh_host'] }}"
     search_regex: OpenSSH
@@ -19,7 +19,7 @@
     timeout: 600
 
 - name: wait for dst conversion host reachability
-  wait_for:
+  ansible.builtin.wait_for:
     port: 22
     host: "{{ hostvars['os_migrate_conv_dst']['ansible_ssh_host'] }}"
     search_regex: OpenSSH

--- a/os_migrate/roles/conversion_host/tasks/main.yml
+++ b/os_migrate/roles/conversion_host/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: generate os_migrate conversion keypair
-  include_tasks: generate_keypair.yml
+  ansible.builtin.include_tasks: generate_keypair.yml
   when: os_migrate_conversion_keypair_generate
 
 - name: create os_migrate conversion net
-  os_network:
+  openstack.cloud.network:
     name: "{{ os_migrate_conversion_net_name }}"
     mtu: "{{ os_migrate_conversion_net_mtu }}"
     auth: "{{ os_migrate_conversion_auth }}"
@@ -15,7 +15,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion subnet
-  os_subnet:
+  openstack.cloud.subnet:
     name: "{{ os_migrate_conversion_subnet_name }}"
     network_name: "{{ os_migrate_conversion_net_name }}"
     dns_nameservers: "{{ os_migrate_conversion_subnet_dns_nameservers }}"
@@ -31,7 +31,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion router
-  os_router:
+  openstack.cloud.router:
     name: "{{ os_migrate_conversion_router_name }}"
     network: "{{ os_migrate_conversion_external_network_name }}"
     interfaces:
@@ -47,7 +47,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion security group
-  os_security_group:
+  openstack.cloud.security_group:
     name: "{{ os_migrate_conversion_secgroup_name }}"
     auth: "{{ os_migrate_conversion_auth }}"
     auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
@@ -58,7 +58,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: allow ssh in os_migrate conversion security group
-  os_security_group_rule:
+  openstack.cloud.security_group_rule:
     security_group: "{{ os_migrate_conversion_secgroup_name }}"
     remote_ip_prefix: 0.0.0.0/0
     protocol: tcp
@@ -73,7 +73,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: allow icmp in os_migrate conversion security group
-  os_security_group_rule:
+  openstack.cloud.security_group_rule:
     security_group: "{{ os_migrate_conversion_secgroup_name }}"
     remote_ip_prefix: 0.0.0.0/0
     protocol: icmp
@@ -86,7 +86,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion keypair
-  os_keypair:
+  openstack.cloud.keypair:
     name: "{{ os_migrate_conversion_keypair_name }}"
     public_key_file: "{{ os_migrate_conversion_keypair_private_path }}.pub"
     auth: "{{ os_migrate_conversion_auth }}"
@@ -98,7 +98,7 @@
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
 
 - name: create os_migrate conversion host
-  os_server:
+  openstack.cloud.server:
     name: "{{ os_migrate_conversion_host_name }}"
     flavor: "{{ os_migrate_conversion_flavor_name }}"
     image: "{{ os_migrate_conversion_image_name }}"

--- a/os_migrate/roles/conversion_host/tasks/unregister.yml
+++ b/os_migrate/roles/conversion_host/tasks/unregister.yml
@@ -1,5 +1,5 @@
 - name: unregister RHEL hosts from RHSM
-  redhat_subscription:
+  community.general.redhat_subscription:
     state: absent
   vars:
     # Unregistration gets stuck unless we explicitly run the module as root.

--- a/os_migrate/roles/conversion_host_content/tasks/centos.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/centos.yml
@@ -1,15 +1,15 @@
 - name: install epel release
-  yum:
+  ansible.builtin.yum:
     name: epel-release
     state: present
 
 - name: update all packages
-  yum:
+  ansible.builtin.yum:
     name: '*'
     state: latest
 
 - name: install content
-  yum:
+  ansible.builtin.yum:
     name:
       - nbdkit
       - nbdkit-basic-plugins

--- a/os_migrate/roles/conversion_host_content/tasks/main.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/main.yml
@@ -1,15 +1,15 @@
 - name: Conversion host content tasks
   block:
     - name: Display host os
-      debug:
+      ansible.builtin.debug:
         msg: >-
           Conversion Host OS is
           {{ ansible_distribution }} {{ ansible_distribution_version }}
 
     - name: Include CentOS tasks
-      include_tasks: centos.yml
+      ansible.builtin.include_tasks: centos.yml
       when: ansible_distribution in ['CentOS']
 
     - name: Include RHEL tasks
-      include_tasks: rhel.yml
+      ansible.builtin.include_tasks: rhel.yml
       when: ansible_distribution in ['RedHat']

--- a/os_migrate/roles/conversion_host_content/tasks/rhel.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/rhel.yml
@@ -1,5 +1,5 @@
 - name: register and auto-subscribe to available content.
-  redhat_subscription:
+  community.general.redhat_subscription:
     state: present
     # These params have defaults specified:
     auto_attach: "{{ os_migrate_conversion_rhsm_auto_attach|default(true) }}"
@@ -31,12 +31,12 @@
       os_migrate_conversion_rhsm_org_id is defined
 
 - name: update all packages
-  yum:
+  ansible.builtin.yum:
     name: '*'
     state: latest
 
 - name: install content
-  yum:
+  ansible.builtin.yum:
     name:
       - nbdkit
       - nbdkit-basic-plugins

--- a/os_migrate/roles/export_flavors/tasks/main.yml
+++ b/os_migrate/roles/export_flavors/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: scan available flavors
-  os_flavor_info:
+  openstack.cloud.compute_flavor_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -10,14 +10,14 @@
   register: src_flavors_info
 
 - name: create id-name pairs of flavors to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_flavors_ids_names: "{{ (
       src_flavors_info.openstack_flavors
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of flavors to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_flavors_ids_names: "{{ (
       export_flavors_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_flavors_filter,

--- a/os_migrate/roles/export_images/tasks/main.yml
+++ b/os_migrate/roles/export_images/tasks/main.yml
@@ -1,7 +1,7 @@
 # NOTE: os_image_info doesn't support os_migrate_src_filters, we apply
 # the filters manually below.
 - name: scan available images
-  os_image_info:
+  openstack.cloud.image_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -12,14 +12,14 @@
   register: src_images_info
 
 - name: create id-name pairs of images to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_images_ids_names: "{{ (
       src_images_info.openstack_image
         | json_query('[*].{name: name, id: id, owner: owner}')
         | sort(attribute='id') ) }}"
 
 - name: filter images to export by project
-  set_fact:
+  ansible.builtin.set_fact:
     export_images_ids_names: "{{ (
       export_images_ids_names
         | json_query(\"[?owner=='\" + os_migrate_src_filters['project_id'] + \"']\")
@@ -29,7 +29,7 @@
     - os_migrate_src_filters['project_id'] is defined
 
 - name: filter names of images to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_images_ids_names: "{{ (
       export_images_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_images_filter,
@@ -49,7 +49,7 @@
   loop: "{{ export_images_ids_names }}"
 
 - name: make sure image blob dir exists
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_image_blobs_dir }}"
     state: directory
   when: os_migrate_export_images_blobs

--- a/os_migrate/roles/export_keypairs/tasks/main.yml
+++ b/os_migrate/roles/export_keypairs/tasks/main.yml
@@ -10,14 +10,14 @@
   register: src_keypairs_info
 
 - name: create id-name pairs of keypairs to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_keypairs_ids_names: "{{ (
       src_keypairs_info.openstack_keypairs
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of keypairs to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_keypairs_ids_names: "{{ (
       export_keypairs_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_keypairs_filter,

--- a/os_migrate/roles/export_networks/tasks/main.yml
+++ b/os_migrate/roles/export_networks/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: scan available networks
-  os_networks_info:
+  openstack.cloud.networks_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -11,14 +11,14 @@
   register: src_networks_info
 
 - name: create id-name pairs of networks to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_networks_ids_names: "{{ (
       src_networks_info.openstack_networks
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of networks to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_networks_ids_names: "{{ (
       export_networks_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_networks_filter,

--- a/os_migrate/roles/export_projects/tasks/main.yml
+++ b/os_migrate/roles/export_projects/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: scan available projects
-  os_project_info:
+  openstack.cloud.project_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -10,14 +10,14 @@
   register: src_projects_info
 
 - name: create id-name pairs of projects to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_projects_ids_names: "{{ (
       src_projects_info.openstack_projects
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of projects to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_projects_ids_names: "{{ (
       export_projects_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_projects_filter,

--- a/os_migrate/roles/export_router_interfaces/tasks/main.yml
+++ b/os_migrate/roles/export_router_interfaces/tasks/main.yml
@@ -11,14 +11,14 @@
   register: src_routers_info
 
 - name: create id-name pairs of routers to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_routers_ids_names: "{{ (
       src_routers_info.openstack_routers
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of routers to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_routers_ids_names: "{{ (
       export_routers_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,

--- a/os_migrate/roles/export_routers/tasks/main.yml
+++ b/os_migrate/roles/export_routers/tasks/main.yml
@@ -11,14 +11,14 @@
   register: src_routers_info
 
 - name: create id-name pairs of routers to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_routers_ids_names: "{{ (
       src_routers_info.openstack_routers
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of routers to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_routers_ids_names: "{{ (
       export_routers_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,

--- a/os_migrate/roles/export_security_group_rules/tasks/main.yml
+++ b/os_migrate/roles/export_security_group_rules/tasks/main.yml
@@ -11,14 +11,14 @@
   register: src_security_groups_info
 
 - name: create id-name pairs of security groups to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_security_groups_ids_names: "{{ (
       src_security_groups_info.openstack_security_groups
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of security groups to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_security_groups_ids_names: "{{ (
       export_security_groups_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,

--- a/os_migrate/roles/export_security_groups/tasks/main.yml
+++ b/os_migrate/roles/export_security_groups/tasks/main.yml
@@ -11,14 +11,14 @@
   register: src_security_groups_info
 
 - name: create id-name pairs of security groups to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_security_groups_ids_names: "{{ (
       src_security_groups_info.openstack_security_groups
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of security groups to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_security_groups_ids_names: "{{ (
       export_security_groups_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,

--- a/os_migrate/roles/export_subnets/tasks/main.yml
+++ b/os_migrate/roles/export_subnets/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: scan available subnets
-  os_subnets_info:
+  openstack.cloud.subnets_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -11,14 +11,14 @@
   register: src_subnets_info
 
 - name: create id-name pairs of subnets to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_subnets_ids_names: "{{ (
       src_subnets_info.openstack_subnets
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of subnets to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_subnets_ids_names: "{{ (
       export_subnets_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_subnets_filter,

--- a/os_migrate/roles/export_users/tasks/main.yml
+++ b/os_migrate/roles/export_users/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: scan available users
-  os_user_info:
+  openstack.cloud.identity_user_info:
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -10,14 +10,14 @@
   register: src_users_info
 
 - name: create id-name pairs of users to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_users_ids_names: "{{ (
       src_users_info.openstack_users
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of users to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_users_ids_names: "{{ (
       export_users_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_users_filter,

--- a/os_migrate/roles/export_workloads/tasks/main.yml
+++ b/os_migrate/roles/export_workloads/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: scan instances for workloads to export
-  os_server_info:
+  openstack.cloud.server_info:
     filters: "{{ os_migrate_src_filters }}"
     auth: "{{ os_migrate_src_auth }}"
     auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
@@ -10,18 +10,18 @@
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
   register: src_workloads_info
 
-- debug:
+- ansible.builtin.debug:
     msg: "{{ src_workloads_info.openstack_servers }}"
 
 - name: create id-name pairs of workloads to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_workloads_ids_names: "{{ (
       src_workloads_info.openstack_servers
         | json_query('[*].{name: name, id: id}')
         | sort(attribute='id') ) }}"
 
 - name: filter names of workloads to export
-  set_fact:
+  ansible.builtin.set_fact:
     export_workloads_ids_names: "{{ (
       export_workloads_ids_names
         | os_migrate.os_migrate.stringfilter(os_migrate_workloads_filter,

--- a/os_migrate/roles/import_flavors/tasks/main.yml
+++ b/os_migrate/roles/import_flavors/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_flavors_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ flavors_file_validation.errors|join(' ') }}"
   when: not ( flavors_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_images/tasks/main.yml
+++ b/os_migrate/roles/import_images/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_images_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ images_file_validation.errors|join(' ') }}"
   when: not ( images_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_keypairs/tasks/main.yml
+++ b/os_migrate/roles/import_keypairs/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_keypairs_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ keypairs_file_validation.errors|join(' ') }}"
   when: not ( keypairs_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_networks/tasks/main.yml
+++ b/os_migrate/roles/import_networks/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_networks_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ networks_file_validation.errors|join(' ') }}"
   when: not ( networks_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_projects/tasks/main.yml
+++ b/os_migrate/roles/import_projects/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_projects_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ projects_file_validation.errors|join(' ') }}"
   when: not ( projects_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_router_interfaces/tasks/main.yml
+++ b/os_migrate/roles/import_router_interfaces/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_router_interfaces_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ router_interfaces_file_validation.errors|join(' ') }}"
   when: not ( router_interfaces_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_routers/tasks/main.yml
+++ b/os_migrate/roles/import_routers/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_routers_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ routers_file_validation.errors|join(' ') }}"
   when: not ( routers_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_security_group_rules/tasks/main.yml
+++ b/os_migrate/roles/import_security_group_rules/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_security_group_rules_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ security_group_rules_file_validation.errors|join(' ') }}"
   when: not ( security_group_rules_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_security_groups/tasks/main.yml
+++ b/os_migrate/roles/import_security_groups/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_security_groups_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ security_groups_file_validation.errors|join(' ') }}"
   when: not ( security_groups_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_subnets/tasks/main.yml
+++ b/os_migrate/roles/import_subnets/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_subnets_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ subnets_file_validation.errors|join(' ') }}"
   when: not ( subnets_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_users/tasks/main.yml
+++ b/os_migrate/roles/import_users/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_users_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ users_file_validation.errors|join(' ') }}"
   when: not ( users_file_validation.ok | bool )
 

--- a/os_migrate/roles/import_workloads/tasks/main.yml
+++ b/os_migrate/roles/import_workloads/tasks/main.yml
@@ -6,7 +6,7 @@
   when: import_workloads_validate_file
 
 - name: stop when errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ workloads_file_validation.errors|join(' ') }}"
   when: not ( workloads_file_validation.ok | bool )
 
@@ -16,7 +16,7 @@
   register: read_workloads
 
 - name: create directory for workload migration logs
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}/workload_logs"
     state: directory
 
@@ -34,7 +34,7 @@
   register: os_src_conversion_host_info
 
 - name: fail if source conversion host is not active
-  fail:
+  ansible.builtin.fail:
     msg: The source conversion host is not running!
   when: os_src_conversion_host_info.openstack_conversion_host.status != "ACTIVE"
 
@@ -52,7 +52,7 @@
   register: os_dst_conversion_host_info
 
 - name: fail if destination conversion is not active
-  fail:
+  ansible.builtin.fail:
     msg: The destination conversion host is not running!
   when: os_dst_conversion_host_info.openstack_conversion_host.status != "ACTIVE"
 
@@ -61,7 +61,7 @@
 # much time to start.
 
 - name: Wait until the dst conversion host is reachable
-  wait_for:
+  ansible.builtin.wait_for:
     port: 22
     host: '{{ os_dst_conversion_host_info.openstack_conversion_host.address }}'
     search_regex: OpenSSH
@@ -69,7 +69,7 @@
     timeout: 600
 
 - name: Wait until the src conversion host is reachable
-  wait_for:
+  ansible.builtin.wait_for:
     port: 22
     host: '{{ os_src_conversion_host_info.openstack_conversion_host.address }}'
     search_regex: OpenSSH
@@ -77,5 +77,5 @@
     timeout: 600
 
 - name: import workloads
-  include_tasks: workload.yml
+  ansible.builtin.include_tasks: workload.yml
   loop: "{{ read_workloads.resources }}"

--- a/os_migrate/roles/import_workloads/tasks/workload.yml
+++ b/os_migrate/roles/import_workloads/tasks/workload.yml
@@ -15,7 +15,7 @@
       data: "{{ item }}"
     register: prelim
 
-  - debug:
+  - ansible.builtin.debug:
       msg:
         - "{{ prelim.server_name }} log file: {{ prelim.log_file }}"
         - "{{ prelim.server_name }} progress file: {{ prelim.state_file }}"
@@ -99,8 +99,7 @@
       client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
       data: "{{ item }}"
-      conversion_host:
-        "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+      conversion_host: "{{ os_src_conversion_host_info.openstack_conversion_host }}"
       ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
       ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
       transfer_uuid: "{{ exports.transfer_uuid }}"
@@ -110,5 +109,5 @@
     when: prelim.changed
 
   rescue:
-    - fail:
+    - ansible.builtin.fail:
         msg: "Failed to import {{ item.params.name }}!"

--- a/os_migrate/roles/prelude_dst/tasks/main.yml
+++ b/os_migrate/roles/prelude_dst/tasks/main.yml
@@ -14,7 +14,7 @@
       register: _auth_info
 
     - name: set os_migrate_dst_project_id and os_migrate_dst_filters
-      set_fact:
+      ansible.builtin.set_fact:
         os_migrate_dst_project_id: "{{ _auth_info.auth_info.project_id }}"
         os_migrate_dst_filters:
           project_id: "{{ _auth_info.auth_info.project_id }}"

--- a/os_migrate/roles/prelude_src/tasks/main.yml
+++ b/os_migrate/roles/prelude_src/tasks/main.yml
@@ -14,7 +14,7 @@
       register: _auth_info
 
     - name: set os_migrate_src_project_id and os_migrate_src_filters
-      set_fact:
+      ansible.builtin.set_fact:
         os_migrate_src_project_id: "{{ _auth_info.auth_info.project_id }}"
         os_migrate_src_filters:
           project_id: "{{ _auth_info.auth_info.project_id }}"

--- a/os_migrate/roles/validate_data_dir/tasks/main.yml
+++ b/os_migrate/roles/validate_data_dir/tasks/main.yml
@@ -1,12 +1,12 @@
 - name: list resource files
-  find:
+  ansible.builtin.find:
     paths:
       - "{{ os_migrate_data_dir }}"
     patterns:
       - "*.yml"
   register: resource_files_result
 
-- fail:
+- ansible.builtin.fail:
     msg: No resource files found.
   when: resource_files_result.files | count < 1
 
@@ -16,6 +16,6 @@
   register: validate_data_dir_result
 
 - name: stop if errors found
-  fail:
+  ansible.builtin.fail:
     msg: "{{ validate_data_dir_result.errors | join(' ') }}"
   when: not ( validate_data_dir_result.ok | bool )

--- a/tests/e2e/admin/scenario_variables.yml
+++ b/tests/e2e/admin/scenario_variables.yml
@@ -1,5 +1,5 @@
-os_migrate_src_validate_certs: False
-os_migrate_dst_validate_certs: False
+os_migrate_src_validate_certs: false
+os_migrate_dst_validate_certs: false
 
 os_migrate_src_release: 13
 os_migrate_dst_release: 13

--- a/tests/e2e/common/prep.yml
+++ b/tests/e2e/common/prep.yml
@@ -1,20 +1,20 @@
 # make sure no artifacts from prevoius test persisted
 - name: delete os_migrate_data_dir
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}"
     state: absent
   tags:
     - test_prep
 
 - name: create os_migrate_tests_tmp_dir
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_tests_tmp_dir }}"
     state: directory
   tags:
     - test_prep
 
 - name: create os_migrate_data_dir
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}"
     state: directory
   tags:

--- a/tests/e2e/tenant/clean_pre_workload.yml
+++ b/tests/e2e/tenant/clean_pre_workload.yml
@@ -1,5 +1,5 @@
 - name: Remove pre-workload test data
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}/{{ item }}"
     state: absent
   loop:
@@ -12,7 +12,7 @@
     - subnets.yml
 
 - name: remove osm_image
-  os_image:
+  openstack.cloud.image:
     auth: "{{ item.auth }}"
     name: osm_image
     state: absent
@@ -33,7 +33,7 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: remove osm_key keypair
-  os_keypair:
+  openstack.cloud.keypair:
     auth: "{{ item.auth }}"
     state: absent
     name: osm_key
@@ -54,7 +54,7 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: remove osm_router
-  os_router:
+  openstack.cloud.router:
     auth: "{{ item.auth }}"
     name: osm_router
     state: absent
@@ -76,7 +76,7 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: remove osm_server_port
-  os_port:
+  openstack.cloud.port:
     auth: "{{ item.auth }}"
     name: osm_server_port_0
     network: osm_net
@@ -98,7 +98,7 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: remove osm_subnet
-  os_subnet:
+  openstack.cloud.subnet:
     auth: "{{ item.auth }}"
     name: osm_subnet
     state: absent
@@ -119,7 +119,7 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: remove osm_net
-  os_network:
+  openstack.cloud.network:
     auth: "{{ item.auth }}"
     name: osm_net
     state: absent
@@ -140,7 +140,7 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: remove osm_security_group
-  os_security_group:
+  openstack.cloud.security_group:
     auth: "{{ item.auth }}"
     name: osm_security_group
     state: absent
@@ -161,7 +161,7 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: remove osm_security_group_rule
-  os_security_group_rule:
+  openstack.cloud.security_group_rule:
     auth: "{{ item.auth }}"
     security_group: osm_security_group
     state: absent

--- a/tests/e2e/tenant/clean_workload.yml
+++ b/tests/e2e/tenant/clean_workload.yml
@@ -1,5 +1,5 @@
 - name: Remove workload test data
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}/{{ item }}"
     state: absent
   loop:
@@ -8,7 +8,7 @@
     - workloads.yml
 
 - name: Detach src volumes if still attached
-  os_server_volume:
+  openstack.cloud.server_volume:
     server: "{{ item.server }}"
     volume: "{{ item.volume }}"
     state: absent
@@ -28,7 +28,7 @@
   failed_when: false
 
 - name: Detach dst volumes if still attached
-  os_server_volume:
+  openstack.cloud.server_volume:
     server: "{{ item.server }}"
     volume: "{{ item.volume }}"
     state: absent
@@ -48,7 +48,7 @@
   failed_when: false
 
 - name: Remove osm_server
-  os_server:
+  openstack.cloud.server:
     name: osm_server
     state: absent
     delete_fip: yes
@@ -71,7 +71,7 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: Remove osm_server boot volume
-  os_volume:
+  openstack.cloud.volume:
     display_name: rhosp-migration-root-osm_server
     state: absent
     auth: "{{ item.auth }}"
@@ -92,7 +92,7 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: Remove osm_volume
-  os_volume:
+  openstack.cloud.volume:
     display_name: osm_volume
     state: absent
     auth: "{{ item.auth }}"

--- a/tests/e2e/tenant/run_pre_workload.yml
+++ b/tests/e2e/tenant/run_pre_workload.yml
@@ -6,7 +6,7 @@
 
 - name: Network tasks
   block:
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.export_networks
       vars:
         # This expression should export all osm_ workloads
@@ -17,26 +17,26 @@
           - regex: '^osm_(?!uch)'
 
     - name: load exported data
-      set_fact:
+      ansible.builtin.set_fact:
         resources: "{{ (lookup('file',
                                os_migrate_data_dir +
                                '/networks.yml') | from_yaml)
                        ['resources'] }}"
 
     - name: verify data contents
-      assert:
+      ansible.builtin.assert:
         that:
           - (resources |
             json_query("[?params.name ==
             'osm_net'].params.name")
             == ['osm_net'])
 
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.import_networks
 
 - name: Subnet tasks
   block:
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.export_subnets
       vars:
         # This expression should export all osm_ workloads
@@ -47,33 +47,33 @@
           - regex: '^osm_(?!uch)'
 
     - name: load exported data
-      set_fact:
+      ansible.builtin.set_fact:
         subnet_resources: "{{ (lookup('file',
                                       os_migrate_data_dir +
                                       '/subnets.yml') | from_yaml)
                        ['resources'] }}"
 
     - name: verify data contents
-      assert:
+      ansible.builtin.assert:
         that:
           - (subnet_resources |
             json_query("[?params.name ==
             'osm_subnet'].params.cidr")
             == ['192.168.20.0/24'])
 
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.import_subnets
 
 - name: Security group tasks
   block:
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.export_security_groups
       vars:
         os_migrate_security_groups_filter:
           - regex: '^osm_'
 
     - name: load exported data
-      set_fact:
+      ansible.builtin.set_fact:
         security_group_resources: "{{ (lookup('file',
                                               os_migrate_data_dir +
                                               '/security_groups.yml') |
@@ -81,26 +81,26 @@
                        ['resources'] }}"
 
     - name: verify data contents
-      assert:
+      ansible.builtin.assert:
         that:
           - (security_group_resources |
             json_query("[?params.name ==
             'osm_security_group'].params.description")
             == ['OSM security group'])
 
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.import_security_groups
 
 - name: Security group rules tasks
   block:
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.export_security_group_rules
       vars:
         os_migrate_security_groups_filter:
           - regex: '^osm_'
 
     - name: load exported data
-      set_fact:
+      ansible.builtin.set_fact:
         security_group_rule_resources: "{{ (lookup('file',
                                                os_migrate_data_dir +
                                                '/security_group_rules.yml') |
@@ -108,19 +108,19 @@
                        ['resources'] }}"
 
     - name: verify data contents
-      assert:
+      ansible.builtin.assert:
         that:
           - (security_group_rule_resources |
             json_query("[?params.security_group_ref.name ==
             'osm_security_group'].params.remote_ip_prefix")
             == ['0.0.0.0/0'])
 
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.import_security_group_rules
 
 - name: Router tasks
   block:
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.export_routers
       vars:
         # This expression should export all osm_ workloads
@@ -131,26 +131,26 @@
           - regex: '^osm_(?!uch)'
 
     - name: load exported data
-      set_fact:
+      ansible.builtin.set_fact:
         router_resources: "{{ (lookup('file',
                                       os_migrate_data_dir +
                                       '/routers.yml') | from_yaml)
                               ['resources'] }}"
 
     - name: verify data contents
-      assert:
+      ansible.builtin.assert:
         that:
           - "(router_resources |
               json_query(\"[?params.name ==
               'osm_router'].params.external_gateway_refinfo.network_ref.name\")) ==
               [os_migrate_src_osm_router_external_network | default('public')]"
 
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.import_routers
 
 - name: Router interface tasks
   block:
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.export_router_interfaces
       vars:
         # This expression should export all osm_ workloads
@@ -161,45 +161,45 @@
           - regex: '^osm_(?!uch)'
 
     - name: load exported data
-      set_fact:
+      ansible.builtin.set_fact:
         router_interface_resources: "{{ (lookup('file',
                                          os_migrate_data_dir +
                                          '/router_interfaces.yml') | from_yaml)
                                          ['resources'] }}"
 
     - name: verify data contents
-      assert:
+      ansible.builtin.assert:
         that:
           - "(router_interface_resources |
               json_query(\"[?params.device_ref.name ==
               'osm_router'].params.fixed_ips_refs[].subnet_ref.name\")) | sort ==
               ['osm_subnet']"
 
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.import_router_interfaces
 
 - name: Image tasks
   block:
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.export_images
       vars:
         os_migrate_images_filter:
           - regex: '^osm_'
 
     - name: load exported data
-      set_fact:
+      ansible.builtin.set_fact:
         resources: "{{ (lookup('file',
                                os_migrate_data_dir +
                                '/images.yml') | from_yaml)
                        ['resources'] }}"
 
     - name: verify data contents
-      assert:
+      ansible.builtin.assert:
         that:
           - (resources |
             json_query("[?params.name ==
             'osm_image'].params.min_ram")
             == [128])
 
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.import_images

--- a/tests/e2e/tenant/run_workload.yml
+++ b/tests/e2e/tenant/run_workload.yml
@@ -6,7 +6,7 @@
 
 - name: Workloads tasks
   block:
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.export_workloads
       vars:
         # This expression should export all osm_ workloads
@@ -17,26 +17,26 @@
           - regex: '^osm_(?!uch)'
 
     - name: set boot disk copy
-      replace:
+      ansible.builtin.replace:
         path: "{{ os_migrate_data_dir }}/workloads.yml"
         regexp: "boot_disk_copy: false"
         replace: "boot_disk_copy: true"
       when: set_boot_volume_copy|default(false)|bool
 
     - name: load exported data
-      set_fact:
+      ansible.builtin.set_fact:
         resources: "{{ (lookup('file',
                                os_migrate_data_dir +
                                '/workloads.yml') | from_yaml)
                        ['resources'] }}"
 
     - name: verify data contents
-      assert:
+      ansible.builtin.assert:
         that:
           - (resources |
             json_query("[?params.name ==
             'osm_server'].params.name")
             == ['osm_server'])
 
-    - include_role:
+    - ansible.builtin.include_role:
         name: os_migrate.os_migrate.import_workloads

--- a/tests/e2e/tenant/scenario_variables.yml
+++ b/tests/e2e/tenant/scenario_variables.yml
@@ -18,8 +18,8 @@ os_migrate_dst_conversion_external_network_name: public
 os_migrate_dst_conversion_flavor_name: m1.medium
 os_migrate_dst_conversion_image_name: CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2
 
-os_migrate_src_validate_certs: False
-os_migrate_dst_validate_certs: False
+os_migrate_src_validate_certs: false
+os_migrate_dst_validate_certs: false
 
 os_migrate_src_release: 13
 os_migrate_dst_release: 13

--- a/tests/e2e/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tenant/seed_pre_workload.yml
@@ -1,5 +1,5 @@
 - name: create osm_net
-  os_network:
+  openstack.cloud.network:
     auth: "{{ item.auth }}"
     name: osm_net
     # Apparently description is an unsupported param in Ansible even
@@ -21,7 +21,7 @@
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
 
 - name: Create osm subnet
-  os_subnet:
+  openstack.cloud.subnet:
     auth: "{{ item.auth }}"
     state: present
     network_name: osm_net
@@ -44,7 +44,7 @@
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
 
 - name: Create security group
-  os_security_group:
+  openstack.cloud.security_group:
     auth: "{{ item.auth }}"
     state: present
     name: osm_security_group
@@ -61,7 +61,7 @@
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
 
 - name: Create security group rule
-  os_security_group_rule:
+  openstack.cloud.security_group_rule:
     auth: "{{ item.auth }}"
     security_group: osm_security_group
     remote_ip_prefix: 0.0.0.0/0
@@ -77,7 +77,7 @@
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
 
 - name: create osm_router
-  os_router:
+  openstack.cloud.router:
     auth: "{{ item.auth }}"
     name: osm_router
     state: present
@@ -98,7 +98,7 @@
       client_key: "{{ os_migrate_src_client_key|default(omit) }}"
 
 - name: Create the key folder
-  file:
+  ansible.builtin.file:
     path: "{{ '~' | expanduser }}/ssh-ci"
     mode: 0700
     state: directory
@@ -106,11 +106,11 @@
 - name: Generate a keypair for the migration
   # This will not regenerate the key if
   # it already exists
-  openssh_keypair:
+  community.crypto.openssh_keypair:
     path: "{{ '~' | expanduser }}/ssh-ci/id_rsa"
 
 - name: Create new keypair as osm_key
-  os_keypair:
+  openstack.cloud.keypair:
     auth: "{{ item.auth }}"
     state: present
     name: osm_key
@@ -132,17 +132,17 @@
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
 
 - name: make sure test_inputs dir exists
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_tests_tmp_dir }}/test_inputs"
     state: directory
 
 - name: fetch cirros image
-  get_url:
+  ansible.builtin.get_url:
     url: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
     dest: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
 
 - name: create osm_image
-  os_image:
+  openstack.cloud.image:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_image
     filename: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"

--- a/tests/e2e/tenant/seed_workload.yml
+++ b/tests/e2e/tenant/seed_workload.yml
@@ -1,5 +1,5 @@
 - name: Create osm_volume
-  os_volume:
+  openstack.cloud.volume:
     display_name: osm_volume
     size: 1
     auth: "{{ os_migrate_src_auth }}"
@@ -9,7 +9,7 @@
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
 
 - name: Create osm_server
-  os_server:
+  openstack.cloud.server:
     name: osm_server
     state: present
     flavor: "{{ os_migrate_src_osm_server_flavor|default(m1.small) }}"
@@ -32,7 +32,7 @@
 
 # In order to be able to migrate the VMS they must be turned off
 - name: Shutdown osm_server
-  os_server_action:
+  openstack.cloud.server_action:
     auth: "{{ os_migrate_src_auth }}"
     server: osm_server
     action: stop

--- a/tests/e2e/test_as_admin.yml
+++ b/tests/e2e/test_as_admin.yml
@@ -1,19 +1,24 @@
 - name: Test preparation
   hosts: migrator
   tasks:
-    - import_tasks: common/prep.yml
+    - name: prepate the test
+      ansible.builtin.import_tasks: common/prep.yml
 
 - name: Migration tests
   hosts: migrator
   tasks:
-    - include_tasks: admin/clean.yml
+    - name: clean the environment
+      ansible.builtin.include_tasks: admin/clean.yml
       args:
         apply:
           tags: test_clean_before
       tags: always
-    - import_tasks: admin/seed.yml
-    - import_tasks: admin/run.yml
-    - include_tasks: admin/clean.yml
+    - name: seed the environment
+      ansible.builtin.import_tasks: admin/seed.yml
+    - name: run the tests
+      ansible.builtin.import_tasks: admin/run.yml
+    - name: clean the environment
+      ansible.builtin.include_tasks: admin/clean.yml
       args:
         apply:
           tags: test_clean_after

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -1,18 +1,22 @@
 - name: Test preparation
   hosts: migrator
   tasks:
-    - import_tasks: common/prep.yml
+    - name: prepare the environment
+      ansible.builtin.import_tasks: common/prep.yml
 
 - name: Make sure conversion hosts are cleaned up
-  import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/delete_conversion_hosts.yml"
+  ansible.builtin.import_playbook:
+    "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/delete_conversion_hosts.yml"
 
 - name: Deploy conversion hosts
-  import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/deploy_conversion_hosts.yml"
+  ansible.builtin.import_playbook:
+    "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/deploy_conversion_hosts.yml"
 
 - name: Conversion host inventory
   hosts: migrator
   tasks:
-    - include_role:
+    - name: include the conversion hosts inventory
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: conv_hosts_inventory.yml
 
@@ -22,14 +26,16 @@
   hosts: conversion_hosts
   ignore_unreachable: true
   tasks:
-    - include_role:
+    - name: unregister the conversion hosts
+      ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host
         tasks_from: unregister.yml
 
 - name: Migration tests
   hosts: migrator
   tasks:
-    - include_tasks: tenant/clean_workload.yml
+    - name: clean workloads
+      ansible.builtin.include_tasks: tenant/clean_workload.yml
       args:
         apply:
           tags:
@@ -38,7 +44,9 @@
             - test_image_workload_boot_copy
             - test_image_workload_boot_nocopy
       tags: always
-    - include_tasks: tenant/clean_pre_workload.yml
+
+    - name: clean pre workloads
+      ansible.builtin.include_tasks: tenant/clean_pre_workload.yml
       args:
         apply:
           tags:
@@ -47,12 +55,15 @@
       tags: always
 
     # pre-workload seed & migrate
-    - include_tasks: tenant/seed_pre_workload.yml
+    - name: seed pre workloads
+      ansible.builtin.include_tasks: tenant/seed_pre_workload.yml
       args:
         apply:
           tags: test_pre_workload
       tags: always
-    - include_tasks: tenant/run_pre_workload.yml
+
+    - name: run the pre workloads
+      ansible.builtin.include_tasks: tenant/run_pre_workload.yml
       args:
         apply:
           tags: test_pre_workload
@@ -60,7 +71,8 @@
 
     # server from tenant-owned image with attached volume,
     # migration w/o boot volume copy
-    - include_tasks: tenant/seed_workload.yml
+    - name: seed the workloads
+      ansible.builtin.include_tasks: tenant/seed_workload.yml
       args:
         apply:
           tags:
@@ -69,14 +81,18 @@
       tags: always
       vars:
         workload_image: osm_image
-    - include_tasks: tenant/run_workload.yml
+
+    - name: run the workloads
+      ansible.builtin.include_tasks: tenant/run_workload.yml
       args:
         apply:
           tags:
             - test_workload
             - test_image_workload_boot_nocopy
       tags: always
-    - include_tasks: tenant/clean_workload.yml
+
+    - name: clean the workloads
+      ansible.builtin.include_tasks: tenant/clean_workload.yml
       args:
         apply:
           tags:
@@ -87,7 +103,8 @@
 
     # server from public image with attached volume,
     # migration with boot volume copy
-    - include_tasks: tenant/seed_workload.yml
+    - name: seed the workloads
+      ansible.builtin.include_tasks: tenant/seed_workload.yml
       args:
         apply:
           tags:
@@ -96,7 +113,9 @@
       tags: always
       vars:
         workload_image: "{{ os_migrate_src_osm_server_image }}"
-    - include_tasks: tenant/run_workload.yml
+
+    - name: run the workloads
+      ansible.builtin.include_tasks: tenant/run_workload.yml
       args:
         apply:
           tags:
@@ -105,7 +124,9 @@
       tags: always
       vars:
         set_boot_volume_copy: true
-    - include_tasks: tenant/clean_workload.yml
+
+    - name: clean the workloads
+      ansible.builtin.include_tasks: tenant/clean_workload.yml
       args:
         apply:
           tags:
@@ -116,7 +137,8 @@
       tags: always
 
     # pre-workload cleanup
-    - include_tasks: tenant/clean_pre_workload.yml
+    - name: clean pre workloads
+      ansible.builtin.include_tasks: tenant/clean_pre_workload.yml
       args:
         apply:
           tags:
@@ -127,5 +149,6 @@
     - test_migration
 
 - name: Delete conversion hosts
-  import_playbook: "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/delete_conversion_hosts.yml"
   when: test_clean_conversion_hosts_after|default(true)|bool
+  ansible.builtin.import_playbook:
+    "{{ lookup('env', 'OS_MIGRATE') }}/playbooks/delete_conversion_hosts.yml"

--- a/tests/func/admin/clean/all.yml
+++ b/tests/func/admin/clean/all.yml
@@ -1,5 +1,5 @@
 - name: Include keypair tasks
-  include_tasks: keypair.yml
+  ansible.builtin.include_tasks: keypair.yml
   args:
     apply:
       tags:
@@ -7,7 +7,7 @@
         - test_clean
 
 - name: Include user tasks
-  include_tasks: user.yml
+  ansible.builtin.include_tasks: user.yml
   args:
     apply:
       tags:
@@ -17,7 +17,7 @@
     - always
 
 - name: Include project tasks
-  include_tasks: project.yml
+  ansible.builtin.include_tasks: project.yml
   args:
     apply:
       tags:
@@ -27,7 +27,7 @@
     - always
 
 - name: Include flavor tasks
-  include_tasks: flavor.yml
+  ansible.builtin.include_tasks: flavor.yml
   args:
     apply:
       tags:

--- a/tests/func/admin/clean/flavor.yml
+++ b/tests/func/admin/clean/flavor.yml
@@ -1,5 +1,5 @@
 - name: remove osm_flavor
-  os_nova_flavor:
+  openstack.cloud.compute_flavor:
     auth: "{{ item }}"
     name: osm_flavor
     state: absent

--- a/tests/func/admin/clean/keypair.yml
+++ b/tests/func/admin/clean/keypair.yml
@@ -1,5 +1,5 @@
 - name: remove osm_keypair
-  os_keypair:
+  openstack.cloud.keypair:
     auth: "{{ item }}"
     name: osm_keypair
     state: absent

--- a/tests/func/admin/clean/project.yml
+++ b/tests/func/admin/clean/project.yml
@@ -1,5 +1,5 @@
 - name: remove osm_project
-  os_project:
+  openstack.cloud.project:
     auth: "{{ item }}"
     name: osm_project
     state: absent

--- a/tests/func/admin/clean/user.yml
+++ b/tests/func/admin/clean/user.yml
@@ -1,5 +1,5 @@
 - name: remove osm_user
-  os_user:
+  openstack.cloud.identity_user:
     auth: "{{ item }}"
     name: osm_user
     state: absent

--- a/tests/func/admin/idempotence/all.yml
+++ b/tests/func/admin/idempotence/all.yml
@@ -1,5 +1,5 @@
 - name: Include flavor tasks
-  include_tasks: flavor.yml
+  ansible.builtin.include_tasks: flavor.yml
   args:
     apply:
       tags:
@@ -7,7 +7,7 @@
   tags: always
 
 - name: Include keypair tasks
-  include_tasks: keypair.yml
+  ansible.builtin.include_tasks: keypair.yml
   args:
     apply:
       tags:
@@ -15,7 +15,7 @@
   tags: always
 
 - name: Include project tasks
-  include_tasks: project.yml
+  ansible.builtin.include_tasks: project.yml
   args:
     apply:
       tags:
@@ -23,7 +23,7 @@
   tags: always
 
 - name: Include flavor tasks
-  include_tasks: flavor.yml
+  ansible.builtin.include_tasks: flavor.yml
   args:
     apply:
       tags:

--- a/tests/func/admin/idempotence/flavor.yml
+++ b/tests/func/admin/idempotence/flavor.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_flavors
   vars:
     os_migrate_flavors_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     flavor_resources_idem: "{{ (lookup('file',
                                 os_migrate_data_dir +
                                 '/flavors.yml') | from_yaml)
                         ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - flavor_resources_idem == flavor_resources
     fail_msg: |
@@ -22,25 +22,26 @@
       {{ flavor_resources_idem | to_nice_yaml }}
       flavor_resources:
       {{ flavor_resources | to_nice_yaml }}
+
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_flavor dst cloud
-  os_flavor_info:
+  openstack.cloud.compute_flavor_info:
     auth: "{{ os_migrate_dst_auth }}"
     name: "osm_flavor"
   register: flavor_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_flavors
 
 - name: look up osm_flavor in dst cloud again
-  os_flavor_info:
+  openstack.cloud.compute_flavor_info:
     auth: "{{ os_migrate_dst_auth }}"
     name: "osm_flavor"
   register: flavor_import_idem_after
 
 - name: ensure ram for osm_flavor did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - flavor_import_idem_before['openstack_flavors'][0].ram != None
       - "flavor_import_idem_before['openstack_flavors'][0]['ram'] \

--- a/tests/func/admin/idempotence/keypair.yml
+++ b/tests/func/admin/idempotence/keypair.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_keypairs
   vars:
     os_migrate_keypairs_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     keypair_resources_idem: "{{ (lookup('file',
                                 os_migrate_data_dir +
                                 '/keypairs.yml') | from_yaml)
                         ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - keypair_resources_idem == keypair_resources
     fail_msg: |
@@ -30,7 +30,7 @@
     auth: "{{ os_migrate_dst_auth }}"
   register: keypair_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_keypairs
 
 - name: look up osm_keypair in dst cloud again
@@ -39,7 +39,7 @@
   register: keypair_import_idem_after
 
 - name: ensure fingerprint for osm_keypair did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - keypair_import_idem_before['openstack_keypairs'][0].fingerprint != None
       - "keypair_import_idem_before['openstack_keypairs'][0]['fingerprint'] \

--- a/tests/func/admin/idempotence/project.yml
+++ b/tests/func/admin/idempotence/project.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_projects
   vars:
     os_migrate_projects_filter:
       - regex: '^osm_'
 
 - name: re-load project_resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     project_resources_idem: "{{ (lookup('file',
                                 os_migrate_data_dir +
                                 '/projects.yml') | from_yaml)
                         ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - project_resources_idem == project_resources
     fail_msg: |
@@ -26,24 +26,24 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_project dst cloud
-  os_project_info:
+  openstack.cloud.project_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_project
   register: project_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_projects
 
 - name: look up osm_project in dst cloud again
-  os_project_info:
+  openstack.cloud.project_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_project
   register: project_import_idem_after
 
 - name: ensure is_enabled for osm_project did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - project_import_idem_before['openstack_projects'][0].is_enabled != None
       - "project_import_idem_before['openstack_projects'][0]['is_enabled'] \

--- a/tests/func/admin/run/all.yml
+++ b/tests/func/admin/run/all.yml
@@ -1,5 +1,5 @@
 - name: Include flavor tasks
-  include_tasks: flavor.yml
+  ansible.builtin.include_tasks: flavor.yml
   args:
     apply:
       tags:
@@ -7,7 +7,7 @@
   tags: always
 
 - name: Include keypair tasks
-  include_tasks: keypair.yml
+  ansible.builtin.include_tasks: keypair.yml
   args:
     apply:
       tags:
@@ -15,7 +15,7 @@
   tags: always
 
 - name: Include user tasks
-  include_tasks: user.yml
+  ansible.builtin.include_tasks: user.yml
   args:
     apply:
       tags:
@@ -23,7 +23,7 @@
   tags: always
 
 - name: Include project tasks
-  include_tasks: project.yml
+  ansible.builtin.include_tasks: project.yml
   args:
     apply:
       tags:

--- a/tests/func/admin/run/flavor.yml
+++ b/tests/func/admin/run/flavor.yml
@@ -1,23 +1,23 @@
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_flavors
   vars:
     os_migrate_flavors_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     flavor_resources: "{{ (lookup('file',
                                   os_migrate_data_dir +
                                   '/flavors.yml') | from_yaml)
                     ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - (flavor_resources |
         json_query("[?params.name ==
         'osm_flavor'].params.name")
         == ['osm_flavor'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_flavors

--- a/tests/func/admin/run/keypair.yml
+++ b/tests/func/admin/run/keypair.yml
@@ -1,18 +1,18 @@
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_keypairs
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     keypair_resources: "{{ (lookup('file',
                                   os_migrate_data_dir +
                                   '/keypairs.yml') | from_yaml)
                    ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - (keypair_resources | json_query("[?params.name ==
                             'osm_keypair']._info.type") == ['ssh'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_keypairs

--- a/tests/func/admin/run/project.yml
+++ b/tests/func/admin/run/project.yml
@@ -3,26 +3,26 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_projects
   vars:
     os_migrate_projects_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     project_resources: "{{ (lookup('file',
                            os_migrate_data_dir +
                            '/projects.yml') | from_yaml)
                    ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - (project_resources |
         json_query("[?params.name ==
         'osm_project'].params.name")
         == ['osm_project'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_projects

--- a/tests/func/admin/run/user.yml
+++ b/tests/func/admin/run/user.yml
@@ -1,23 +1,23 @@
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_users
   vars:
     os_migrate_users_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     resources: "{{ (lookup('file',
                            os_migrate_data_dir +
                            '/users.yml') | from_yaml)
                    ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - (resources |
         json_query("[?params.name ==
         'osm_user'].params.name")
         == ['osm_user'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_users

--- a/tests/func/admin/seed/all.yml
+++ b/tests/func/admin/seed/all.yml
@@ -1,5 +1,5 @@
 - name: Include keypair tasks
-  include_tasks: keypair.yml
+  ansible.builtin.include_tasks: keypair.yml
   args:
     apply:
       tags:
@@ -7,7 +7,7 @@
   tags: always
 
 - name: Include user tasks
-  include_tasks: user.yml
+  ansible.builtin.include_tasks: user.yml
   args:
     apply:
       tags:
@@ -15,7 +15,7 @@
   tags: always
 
 - name: Include project tasks
-  include_tasks: project.yml
+  ansible.builtin.include_tasks: project.yml
   args:
     apply:
       tags:
@@ -23,7 +23,7 @@
   tags: always
 
 - name: Include flavor tasks
-  include_tasks: flavor.yml
+  ansible.builtin.include_tasks: flavor.yml
   args:
     apply:
       tags:

--- a/tests/func/admin/seed/flavor.yml
+++ b/tests/func/admin/seed/flavor.yml
@@ -1,5 +1,5 @@
 - name: create osm_flavor
-  os_nova_flavor:
+  openstack.cloud.compute_flavor:
     auth: "{{ os_migrate_src_auth }}"
     state: present
     name: osm_flavor

--- a/tests/func/admin/seed/keypair.yml
+++ b/tests/func/admin/seed/keypair.yml
@@ -1,5 +1,5 @@
 - name: create osm_keypair
-  os_keypair:
+  openstack.cloud.keypair:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_keypair
     state: present

--- a/tests/func/admin/seed/project.yml
+++ b/tests/func/admin/seed/project.yml
@@ -1,5 +1,5 @@
 - name: create osm_project
-  os_project:
+  openstack.cloud.project:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_project
     domain: default

--- a/tests/func/admin/seed/user.yml
+++ b/tests/func/admin/seed/user.yml
@@ -1,5 +1,5 @@
 - name: create osm_user
-  os_user:
+  openstack.cloud.identity_user:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_user
     state: present

--- a/tests/func/admin/update/all.yml
+++ b/tests/func/admin/update/all.yml
@@ -1,5 +1,5 @@
 - name: Include project tasks
-  include_tasks: project.yml
+  ansible.builtin.include_tasks: project.yml
   args:
     apply:
       tags:

--- a/tests/func/admin/update/project.yml
+++ b/tests/func/admin/update/project.yml
@@ -1,41 +1,41 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/projects.yml"
     regexp: "    description: seeded"
     replace: "    description: 'osm_project_updated'"
     backup: yes
 
 - name: scan available projects after before test
-  os_project_info:
+  openstack.cloud.project_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_project
   register: dst_projects_info_before
 
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
       {{ dst_projects_info_before['openstack_projects'] | json_query(
         "[?name=='osm_project'].description") }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_projects
 
 - name: scan available projects after update test
-  os_project_info:
+  openstack.cloud.project_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_project
   register: dst_projects_info_after
 
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
       {{ dst_projects_info_after['openstack_projects'] | json_query(
         "[?name=='osm_project'].description") }}
 
 - name: ensure description for osm_project changed
-  assert:
+  ansible.builtin.assert:
     that:
       - original_desc == ['seeded']
       - changed_desc == ['osm_project_updated']

--- a/tests/func/global/prep.yml
+++ b/tests/func/global/prep.yml
@@ -1,6 +1,6 @@
 # make sure no artifacts from prevoius test persisted
 - name: delete os_migrate_data_dir
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}"
     state: absent
   tags:
@@ -8,7 +8,7 @@
     - test_prep
 
 - name: create os_migrate_tests_tmp_dir
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_tests_tmp_dir }}"
     state: directory
   tags:
@@ -16,7 +16,7 @@
     - test_prep
 
 - name: create os_migrate_data_dir
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}"
     state: directory
   tags:

--- a/tests/func/tenant/clean/all.yml
+++ b/tests/func/tenant/clean/all.yml
@@ -1,5 +1,5 @@
 - name: Include image tasks
-  include_tasks: image.yml
+  ansible.builtin.include_tasks: image.yml
   args:
     apply:
       tags:
@@ -8,7 +8,7 @@
   tags: always
 
 - name: Include router tasks
-  include_tasks: router.yml
+  ansible.builtin.include_tasks: router.yml
   args:
     apply:
       tags:
@@ -18,7 +18,7 @@
     - always
 
 - name: Include subnet tasks
-  include_tasks: subnet.yml
+  ansible.builtin.include_tasks: subnet.yml
   args:
     apply:
       tags:
@@ -28,7 +28,7 @@
     - always
 
 - name: Include network tasks
-  include_tasks: network.yml
+  ansible.builtin.include_tasks: network.yml
   args:
     apply:
       tags:
@@ -38,7 +38,7 @@
     - always
 
 - name: Include security group rule tasks
-  include_tasks: security_group_rule.yml
+  ansible.builtin.include_tasks: security_group_rule.yml
   args:
     apply:
       tags:
@@ -48,7 +48,7 @@
     - always
 
 - name: Include security group tasks
-  include_tasks: security_group.yml
+  ansible.builtin.include_tasks: security_group.yml
   args:
     apply:
       tags:

--- a/tests/func/tenant/clean/image.yml
+++ b/tests/func/tenant/clean/image.yml
@@ -1,5 +1,5 @@
 - name: remove osm_image
-  os_image:
+  openstack.cloud.image:
     auth: "{{ item }}"
     name: osm_image
     state: absent

--- a/tests/func/tenant/clean/network.yml
+++ b/tests/func/tenant/clean/network.yml
@@ -1,5 +1,5 @@
 - name: remove osm_net
-  os_network:
+  openstack.cloud.network:
     auth: "{{ item }}"
     name: osm_net
     state: absent

--- a/tests/func/tenant/clean/router.yml
+++ b/tests/func/tenant/clean/router.yml
@@ -1,5 +1,5 @@
 - name: remove osm_router
-  os_router:
+  openstack.cloud.router:
     auth: "{{ item }}"
     name: osm_router
     state: absent

--- a/tests/func/tenant/clean/security_group.yml
+++ b/tests/func/tenant/clean/security_group.yml
@@ -1,5 +1,5 @@
 - name: remove osm_security_group
-  os_security_group:
+  openstack.cloud.security_group:
     auth: "{{ item }}"
     name: osm_security_group
     state: absent

--- a/tests/func/tenant/clean/security_group_rule.yml
+++ b/tests/func/tenant/clean/security_group_rule.yml
@@ -1,5 +1,5 @@
 - name: remove osm_security_group_rule
-  os_security_group_rule:
+  openstack.cloud.security_group_rule:
     auth: "{{ item }}"
     security_group: osm_security_group
     state: absent

--- a/tests/func/tenant/clean/subnet.yml
+++ b/tests/func/tenant/clean/subnet.yml
@@ -1,5 +1,5 @@
 - name: remove osm_subnet
-  os_subnet:
+  openstack.cloud.subnet:
     auth: "{{ item }}"
     name: osm_subnet
     state: absent
@@ -8,7 +8,7 @@
     - "{{ os_migrate_dst_auth }}"
 
 - name: remove osm_router_subnet
-  os_subnet:
+  openstack.cloud.subnet:
     auth: "{{ item }}"
     name: osm_router_subnet
     state: absent

--- a/tests/func/tenant/idempotence/all.yml
+++ b/tests/func/tenant/idempotence/all.yml
@@ -1,5 +1,5 @@
 - name: Include network tasks
-  include_tasks: network.yml
+  ansible.builtin.include_tasks: network.yml
   args:
     apply:
       tags:
@@ -7,7 +7,7 @@
   tags: always
 
 - name: Include subnet tasks
-  include_tasks: subnet.yml
+  ansible.builtin.include_tasks: subnet.yml
   args:
     apply:
       tags:
@@ -15,7 +15,7 @@
   tags: always
 
 - name: Include security group tasks
-  include_tasks: security_group.yml
+  ansible.builtin.include_tasks: security_group.yml
   args:
     apply:
       tags:
@@ -23,14 +23,14 @@
   tags: always
 
 - name: Include router tasks
-  include_tasks: router.yml
+  ansible.builtin.include_tasks: router.yml
   args:
     apply:
       tags:
         - test_router
 
 - name: Include security group rule tasks
-  include_tasks: security_group_rule.yml
+  ansible.builtin.include_tasks: security_group_rule.yml
   args:
     apply:
       tags:
@@ -38,7 +38,7 @@
   tags: always
 
 - name: Include router interface tasks
-  include_tasks: router_interface.yml
+  ansible.builtin.include_tasks: router_interface.yml
   args:
     apply:
       tags:
@@ -46,7 +46,7 @@
   tags: always
 
 - name: Include image tasks
-  include_tasks: image.yml
+  ansible.builtin.include_tasks: image.yml
   args:
     apply:
       tags:

--- a/tests/func/tenant/idempotence/image.yml
+++ b/tests/func/tenant/idempotence/image.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_images
   vars:
     os_migrate_images_filter:
       - regex: '^osm_'
 
 - name: re-load image_resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     image_resources_idem: "{{ (lookup('file',
                                   os_migrate_data_dir +
                                   '/images.yml') | from_yaml)
                               ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - image_resources_idem == image_resources
     fail_msg: |
@@ -26,22 +26,22 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_image dst cloud
-  os_image_info:
+  openstack.cloud.image_info:
     auth: "{{ os_migrate_dst_auth }}"
     image: osm_image
   register: image_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_images
 
 - name: look up osm_image in dst cloud again
-  os_image_info:
+  openstack.cloud.image_info:
     auth: "{{ os_migrate_dst_auth }}"
     image: osm_image
   register: image_import_idem_after
 
 - name: ensure updated_at for osm_image did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - image_import_idem_before['openstack_image'].updated_at != None
       - "image_import_idem_before['openstack_image']['updated_at'] \

--- a/tests/func/tenant/idempotence/network.yml
+++ b/tests/func/tenant/idempotence/network.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_networks
   vars:
     os_migrate_networks_filter:
       - regex: '^osm_'
 
 - name: re-load network_resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     network_resources_idem: "{{ (lookup('file',
                                 os_migrate_data_dir +
                                 '/networks.yml') | from_yaml)
                         ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - network_resources_idem == network_resources
     fail_msg: |
@@ -26,24 +26,24 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_net dst cloud
-  os_networks_info:
+  openstack.cloud.networks_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_net
   register: network_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_networks
 
 - name: look up osm_net in dst cloud again
-  os_networks_info:
+  openstack.cloud.networks_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_net
   register: network_import_idem_after
 
 - name: ensure updated_at for osm_net did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - network_import_idem_before['openstack_networks'][0].updated_at != None
       - "network_import_idem_before['openstack_networks'][0]['updated_at'] \

--- a/tests/func/tenant/idempotence/router.yml
+++ b/tests/func/tenant/idempotence/router.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_routers
   vars:
     os_migrate_routers_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     router_resources_idem: "{{ (lookup('file',
                                 os_migrate_data_dir +
                                 '/routers.yml') | from_yaml)
                         ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - router_resources_idem == router_resources
     fail_msg: |
@@ -32,7 +32,7 @@
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
   register: router_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_routers
 
 - name: look up osm_router in dst cloud again
@@ -43,7 +43,7 @@
   register: router_import_idem_after
 
 - name: ensure updated_at for osm_router did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - router_import_idem_before['openstack_routers'][0].updated_at != None
       - "router_import_idem_before['openstack_routers'][0]['updated_at'] \

--- a/tests/func/tenant/idempotence/router_interface.yml
+++ b/tests/func/tenant/idempotence/router_interface.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_router_interfaces
   vars:
     os_migrate_routers_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     router_interface_resources_idem: "{{ (lookup('file',
                                 os_migrate_data_dir +
                                 '/router_interfaces.yml') | from_yaml)
                         ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - router_interface_resources_idem == router_interface_resources
     fail_msg: |
@@ -32,7 +32,7 @@
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
   register: ri_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_router_interfaces
 
 - name: look up osm_router in dst cloud again
@@ -43,7 +43,7 @@
   register: ri_import_idem_after
 
 - name: ensure updated_at for osm_router did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - ri_import_idem_before['openstack_routers'][0].updated_at != None
       - "ri_import_idem_before['openstack_routers'][0]['updated_at'] \

--- a/tests/func/tenant/idempotence/security_group.yml
+++ b/tests/func/tenant/idempotence/security_group.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_security_groups
   vars:
     os_migrate_security_groups_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     sec_group_resources_idem: "{{ (lookup('file',
                                    os_migrate_data_dir +
                                    '/security_groups.yml') | from_yaml)
                                    ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - sec_group_resources_idem == security_group_resources
     fail_msg: |
@@ -32,7 +32,7 @@
       name: osm_security_group
   register: sg_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_groups
 
 - name: look up osm_security_group in dst cloud again
@@ -43,7 +43,7 @@
   register: sg_import_idem_after
 
 - name: ensure updated_at for osm_security_group did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - sg_import_idem_before['openstack_security_groups'][0].updated_at != None
       - "sg_import_idem_before['openstack_security_groups'][0]['updated_at'] \

--- a/tests/func/tenant/idempotence/security_group_rule.yml
+++ b/tests/func/tenant/idempotence/security_group_rule.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_security_group_rules
   vars:
     os_migrate_security_groups_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     sgr_resources_idem: "{{ (lookup('file',
                                 os_migrate_data_dir +
                                 '/security_group_rules.yml') | from_yaml)
                         ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - sgr_resources_idem == security_group_rule_resources
     fail_msg: |
@@ -32,7 +32,7 @@
     region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
   register: sgr_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_group_rules
 
 - name: look up osm_security_group dst cloud again
@@ -43,7 +43,7 @@
   register: sgr_import_idem_after
 
 - name: ensure updated_at for osm_security_group did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - "sgr_import_idem_before['openstack_security_groups'][0].updated_at
         != None"

--- a/tests/func/tenant/idempotence/subnet.yml
+++ b/tests/func/tenant/idempotence/subnet.yml
@@ -1,20 +1,20 @@
 ### EXPORT IDEMPOTENCE ###
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_subnets
   vars:
     os_migrate_subnets_filter:
       - regex: '^osm_'
 
 - name: re-load resources for idempotency test
-  set_fact:
+  ansible.builtin.set_fact:
     subnet_resources_idem: "{{ (lookup('file',
                                 os_migrate_data_dir +
                                 '/subnets.yml') | from_yaml)
                         ['resources'] }}"
 
 - name: verify that export file did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - subnet_resources_idem == subnet_resources
     fail_msg: |
@@ -26,24 +26,24 @@
 ### IMPORT IDEMPOTENCE ###
 
 - name: look up osm_subnet dst cloud
-  os_subnets_info:
+  openstack.cloud.subnets_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_subnet
   register: subnet_import_idem_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_subnets
 
 - name: look up osm_subnet in dst cloud again
-  os_subnets_info:
+  openstack.cloud.subnets_info:
     auth: "{{ os_migrate_dst_auth }}"
     filters:
       name: osm_subnet
   register: subnet_import_idem_after
 
 - name: ensure updated_at for osm_subnet did not change
-  assert:
+  ansible.builtin.assert:
     that:
       - subnet_import_idem_before['openstack_subnets'][0].updated_at != None
       - "subnet_import_idem_before['openstack_subnets'][0]['updated_at'] \

--- a/tests/func/tenant/independent/all.yml
+++ b/tests/func/tenant/independent/all.yml
@@ -1,5 +1,5 @@
 - name: Include validate data dir tasks
-  include_tasks: validate_data_dir.yml
+  ansible.builtin.include_tasks: validate_data_dir.yml
   args:
     apply:
       tags:

--- a/tests/func/tenant/independent/validate_data_dir.yml
+++ b/tests/func/tenant/independent/validate_data_dir.yml
@@ -1,27 +1,27 @@
 - name: validate valid dir
-  changed_when: true
-  shell: |
+  ansible.builtin.shell: |
     OS_MIGRATE="$HOME/.ansible/collections/ansible_collections/os_migrate/os_migrate"
     OS_MIGRATE_DATA="{{ playbook_dir }}/tenant/data/validate_data_dir/valid"
     ansible-playbook -v \
         -i $OS_MIGRATE/localhost_inventory.yml \
         -e "os_migrate_data_dir=$OS_MIGRATE_DATA" \
         $OS_MIGRATE/playbooks/validate_data_dir.yml
+  changed_when: true
 
 - name: validate invalid dir
-  changed_when: true
-  shell: |
+  ansible.builtin.shell: |
     OS_MIGRATE="$HOME/.ansible/collections/ansible_collections/os_migrate/os_migrate"
     OS_MIGRATE_DATA="{{ playbook_dir }}/tenant/data/validate_data_dir/invalid"
     ansible-playbook -v \
         -i $OS_MIGRATE/localhost_inventory.yml \
         -e "os_migrate_data_dir=$OS_MIGRATE_DATA" \
         $OS_MIGRATE/playbooks/validate_data_dir.yml
+  changed_when: true
   failed_when: false
   register: validate_data_dir_invalid_result
 
 - name: assert invalid dir validation failed
-  fail:
+  ansible.builtin.fail:
     msg: |
       =======
       STDOUT:

--- a/tests/func/tenant/run/all.yml
+++ b/tests/func/tenant/run/all.yml
@@ -1,5 +1,5 @@
 - name: Include network tasks
-  include_tasks: network.yml
+  ansible.builtin.include_tasks: network.yml
   args:
     apply:
       tags:
@@ -7,7 +7,7 @@
   tags: always
 
 - name: Include subnet tasks
-  include_tasks: subnet.yml
+  ansible.builtin.include_tasks: subnet.yml
   args:
     apply:
       tags:
@@ -15,7 +15,7 @@
   tags: always
 
 - name: Include security group tasks
-  include_tasks: security_group.yml
+  ansible.builtin.include_tasks: security_group.yml
   args:
     apply:
       tags:
@@ -23,7 +23,7 @@
   tags: always
 
 - name: Include security group rules tasks
-  include_tasks: security_group_rule.yml
+  ansible.builtin.include_tasks: security_group_rule.yml
   args:
     apply:
       tags:
@@ -31,7 +31,7 @@
   tags: always
 
 - name: Include router tasks
-  include_tasks: router.yml
+  ansible.builtin.include_tasks: router.yml
   args:
     apply:
       tags:
@@ -39,7 +39,7 @@
   tags: always
 
 - name: Include router interface tasks
-  include_tasks: router_interface.yml
+  ansible.builtin.include_tasks: router_interface.yml
   args:
     apply:
       tags:
@@ -47,7 +47,7 @@
   tags: always
 
 - name: Include image tasks
-  include_tasks: image.yml
+  ansible.builtin.include_tasks: image.yml
   args:
     apply:
       tags:

--- a/tests/func/tenant/run/image.yml
+++ b/tests/func/tenant/run/image.yml
@@ -3,26 +3,26 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_images
   vars:
     os_migrate_images_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     image_resources: "{{ (lookup('file',
                            os_migrate_data_dir +
                            '/images.yml') | from_yaml)
                    ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - (image_resources |
         json_query("[?params.name ==
         'osm_image'].params.min_ram")
         == [128])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_images

--- a/tests/func/tenant/run/network.yml
+++ b/tests/func/tenant/run/network.yml
@@ -3,26 +3,26 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_networks
   vars:
     os_migrate_networks_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     network_resources: "{{ (lookup('file',
                            os_migrate_data_dir +
                            '/networks.yml') | from_yaml)
                    ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - (network_resources |
         json_query("[?params.name ==
         'osm_net'].params.name")
         == ['osm_net'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_networks

--- a/tests/func/tenant/run/router.yml
+++ b/tests/func/tenant/run/router.yml
@@ -3,26 +3,26 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_routers
   vars:
     os_migrate_routers_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     router_resources: "{{ (lookup('file',
                                   os_migrate_data_dir +
                                   '/routers.yml') | from_yaml)
                           ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - "(router_resources |
           json_query(\"[?params.name ==
           'osm_router'].params.external_gateway_refinfo.network_ref.name\")) ==
           [test_router_external_network | default('public')]"
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_routers

--- a/tests/func/tenant/run/router_interface.yml
+++ b/tests/func/tenant/run/router_interface.yml
@@ -3,21 +3,21 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_router_interfaces
   vars:
     os_migrate_routers_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     router_interface_resources: "{{ (lookup('file',
                                      os_migrate_data_dir +
                                      '/router_interfaces.yml') | from_yaml)
                                      ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - "(router_interface_resources |
           json_query(\"[?params.device_ref.name ==
@@ -28,5 +28,5 @@
           'osm_router'].params.fixed_ips_refs[].subnet_ref.name\")) | sort ==
           ['osm_router_subnet', 'osm_subnet']"
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_router_interfaces

--- a/tests/func/tenant/run/security_group.yml
+++ b/tests/func/tenant/run/security_group.yml
@@ -3,14 +3,14 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_security_groups
   vars:
     os_migrate_security_groups_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     security_group_resources: "{{ (lookup('file',
                                           os_migrate_data_dir +
                                           '/security_groups.yml') |
@@ -18,12 +18,12 @@
                    ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - (security_group_resources |
         json_query("[?params.name ==
         'osm_security_group'].params.description")
         == ['OSM security group'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_groups

--- a/tests/func/tenant/run/security_group_rule.yml
+++ b/tests/func/tenant/run/security_group_rule.yml
@@ -3,14 +3,14 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_security_group_rules
   vars:
     os_migrate_security_groups_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     security_group_rule_resources: "{{ (lookup('file',
                                                os_migrate_data_dir +
                                                '/security_group_rules.yml') |
@@ -18,12 +18,12 @@
                    ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - (security_group_rule_resources |
         json_query("[?params.security_group_ref.name ==
         'osm_security_group'].params.protocol")
         == ['tcp'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_group_rules

--- a/tests/func/tenant/run/subnet.yml
+++ b/tests/func/tenant/run/subnet.yml
@@ -3,26 +3,26 @@
 # import_playbook, or spawn an ansible-playbook subprocess? The latter
 # might be actually a more precise way to test the real end-user
 # experience.
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.export_subnets
   vars:
     os_migrate_subnets_filter:
       - regex: '^osm_'
 
 - name: load exported data
-  set_fact:
+  ansible.builtin.set_fact:
     subnet_resources: "{{ (lookup('file',
                                   os_migrate_data_dir +
                                   '/subnets.yml') | from_yaml)
                    ['resources'] }}"
 
 - name: verify data contents
-  assert:
+  ansible.builtin.assert:
     that:
       - (subnet_resources |
         json_query("[?params.name ==
         'osm_subnet'].params.cidr")
         == ['192.168.0.0/24'])
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_subnets

--- a/tests/func/tenant/seed/all.yml
+++ b/tests/func/tenant/seed/all.yml
@@ -1,13 +1,14 @@
 - name: Include network tasks
-  include_tasks: network.yml
+  ansible.builtin.include_tasks: network.yml
   args:
     apply:
       tags:
         - test_network
   tags: always
 
+
 - name: Include subnet tasks
-  include_tasks: subnet.yml
+  ansible.builtin.include_tasks: subnet.yml
   args:
     apply:
       tags:
@@ -15,7 +16,7 @@
   tags: always
 
 - name: Include security group tasks
-  include_tasks: security_group.yml
+  ansible.builtin.include_tasks: security_group.yml
   args:
     apply:
       tags:
@@ -23,7 +24,7 @@
   tags: always
 
 - name: Include security group rule tasks
-  include_tasks: security_group_rule.yml
+  ansible.builtin.include_tasks: security_group_rule.yml
   args:
     apply:
       tags:
@@ -31,7 +32,7 @@
   tags: always
 
 - name: Include router tasks
-  include_tasks: router.yml
+  ansible.builtin.include_tasks: router.yml
   args:
     apply:
       tags:
@@ -39,7 +40,7 @@
   tags: always
 
 - name: Include image tasks
-  include_tasks: image.yml
+  ansible.builtin.include_tasks: image.yml
   args:
     apply:
       tags:

--- a/tests/func/tenant/seed/image.yml
+++ b/tests/func/tenant/seed/image.yml
@@ -1,15 +1,15 @@
 - name: make sure test_inputs dir exists
-  file:
+  ansible.builtin.file:
     path: "{{ os_migrate_tests_tmp_dir }}/test_inputs"
     state: directory
 
 - name: fetch cirros image
-  get_url:
+  ansible.builtin.get_url:
     url: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
     dest: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
 
 - name: create osm_image
-  os_image:
+  openstack.cloud.image:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_image
     filename: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"

--- a/tests/func/tenant/seed/network.yml
+++ b/tests/func/tenant/seed/network.yml
@@ -1,5 +1,5 @@
 - name: create osm_net
-  os_network:
+  openstack.cloud.network:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_net
     # Apparently description is an unsupported param in Ansible even

--- a/tests/func/tenant/seed/router.yml
+++ b/tests/func/tenant/seed/router.yml
@@ -1,5 +1,5 @@
 - name: create osm_router
-  os_router:
+  openstack.cloud.router:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_router
     state: present

--- a/tests/func/tenant/seed/security_group.yml
+++ b/tests/func/tenant/seed/security_group.yml
@@ -1,5 +1,5 @@
 - name: Create security group
-  os_security_group:
+  openstack.cloud.security_group:
     auth: "{{ os_migrate_src_auth }}"
     state: present
     name: osm_security_group

--- a/tests/func/tenant/seed/security_group_rule.yml
+++ b/tests/func/tenant/seed/security_group_rule.yml
@@ -1,5 +1,5 @@
 - name: Create security group rule
-  os_security_group_rule:
+  openstack.cloud.security_group_rule:
     auth: "{{ os_migrate_src_auth }}"
     security_group: osm_security_group
     protocol: tcp

--- a/tests/func/tenant/seed/subnet.yml
+++ b/tests/func/tenant/seed/subnet.yml
@@ -1,5 +1,5 @@
 - name: Create subnet
-  os_subnet:
+  openstack.cloud.subnet:
     auth: "{{ os_migrate_src_auth }}"
     state: present
     network_name: osm_net
@@ -15,7 +15,7 @@
         nexthop: 192.168.0.1
 
 - name: Create a 2nd subnet for router testing
-  os_subnet:
+  openstack.cloud.subnet:
     auth: "{{ os_migrate_src_auth }}"
     state: present
     network_name: osm_net

--- a/tests/func/tenant/update/all.yml
+++ b/tests/func/tenant/update/all.yml
@@ -1,5 +1,5 @@
 - name: Include router tasks
-  include_tasks: router.yml
+  ansible.builtin.include_tasks: router.yml
   args:
     apply:
       tags:
@@ -7,7 +7,7 @@
   tags: always
 
 - name: Include network tasks
-  include_tasks: network.yml
+  ansible.builtin.include_tasks: network.yml
   args:
     apply:
       tags:
@@ -15,7 +15,7 @@
   tags: always
 
 - name: Include subnet tasks
-  include_tasks: subnet.yml
+  ansible.builtin.include_tasks: subnet.yml
   args:
     apply:
       tags:
@@ -23,7 +23,7 @@
   tags: always
 
 - name: Include security group tasks
-  include_tasks: security_group.yml
+  ansible.builtin.include_tasks: security_group.yml
   args:
     apply:
       tags:
@@ -31,7 +31,7 @@
   tags: always
 
 - name: Include image tasks
-  include_tasks: image.yml
+  ansible.builtin.include_tasks: image.yml
   args:
     apply:
       tags:

--- a/tests/func/tenant/update/image.yml
+++ b/tests/func/tenant/update/image.yml
@@ -1,12 +1,12 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/images.yml"
     regexp: "    min_disk: 1"
     replace: "    min_disk: 2"
     backup: yes
 
 - name: scan image before update test
-  os_image_info:
+  openstack.cloud.image_info:
     image: osm_image
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -18,15 +18,15 @@
   register: dst_images_info_before
 
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
       {{ dst_images_info_before['openstack_image']['min_disk'] }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_images
 
 - name: scan available images after update test
-  os_image_info:
+  openstack.cloud.image_info:
     image: osm_image
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -38,12 +38,12 @@
   register: dst_images_info_after
 
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
       {{ dst_images_info_after['openstack_image']['min_disk'] }}
 
 - name: ensure min_disk for osm_image changed
-  assert:
+  ansible.builtin.assert:
     that:
       - original_desc == "1"
       - changed_desc == "2"

--- a/tests/func/tenant/update/network.yml
+++ b/tests/func/tenant/update/network.yml
@@ -1,12 +1,12 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/networks.yml"
     regexp: "    description: ''"
     replace: "    description: 'osm_net_updated'"
     backup: yes
 
 - name: scan available networks after before test
-  os_networks_info:
+  openstack.cloud.networks_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -18,16 +18,16 @@
   register: dst_networks_info_before
 
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
       {{ dst_networks_info_before['openstack_networks'] | json_query(
         "[?name=='osm_net'].description") }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_networks
 
 - name: scan available networks after update test
-  os_networks_info:
+  openstack.cloud.networks_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -39,13 +39,13 @@
   register: dst_networks_info_after
 
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
       {{ dst_networks_info_after['openstack_networks'] | json_query(
         "[?name=='osm_net'].description") }}
 
 - name: ensure description for osm_net changed
-  assert:
+  ansible.builtin.assert:
     that:
       - original_desc == ['']
       - changed_desc == ['osm_net_updated']

--- a/tests/func/tenant/update/router.yml
+++ b/tests/func/tenant/update/router.yml
@@ -1,5 +1,5 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/routers.yml"
     regexp: "    description: ''"
     replace: "    description: 'osm_router_updated'"
@@ -17,7 +17,7 @@
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
   register: dst_routers_info_before
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_routers
 
 - name: scan available routers after update test
@@ -33,7 +33,7 @@
   register: dst_routers_info_after
 
 - name: ensure description for osm_router changed
-  assert:
+  ansible.builtin.assert:
     that:
       - dst_routers_info_before['openstack_routers'][0].description != None
       - "dst_routers_info_before['openstack_routers'][0]['description'] \

--- a/tests/func/tenant/update/security_group.yml
+++ b/tests/func/tenant/update/security_group.yml
@@ -1,5 +1,5 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/security_groups.yml"
     regexp: "    description: OSM security group"
     replace: "    description: 'OSM security group updated'"
@@ -18,12 +18,12 @@
   register: dst_sg_info_before
 
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
       {{ dst_sg_info_before['openstack_security_groups'] | json_query(
         "[?name=='osm_security_group'].description") }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_groups
 
 - name: scan available security_groups after update test
@@ -39,13 +39,13 @@
   register: dst_sg_info_after
 
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
       {{ dst_sg_info_after['openstack_security_groups'] | json_query(
         "[?name=='osm_security_group'].description") }}
 
 - name: ensure description for osm_security_group changed
-  assert:
+  ansible.builtin.assert:
     that:
       - original_desc[0] == 'OSM security group'
       - changed_desc[0] == 'OSM security group updated'

--- a/tests/func/tenant/update/subnet.yml
+++ b/tests/func/tenant/update/subnet.yml
@@ -1,12 +1,12 @@
 - name: change item in file for update test
-  replace:
+  ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/subnets.yml"
     regexp: "    description: ''"
     replace: "    description: 'osm_subnet_updated'"
     backup: yes
 
 - name: scan available subnets after before test
-  os_subnets_info:
+  openstack.cloud.subnets_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -18,16 +18,16 @@
   register: dst_subnets_info_before
 
 - name: get original description
-  set_fact:
+  ansible.builtin.set_fact:
     original_desc: |-
       {{ dst_subnets_info_before['openstack_subnets'] | json_query(
         "[?name=='osm_subnet'].description") }}
 
-- include_role:
+- ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_subnets
 
 - name: scan available subnets after update test
-  os_subnets_info:
+  openstack.cloud.subnets_info:
     filters: "{{ os_migrate_dst_filters }}"
     auth: "{{ os_migrate_dst_auth }}"
     auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
@@ -39,13 +39,13 @@
   register: dst_subnets_info_after
 
 - name: get changed description
-  set_fact:
+  ansible.builtin.set_fact:
     changed_desc: |-
       {{ dst_subnets_info_after['openstack_subnets'] | json_query(
         "[?name=='osm_subnet'].description") }}
 
 - name: ensure description for osm_subnet changed
-  assert:
+  ansible.builtin.assert:
     that:
       - original_desc == ['']
       - changed_desc == ['osm_subnet_updated']

--- a/tests/func/test_as_admin.yml
+++ b/tests/func/test_as_admin.yml
@@ -1,17 +1,24 @@
 - name: Migration tests
   hosts: migrator
   tasks:
-    - import_tasks: global/prep.yml
-    - include_tasks: admin/clean/all.yml
+    - name: prepare
+      ansible.builtin.import_tasks: global/prep.yml
+    - name: clean
+      ansible.builtin.include_tasks: admin/clean/all.yml
       args:
         apply:
           tags: test_clean_before
       tags: always
-    - import_tasks: admin/seed/all.yml
-    - import_tasks: admin/run/all.yml
-    - import_tasks: admin/idempotence/all.yml
-    - import_tasks: admin/update/all.yml
-    - include_tasks: admin/clean/all.yml
+    - name: seed
+      ansible.builtin.import_tasks: admin/seed/all.yml
+    - name: run
+      ansible.builtin.import_tasks: admin/run/all.yml
+    - name: check idempotence
+      ansible.builtin.import_tasks: admin/idempotence/all.yml
+    - name: update
+      ansible.builtin.import_tasks: admin/update/all.yml
+    - name: clean
+      ansible.builtin.include_tasks: admin/clean/all.yml
       args:
         apply:
           tags: test_clean_after

--- a/tests/func/test_as_tenant.yml
+++ b/tests/func/test_as_tenant.yml
@@ -1,24 +1,32 @@
 - name: Independent tests
   hosts: migrator
   tasks:
-    - import_tasks: tenant/independent/all.yml
+    - name: check independent
+      ansible.builtin.import_tasks: tenant/independent/all.yml
   tags:
     - test_independent
 
 - name: Migration tests
   hosts: migrator
   tasks:
-    - import_tasks: global/prep.yml
-    - include_tasks: tenant/clean/all.yml
+    - name: prepare
+      ansible.builtin.import_tasks: global/prep.yml
+    - name: clean
+      ansible.builtin.include_tasks: tenant/clean/all.yml
       args:
         apply:
           tags: test_clean_before
       tags: always
-    - import_tasks: tenant/seed/all.yml
-    - import_tasks: tenant/run/all.yml
-    - import_tasks: tenant/idempotence/all.yml
-    - import_tasks: tenant/update/all.yml
-    - include_tasks: tenant/clean/all.yml
+    - name: seed
+      ansible.builtin.import_tasks: tenant/seed/all.yml
+    - name: run
+      ansible.builtin.import_tasks: tenant/run/all.yml
+    - name: check idempotence
+      ansible.builtin.import_tasks: tenant/idempotence/all.yml
+    - name: update
+      ansible.builtin.import_tasks: tenant/update/all.yml
+    - name: clean
+      ansible.builtin.include_tasks: tenant/clean/all.yml
       args:
         apply:
           tags: test_clean_after

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
@@ -1,5 +1,5 @@
 - name: clone devstack
-  git:
+  ansible.builtin.git:
     repo: https://opendev.org/openstack/devstack
     version: master
     dest: /home/stack/devstack
@@ -8,7 +8,7 @@
   become_user: stack
 
 - name: write devstack config
-  template:
+  ansible.builtin.template:
     src: local.conf.j2
     dest: /home/stack/devstack/local.conf
   become: true

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/main.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/main.yml
@@ -1,3 +1,6 @@
-- include: prereqs.yml
-- include: config.yml
-- include: start.yml
+- name: install prereqs
+  ansible.builtin.include: prereqs.yml
+- name: config
+  ansible.builtin.include: config.yml
+- name: start
+  ansible.builtin.include: start.yml

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
@@ -1,5 +1,5 @@
 - name: install packages for devstack
-  package:
+  ansible.builtin.package:
     name:
       - git
       - python2
@@ -8,17 +8,17 @@
     state: present
 
 - name: remove packages which devstack does not like
-  package:
+  ansible.builtin.package:
     name:
       - python3-pyyaml
     state: absent
 
 - name: create stack user
-  user:
+  ansible.builtin.user:
     name: stack
 
 - name: create sudoers entry for stack
-  copy:
+  ansible.builtin.copy:
     dest: /etc/sudoers.d/stack
     content: |
       stack ALL=(ALL) NOPASSWD:ALL

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/start.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/start.yml
@@ -1,7 +1,7 @@
 - name: start devstack
-  changed_when: true
-  shell: |
+  ansible.builtin.shell: |
     cd /home/stack/devstack
     LOGFILE=/home/stack/devstack.log ./stack.sh 2>&1
+  changed_when: true
   become: true
   become_user: stack


### PR DESCRIPTION
Starting on Ansible 2.9 all tasks can use
the fully defined collection name the builtin
runtime is specified in:
https://github.com/ansible/ansible/blob/devel/lib/ansible/config/ansible_builtin_runtime.yml