### PR TITLE
Fix: Do not look up server image when boot_disk_copy: true

### DIFF
--- a/os_migrate/plugins/module_utils/server.py
+++ b/os_migrate/plugins/module_utils/server.py
@@ -153,8 +153,8 @@ class Server(resource.Resource):
                      "Block device mapping: {2}").format(
                          params['name'], info['id'], block_device_mapping)
                 )
-        else:
-            sdk_params.pop('image_id')
+        elif 'image_id' in sdk_params:
+            del sdk_params['image_id']
 
     def update_sdk_params_networks_simple(self, conn, sdk_params):
         sdk_params['networks'] = []
@@ -219,7 +219,10 @@ class Server(resource.Resource):
             conn, params['flavor_ref'])
 
         refs['image_ref'] = params['image_ref']
-        refs['image_id'] = reference.image_id(conn, params['image_ref'])
+        if self.migration_params()['boot_disk_copy']:
+            refs['image_id'] = None
+        else:
+            refs['image_id'] = reference.image_id(conn, params['image_ref'])
 
         refs['security_group_refs'] = params['security_group_refs']
         refs['security_group_ids'] = [


### PR DESCRIPTION
When migrating a server which is boot-from-image in source cloud, and
boot-from-volume in destination cloud (due to setting `boot_disk_copy:
true`), the server creation would still try to look up `image_ref` in
the destination cloud, and fail if the image doesn't exist.

This is now fixed. With `boot_disk_copy: true` we don't need any
images in destination, so we no longer perform an image lookup.

Resolves: https://github.com/os-migrate/os-migrate/issues/347