### PR TITLE
Chg: Preserve tags during migration of routers, networks, subnets

### DIFF
--- a/os_migrate/plugins/module_utils/common.py
+++ b/os_migrate/plugins/module_utils/common.py
@@ -1,0 +1,13 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def neutron_set_tags(conn, sdk_res, tags):
+    """Function to be used with Neutron service resources. Use `conn`
+    connection to set `tags` on `sdk_res`, only if the current set of
+    tags on `sdk_res` differs from `tags`.
+    """
+    sorted_actual = sorted(sdk_res['tags'])
+    sorted_expected = sorted(tags)
+    if sorted_actual != sorted_expected:
+        conn.network.set_tags(sdk_res, sorted_expected)

--- a/os_migrate/plugins/module_utils/network.py
+++ b/os_migrate/plugins/module_utils/network.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import openstack
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
-    import const, reference, resource
+    import common, const, reference, resource
 
 
 class Network(resource.Resource):
@@ -39,7 +39,9 @@ class Network(resource.Resource):
         'provider_physical_network',
         'provider_segmentation_id',
         'segments',
+        'tags',
     ]
+    sdk_params_from_params = [x for x in params_from_sdk if x not in ['tags']]
     params_from_refs = [
         'qos_policy_ref',
     ]
@@ -64,6 +66,9 @@ class Network(resource.Resource):
     @staticmethod
     def _find_sdk_res(conn, name_or_id, filters=None):
         return conn.network.find_network(name_or_id, **(filters or {}))
+
+    def _hook_after_update(self, conn, sdk_res, is_create):
+        common.neutron_set_tags(conn, sdk_res, self.params()['tags'])
 
     @staticmethod
     def _refs_from_sdk(conn, sdk_res):

--- a/os_migrate/plugins/module_utils/resource.py
+++ b/os_migrate/plugins/module_utils/resource.py
@@ -220,10 +220,12 @@ class Resource():
         if existing:
             if self._needs_update(self.from_sdk(conn, existing)):
                 self._remove_readonly_params(sdk_params)
-                self._update_sdk_res(conn, existing, sdk_params)
+                sdk_res = self._update_sdk_res(conn, existing, sdk_params)
+                self._hook_after_update(conn, sdk_res, False)
                 return True
         else:
-            self._create_sdk_res(conn, sdk_params)
+            sdk_res = self._create_sdk_res(conn, sdk_params)
+            self._hook_after_update(conn, sdk_res, True)
             return True
         return False  # no change done
 
@@ -314,6 +316,15 @@ class Resource():
         # the specific subclass
         return (self.data[const.RES_INFO].get('id', '__undefined1__') ==
                 target_data[const.RES_INFO].get('id', '__undefined2__'))
+
+    # Meant to be overriden in some subclasses.
+    def _hook_after_update(self, conn, sdk_res, is_create):
+        """Hook method which runs after the resource has been created or
+        updated in the destination cloud. `conn` is SDK connection,
+        `sdk_res` is the just created or updated SDK representation of
+        the resource, `is_create` tells whether the resource was newly created.
+        """
+        pass
 
     # Not meant to be overriden in majority of subclasses.
     def _needs_update(self, target):

--- a/os_migrate/plugins/module_utils/router.py
+++ b/os_migrate/plugins/module_utils/router.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import openstack
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
-    import const, reference, resource
+    import common, const, reference, resource
 
 
 class Router(resource.Resource):
@@ -31,7 +31,9 @@ class Router(resource.Resource):
         'is_distributed',
         'is_ha',
         'name',
+        'tags',
     ]
+    sdk_params_from_params = [x for x in params_from_sdk if x not in ['tags']]
     params_from_refs = [
         'external_gateway_refinfo',
         'flavor_ref',
@@ -58,6 +60,9 @@ class Router(resource.Resource):
     @staticmethod
     def _find_sdk_res(conn, name_or_id, filters=None):
         return conn.network.find_router(name_or_id, **(filters or {}))
+
+    def _hook_after_update(self, conn, sdk_res, is_create):
+        common.neutron_set_tags(conn, sdk_res, self.params()['tags'])
 
     @staticmethod
     def _refs_from_sdk(conn, sdk_res):

--- a/os_migrate/plugins/module_utils/subnet.py
+++ b/os_migrate/plugins/module_utils/subnet.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import openstack
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
-    import const, reference, resource
+    import common, const, reference, resource
 
 
 class Subnet(resource.Resource):
@@ -20,7 +20,6 @@ class Subnet(resource.Resource):
         'revision_number',
         'segment_id',
         'subnet_pool_id',
-        'tags',
         'updated_at',
     ]
 
