### PR TITLE
Fix: Always stop on errors in conversion host deployment

### DIFF
--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -1,4 +1,5 @@
 - hosts: migrator
+  any_errors_fatal: true
   tasks:
     - include_role:
         name: os_migrate.os_migrate.conversion_host
@@ -46,6 +47,7 @@
       when: os_migrate_link_conversion_hosts|default(true)|bool
 
 - hosts: os_migrate_conv_src
+  any_errors_fatal: true
   tasks:
     - include_role:
         name: os_migrate.os_migrate.conversion_host
@@ -53,6 +55,7 @@
       when: os_migrate_link_conversion_hosts|default(true)|bool
 
 - hosts: os_migrate_conv_dst
+  any_errors_fatal: true
   tasks:
     - include_role:
         name: os_migrate.os_migrate.conversion_host
@@ -60,6 +63,7 @@
       when: os_migrate_link_conversion_hosts|default(true)|bool
 
 - hosts: conversion_hosts
+  any_errors_fatal: true
   tasks:
     - include_role:
         name: os_migrate.os_migrate.conversion_host_content


### PR DESCRIPTION
Previously when the source or destination conversion host encountered
some errror, Ansible would mark that host as failed and not run any
other tasks there, but it would continue to run tasks on other hosts,
most notably the migrator. This meant that e.g. subscription errors
wouldn't stop the playbook immediately, and if conversion host
deployment was included into a more complex migration playbook, the
migration itself would fail much later with a non-obvious error. This
is now fixed: whenever an error during conversion host deployment
happens, the playbook stops right away.