### PR TITLE
New: Testing with lower bound requirements

### DIFF
--- a/os_migrate/plugins/module_utils/image.py
+++ b/os_migrate/plugins/module_utils/image.py
@@ -131,7 +131,7 @@ class Image(resource.Resource):
 
     @staticmethod
     def _find_sdk_res(conn, name_or_id, filters=None):
-        # Glance requires owner_id instead of project_id.
+        # Glance filter require owner instead of project_id.
         glance_filters = dict(filters or {})
         if 'project_id' in glance_filters:
             glance_filters['owner'] = glance_filters.pop('project_id')

--- a/os_migrate/plugins/module_utils/reference.py
+++ b/os_migrate/plugins/module_utils/reference.py
@@ -300,7 +300,7 @@ def _fetch_ref(conn, get_method, id_, required=True, get_project_info=True):
     if get_project_info:
         if isinstance(resource, openstack.image.v2.image.Image):
             project_name, domain_name = _fetch_project_name_and_domain_name(
-                conn, resource.owner)
+                conn, resource.owner_id)
         else:
             project_name, domain_name = _fetch_project_name_and_domain_name(
                 conn, resource.project_id)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@ set -euxo pipefail
 
 # Apply virtualenv version overrides if defined
 if [ -n "${OS_MIGRATE_REQUIREMENTS_OVERRIDE:-}" ]; then
-    pip install -r "$OS_MIGRATE_REQUIREMENTS_OVERRIDE"
+    pip install --upgrade -r "$OS_MIGRATE_REQUIREMENTS_OVERRIDE"
 fi
 
 # update version in const.py based on galaxy.yml

--- a/toolbox/build/venv-requirements-lower-bound.txt
+++ b/toolbox/build/venv-requirements-lower-bound.txt
@@ -1,3 +1,3 @@
 # runtime
 ansible>=2.9.1,<2.10
-openstacksdk>=0.39.0,<0.53
+openstacksdk>=0.36.0,<0.37


### PR DESCRIPTION
We started testing with two OpenStack SDK versions:

* 0.52.x which is close to latest but not yet affected by a security
  group rules bug [1].

* 0.36.x which is in Train release (OSP 16).

[1] https://storyboard.openstack.org/#!/story/2008577