@@ -37,8 +36,11 @@ class Subnet(resource.Resource):
         'is_dhcp_enabled',
         'name',
         'service_types',
+        'tags',
         'use_default_subnet_pool'
     ]
+
+    sdk_params_from_params = [x for x in params_from_sdk if x not in ['tags']]
 
     params_from_refs = [
         'network_ref',
@@ -69,6 +71,9 @@ class Subnet(resource.Resource):
     @staticmethod
     def _find_sdk_res(conn, name_or_id, filters=None):
         return conn.network.find_subnet(name_or_id, **(filters or {}))
+
+    def _hook_after_update(self, conn, sdk_res, is_create):
+        common.neutron_set_tags(conn, sdk_res, self.params()['tags'])
 
     @staticmethod
     def _update_sdk_res(conn, sdk_res, sdk_params):

--- a/os_migrate/tests/unit/test_network.py
+++ b/os_migrate/tests/unit/test_network.py
@@ -63,6 +63,7 @@ def serialized_network():
                 'domain_name': 'Default',
             },
             'segments': [],
+            'tags': [],
         },
         const.RES_INFO: {
             'availability_zones': ['nova', 'zone3'],
@@ -125,6 +126,7 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual(params['provider_segmentation_id'], '456')
         self.assertEqual(params['qos_policy_ref']['name'], 'test-qos-policy')
         self.assertEqual(params['segments'], [])
+        self.assertEqual(params['tags'], [])
 
         self.assertEqual(info['availability_zones'], ['nova', 'zone3'])
         self.assertEqual(info['created_at'], '2020-01-06T15:50:55Z')

--- a/os_migrate/tests/unit/test_resource.py
+++ b/os_migrate/tests/unit/test_resource.py
@@ -178,20 +178,24 @@ class TestResource(unittest.TestCase):
         # _find_sdk_res returns stale resource
         res._find_sdk_res = mock.Mock(return_value=stale)
         res._create_sdk_res = mock.Mock()
-        res._update_sdk_res = mock.Mock()
+        res._update_sdk_res = mock.Mock(return_value='mock resource')
+        res._hook_after_update = mock.Mock()
         self.assertTrue(res.create_or_update(None))
         res._create_sdk_res.assert_not_called()
         res._update_sdk_res.assert_called_once()
+        res._hook_after_update.assert_called_once_with(None, 'mock resource', False)
 
     def test_create_and_update_needs_create(self):
         res = FakeResource.from_data(valid_fakeresource_data())
         # _find_sdk_res returns None - not found
         res._find_sdk_res = mock.Mock(return_value=None)
-        res._create_sdk_res = mock.Mock()
+        res._create_sdk_res = mock.Mock(return_value='mock resource')
         res._update_sdk_res = mock.Mock()
+        res._hook_after_update = mock.Mock()
         self.assertTrue(res.create_or_update(None))
         res._create_sdk_res.assert_called_once()
         res._update_sdk_res.assert_not_called()
+        res._hook_after_update.assert_called_once_with(None, 'mock resource', True)
 
     def test_is_same_resource(self):
         r1 = FakeResource.from_data(valid_fakeresource_data())

--- a/os_migrate/tests/unit/test_router.py
+++ b/os_migrate/tests/unit/test_router.py
@@ -142,6 +142,7 @@ class TestRouter(unittest.TestCase):
             'enable_snat': True,
         })
         self.assertEqual(params['flavor_ref']['name'], 'test-network-flavor')
+        self.assertEqual(params['tags'], [])
 
         self.assertEqual(info['availability_zones'], ['nova', 'zone3'])
         self.assertEqual(info['created_at'], '2020-02-26T15:50:55Z')

--- a/os_migrate/tests/unit/test_subnet.py
+++ b/os_migrate/tests/unit/test_subnet.py
@@ -151,6 +151,7 @@ class TestSubnet(unittest.TestCase):
         self.assertEqual(params['subnet_pool_ref']['name'], 'test-subnet-pool')
         self.assertEqual(params['subnet_pool_ref']['project_name'], 'test-project')
         self.assertEqual(params['subnet_pool_ref']['domain_name'], 'Default')
+        self.assertEqual(params['tags'], [])
         self.assertEqual(params['use_default_subnet_pool'], None)
 
         self.assertEqual(info['created_at'], '2020-02-21T17:34:54Z')
@@ -161,7 +162,6 @@ class TestSubnet(unittest.TestCase):
         self.assertEqual(info['revision_number'], 0)
         self.assertEqual(info['segment_id'], 'uuid-test-segment')
         self.assertEqual(info['subnet_pool_id'], 'uuid-test-subnet-pool')
