### PR TITLE
Fix: Explicitly install nmap-ncat on RHEL

### DIFF
--- a/os_migrate/roles/conversion_host_content/tasks/rhel.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/rhel.yml
@@ -40,6 +40,7 @@
     name:
       - nbdkit
       - nbdkit-basic-plugins
+      - nmap-ncat
       - qemu-img
       - libguestfs-tools
     state: present


### PR DESCRIPTION
It seems RPM dependency graphs have changed, and while we were getting
nmap-ncat installed via some dependency chain earlier, we need to
install it explicitly now.