### PR TITLE
Fix: Loosen OpenStack operation timeouts in workload migration

### DIFF
--- a/os_migrate/plugins/module_utils/workload_common.py
+++ b/os_migrate/plugins/module_utils/workload_common.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 
 # Default timeout for OpenStack operations
-DEFAULT_TIMEOUT = 600
+DEFAULT_TIMEOUT = 1800
 
 # Lock to serialize volume attachments. This helps prevent device path
 # mismatches between the OpenStack SDK and /dev in the VM.


### PR DESCRIPTION
The current timeout for OpenStack operations during workload migration
is 10 minutes. This can be too short when working with large storage
volumes. We should make the timeout configurable, but as first
alleviation we increase the timeout to 30 minutes. This should still
be enough to fail in reasonable time when things get stuck, but it
shouldn't produce as many false alarms.