-        self.assertEqual(info['tags'], [])
         self.assertEqual(info['updated_at'], None)
 
     def test_deserialize_subnet(self):

--- a/tests/func/tenant/seed/network.yml
+++ b/tests/func/tenant/seed/network.yml
@@ -6,3 +6,20 @@
     # though OpenStack supports it.
     # description: osm_net test network
     state: present
+  register: _osm_net
+
+- name: get auth token
+  openstack.cloud.auth:
+    auth: "{{ os_migrate_src_auth }}"
+
+- name: set tags on network
+  ansible.builtin.command:
+    cmd: openstack network set --tag test_tag_1 --tag test_tag_2 {{ _osm_net.id }}
+  environment:
+    OS_AUTH_TYPE: token
+    OS_AUTH_URL: "{{ os_migrate_src_auth.auth_url }}"
+    OS_TOKEN: "{{ auth_token }}"
+    OS_PROJECT_ID: "{{ os_migrate_src_auth.project_id|default('') }}"
+    OS_PROJECT_NAME: "{{ os_migrate_src_auth.project_name|default('') }}"
+    OS_PROJECT_DOMAIN_ID: "{{ os_migrate_src_auth.project_domain_id|default('') }}"
+    OS_PROJECT_DOMAIN_NAME: "{{ os_migrate_src_auth.project_domain_name|default('') }}"

--- a/tests/func/tenant/seed/router.yml
+++ b/tests/func/tenant/seed/router.yml
@@ -11,3 +11,20 @@
       - net: osm_net
         subnet: osm_router_subnet
         portip: 192.168.10.10
+  register: _osm_router
+
+- name: get auth token
+  openstack.cloud.auth:
+    auth: "{{ os_migrate_src_auth }}"
+
+- name: set tags on router
+  ansible.builtin.command:
+    cmd: openstack router set --tag test_tag_1 --tag test_tag_2 {{ _osm_router.id }}
+  environment:
+    OS_AUTH_TYPE: token
+    OS_AUTH_URL: "{{ os_migrate_src_auth.auth_url }}"
+    OS_TOKEN: "{{ auth_token }}"
+    OS_PROJECT_ID: "{{ os_migrate_src_auth.project_id|default('') }}"
+    OS_PROJECT_NAME: "{{ os_migrate_src_auth.project_name|default('') }}"
+    OS_PROJECT_DOMAIN_ID: "{{ os_migrate_src_auth.project_domain_id|default('') }}"
+    OS_PROJECT_DOMAIN_NAME: "{{ os_migrate_src_auth.project_domain_name|default('') }}"

--- a/tests/func/tenant/seed/subnet.yml
+++ b/tests/func/tenant/seed/subnet.yml
@@ -13,6 +13,23 @@
         nexthop: 12.34.56.78
       - destination: 192.168.0.0/24
         nexthop: 192.168.0.1
+  register: _osm_subnet
+
+- name: Get auth token
+  openstack.cloud.auth:
+    auth: "{{ os_migrate_src_auth }}"
+
+- name: Set tags on subnet
+  ansible.builtin.command:
+    cmd: openstack subnet set --tag test_tag_1 --tag test_tag_2 {{ _osm_subnet.id }}
+  environment:
+    OS_AUTH_TYPE: token
+    OS_AUTH_URL: "{{ os_migrate_src_auth.auth_url }}"
+    OS_TOKEN: "{{ auth_token }}"
+    OS_PROJECT_ID: "{{ os_migrate_src_auth.project_id|default('') }}"
+    OS_PROJECT_NAME: "{{ os_migrate_src_auth.project_name|default('') }}"
+    OS_PROJECT_DOMAIN_ID: "{{ os_migrate_src_auth.project_domain_id|default('') }}"
+    OS_PROJECT_DOMAIN_NAME: "{{ os_migrate_src_auth.project_domain_name|default('') }}"
 
 - name: Create a 2nd subnet for router testing
   openstack.cloud.subnet:


### PR DESCRIPTION
 Dev: Add after-update (and after-create) hook mechanism to resources

Since it is reasonable to expect that similar or the same actions will
take place in after create and after update, we have a single
`_hook_after_update` method which gets called in both events. It has
an `is_create` parameter in case distinguishing between the two events
is necessary.

------

Chg: Preserve tags during migration of routers, networks, subnets

The tags on networking resources cannot be set during the initial
creation request. Previously we weren't setting tags at all during
migration of networking resources. We are now migrating tags correctly
on routers, networks and subnets using a post-create/update hook.

