### PR TITLE
Dev: Remove podman install from CI jobs

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -15,10 +15,7 @@ jobs:
           sudo dpkg-reconfigure locales
           sudo python -m pip install --upgrade pip
           sudo pip install tox
-          sudo apt install software-properties-common -y
-          sudo add-apt-repository -y ppa:projectatomic/ppa
-          sudo apt update -y
-          sudo apt install build-essential findutils -y
+          sudo apt install software-properties-common build-essential findutils -y
           sudo apt install podman -y
       - name: Build os-migrate image
         run: |

--- a/.github/workflows/docs-build-pr.yml
+++ b/.github/workflows/docs-build-pr.yml
@@ -18,9 +18,6 @@ jobs:
         run: |
           sudo locale-gen en_US.UTF-8
           sudo dpkg-reconfigure locales
-          sudo add-apt-repository -y ppa:projectatomic/ppa
-          sudo apt update -y
-          sudo apt install podman -y
       - name: Fetch toolbox image
         run: |
           REUSE_TOOLBOX=1 NO_VAGRANT=1 make toolbox-build

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -16,9 +16,6 @@ jobs:
         run: |
           sudo locale-gen en_US.UTF-8
           sudo dpkg-reconfigure locales
-          sudo add-apt-repository -y ppa:projectatomic/ppa
-          sudo apt update -y
-          sudo apt install podman -y
       - name: Fetch toolbox image
         run: |
           REUSE_TOOLBOX=1 NO_VAGRANT=1 make toolbox-build


### PR DESCRIPTION
This PR removes the podman install in the pending
CI jobs as it is now shipped directly in the Ubuntu
guest image.