### PR TITLE
Dev: Run shell when venv-run is passed no arguments

### DIFF
--- a/toolbox/build/venv-wrapper
+++ b/toolbox/build/venv-wrapper
@@ -4,4 +4,8 @@ set -euo pipefail
 
 source /root/venv/bin/activate
 
-"$@"
+if [ "$#" = "0" ]; then
+    bash
+else
+    "$@"
+fi


### PR DESCRIPTION
In toolbox dir, we have the run/shell script pairs, one for running a
command in a container, another for launching a shell in a
container. However, it can be done so that if no arguments are passed
to the 'run' script, it acts the same way as the 'shell' script. This
is already true for the plain 'run' and the 'vagrant-run', only
'venv-run' is edited to achieve the behavior described above.