### PR TITLE
Pin openstacksdk version due to os_security_group_rule module breakage

### DIFF
--- a/toolbox/build/venv-requirements.txt
+++ b/toolbox/build/venv-requirements.txt
@@ -1,6 +1,7 @@
 # runtime
 ansible>=2.9.1,<2.10
-openstacksdk>=0.39.0
+# openstacksdk pin for https://github.com/os-migrate/os-migrate/issues/350
+openstacksdk>=0.39.0,<0.53
 
 # test
 ansible-lint==4.1.0


### PR DESCRIPTION
The pin works around this breakage in Ansible:

'BadRequestException: 400: Client Error for url:
http://10.0.110.233:9696/v2.0/security-group-rules, Unrecognized
attribute(s) ''remote_address_group_id'''

Resolves: https://github.com/os-migrate/os-migrate/issues/350