### PR TITLE
Fix: Sparsification of volumes

### DIFF
--- a/os_migrate/plugins/modules/import_workload_transfer_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_transfer_volumes.py
@@ -489,7 +489,7 @@ class OpenStackDestinationHost(OpenStackHostBase):
                 environment['LIBGUESTFS_BACKEND'] = 'direct'
 
                 cmd = ['sudo', 'qemu-img', 'create', '-f', 'qcow2', '-b',
-                       mapping['url'], overlay]
+                       mapping['url'], '-F', 'raw', overlay]
                 out = self.shell.cmd_out(cmd)
                 self.log.info('Overlay output: %s', out)
 

--- a/os_migrate/roles/conversion_host_content/tasks/centos.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/centos.yml
@@ -15,4 +15,11 @@
       - nbdkit-basic-plugins
       - qemu-img
       - libguestfs-tools
+      - libvirt
     state: present
+
+- name: start libvirtd
+  ansible.builtin.service:
+    name: libvirtd
+    state: started
+    enabled: yes

--- a/os_migrate/roles/conversion_host_content/tasks/rhel.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/rhel.yml
@@ -42,4 +42,11 @@
       - nbdkit-basic-plugins
       - qemu-img
       - libguestfs-tools
+      - libvirt
     state: present
+
+- name: start libvirtd
+  ansible.builtin.service:
+    name: libvirtd
+    state: started
+    enabled: yes


### PR DESCRIPTION
To have the volume sparsification work, two things have changed:

* We install and start libvirt in the conversion hosts.

* We specify that the NBD backends of volume qcow2 images are of raw
  format.

Resolves: https://github.com/os-migrate/os-migrate/issues/364