### PR TITLE
Dev: Enable devstack master

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -221,7 +221,7 @@ jobs:
           sudo chown root:root /bin
       - name: Clone devstack
         run: |
-          git clone --single-branch --branch stable/victoria https://opendev.org/openstack/devstack
+          git clone --single-branch --branch master https://opendev.org/openstack/devstack
       - name: Configure devstack
         run: |
           DIR=$(pwd)


### PR DESCRIPTION
This commit enables to deploy
devstack master when testing os-migrate