### PR TITLE
fix: remove remote_group_id in favor of remote_address_group_id

### DIFF
--- a/os_migrate/plugins/module_utils/security_group_rule.py
+++ b/os_migrate/plugins/module_utils/security_group_rule.py
@@ -15,7 +15,7 @@ class SecurityGroupRule(resource.Resource):
     info_from_sdk = [
         'id',
         'security_group_id',
-        'remote_group_id',
+        'remote_address_group_id',
         'project_id',
         'created_at',
         'updated_at',
@@ -38,7 +38,7 @@ class SecurityGroupRule(resource.Resource):
 
     sdk_params_from_refs = [
         'security_group_id',
-        'remote_group_id',
+        'remote_address_group_id',
     ]
 
     @classmethod
@@ -65,8 +65,8 @@ class SecurityGroupRule(resource.Resource):
             conn, sdk_res['security_group_id'])
         refs['security_group_id'] = sdk_res['security_group_id']
         refs['remote_group_ref'] = reference.security_group_ref(
-            conn, sdk_res['remote_group_id'])
-        refs['remote_group_id'] = sdk_res['remote_group_id']
+            conn, sdk_res['remote_address_group_id'])
+        refs['remote_address_group_id'] = sdk_res['remote_address_group_id']
         return refs
 
     def _refs_from_ser(self, conn, filters=None):
@@ -75,7 +75,7 @@ class SecurityGroupRule(resource.Resource):
         refs['security_group_id'] = reference.security_group_id(
             conn, self.params()['security_group_ref'])
         refs['remote_group_ref'] = self.params()['remote_group_ref']
-        refs['remote_group_id'] = reference.security_group_id(
+        refs['remote_address_group_id'] = reference.security_group_id(
             conn, self.params()['remote_group_ref'])
 
         return refs

--- a/os_migrate/tests/unit/test_security_group_rule.py
+++ b/os_migrate/tests/unit/test_security_group_rule.py
@@ -16,7 +16,7 @@ def security_group_rule_refs():
             'project_name': 'test-project',
             'domain_name': 'Default',
         },
-        'remote_group_id': 'uuid-test-remote-secgroup',
+        'remote_address_group_id': 'uuid-test-remote-secgroup',
         'remote_group_ref': {
             'name': 'test-remote-secgroup',
             'project_name': 'test-project',
@@ -30,7 +30,7 @@ def sdk_security_group_rule():
         id='uuid',
         security_group_id='uuid-sec-group',
         security_group_name='default',
-        remote_group_id='uuid-group',
+        remote_address_group_id='uuid-group',
         remote_group_name='default',
         project_id='uuid-project',
         created_at='2020-01-30T14:49:06Z',
@@ -72,7 +72,7 @@ def serialized_security_group_rule():
             'project_id': 'uuid-project',
             'created_at': '2020-01-30T14:49:06Z',
             'updated_at': '2020-01-30T14:49:06Z',
-            'remote_group_id': 'uuid-test-remote-secgroup',
+            'remote_address_group_id': 'uuid-test-remote-secgroup',
             'revision_number': '0',
             'security_group_id': 'uuid-test-default-secgroup',
         },
@@ -113,7 +113,7 @@ class TestSecurityGroupRule(unittest.TestCase):
         self.assertEqual(info['created_at'], '2020-01-30T14:49:06Z')
         self.assertEqual(info['id'], 'uuid')
         self.assertEqual(info['project_id'], 'uuid-project')
-        self.assertEqual(info['remote_group_id'], 'uuid-group')
+        self.assertEqual(info['remote_address_group_id'], 'uuid-group')
         self.assertEqual(info['security_group_id'], 'uuid-sec-group')
         self.assertEqual(info['updated_at'], '2020-01-30T14:49:06Z')
         self.assertEqual(info['revision_number'], 0)


### PR DESCRIPTION
Those 2 params should be compatible, let's use
the latest and allow having 2.10