### PR TITLE
Fix: Fix image lookup for images owned by tenant

### DIFF
--- a/tests/e2e/tenant/seed_workload.yml
+++ b/tests/e2e/tenant/seed_workload.yml
@@ -14,7 +14,7 @@
     state: present
     flavor: "{{ os_migrate_src_osm_server_flavor|default(m1.small) }}"
     key_name: osm_key
-    image: "{{ os_migrate_src_osm_server_image|default(omit) }}"
+    image: "{{ workload_image }}"
     network: osm_net
     security_groups: osm_security_group
     volumes:

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -58,7 +58,7 @@
           tags: test_pre_workload
       tags: always
 
-    # server from image with attached volume
+    # server from tenant-owned image with attached volume,
     # migration w/o boot volume copy
     - include_tasks: tenant/seed_workload.yml
       args:
@@ -67,6 +67,8 @@
             - test_workload
             - test_image_workload_boot_nocopy
       tags: always
+      vars:
+        workload_image: osm_image
     - include_tasks: tenant/run_workload.yml
       args:
         apply:
@@ -83,7 +85,7 @@
             - test_image_workload_boot_nocopy_clean
       tags: always
 
-    # server from image with attached volume
+    # server from public image with attached volume,
     # migration with boot volume copy
     - include_tasks: tenant/seed_workload.yml
       args:
@@ -92,6 +94,8 @@
             - test_workload
             - test_image_workload_boot_copy
       tags: always
+      vars:
+        workload_image: "{{ os_migrate_src_osm_server_image }}"
     - include_tasks: tenant/run_workload.yml
       args:
         apply:


### PR DESCRIPTION
The `connection.image.find_image` method doesn't support filter
arguments (like project_id), unlike other find methods. This caused
failures when looking up images to be used for servers, when the image
was owned by tenant (non-public).

A custom image lookup method is now implemented in our reference.py
module, utilizing `images()` rather than `find_image()`.

End-to-end tests are also amended to test one workload spawned from
public image, and one from tenant-owned image.

Resolves: https://github.com/os-migrate/os-migrate/issues/346