### PR TITLE
New: Filters in import playbooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 OS_MIGRATE := $(HOME)/.ansible/collections/ansible_collections/os_migrate/os_migrate
 export OS_MIGRATE
 
-FUNC_TEST_ARGS ?=
-
 
 # ANSIBLE COLLECTION
 

--- a/docs/src/user/variables-guide.rst
+++ b/docs/src/user/variables-guide.rst
@@ -13,8 +13,13 @@ Resource filters
 ~~~~~~~~~~~~~~~~
 
 Resource filters allow the user to control which resources will be
-exported (and thus which resources will be migrated). The filters
-match against resource **names**.
+migrated. The filters match against resource **names**.
+
+The filters work **both during export and during import**, and it is
+not required that the same value is used during export and
+import. This feature can be used e.g. to export a subset of the
+existing resources, and then during import further limit the subset of
+resources being imported into batches.
 
 The value of a filter variable is a list, where each item can be a
 string (exact match) or a dictionary with ``regex`` key (regular

--- a/docs/src/user/walkthrough.rst
+++ b/docs/src/user/walkthrough.rst
@@ -460,6 +460,15 @@ control how a workload should be migrated. Refer to
 `Migration Parameters Guide <migration-params-guide.rst>`_
 for more information.
 
+Ansible Variables
+~~~~~~~~~~~~~~~~~
+
+In addition to the migration parameters in the resource YAML files,
+you can alter the behavior of OS Migrate via Ansible variables,
+e.g. to specify a subset of resources/workloads that will be exported
+or imported. Refer to the `Variables Guide <variables-guide.rst>`_ for
+details.
+
 Migration
 ~~~~~~~~~
 

--- a/os_migrate/roles/export_images/defaults/main.yml
+++ b/os_migrate/roles/export_images/defaults/main.yml
@@ -1,4 +1,4 @@
 os_migrate_export_images_blobs: true
+os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"
 os_migrate_images_filter:
   - regex: .*
-os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"

--- a/os_migrate/roles/import_flavors/defaults/main.yml
+++ b/os_migrate/roles/import_flavors/defaults/main.yml
@@ -1,1 +1,3 @@
 import_flavors_validate_file: true
+os_migrate_flavors_filter:
+  - regex: .*

--- a/os_migrate/roles/import_flavors/tasks/main.yml
+++ b/os_migrate/roles/import_flavors/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/flavors.yml"
   register: read_flavors
 
+- name: filter flavors to import
+  ansible.builtin.set_fact:
+    filtered_flavors: "{{ (
+      read_flavors.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_flavors_filter,
+                                             attribute='params.name') ) }}"
+
 - name: import flavors
   os_migrate.os_migrate.import_flavor:
     auth: "{{ os_migrate_dst_auth }}"
@@ -25,4 +32,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_flavors.resources }}"
+  loop: "{{ filtered_flavors }}"

--- a/os_migrate/roles/import_images/defaults/main.yml
+++ b/os_migrate/roles/import_images/defaults/main.yml
@@ -1,2 +1,4 @@
 import_images_validate_file: true
 os_migrate_image_blobs_dir: "{{ os_migrate_data_dir }}/image_blobs"
+os_migrate_images_filter:
+  - regex: .*

--- a/os_migrate/roles/import_images/tasks/main.yml
+++ b/os_migrate/roles/import_images/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/images.yml"
   register: read_images
 
+- name: filter images to import
+  ansible.builtin.set_fact:
+    filtered_images: "{{ (
+      read_images.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_images_filter,
+                                             attribute='params.name') ) }}"
+
 - name: import images
   os_migrate.os_migrate.import_image:
     auth: "{{ os_migrate_dst_auth }}"
@@ -28,4 +35,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_images.resources }}"
+  loop: "{{ filtered_images }}"

--- a/os_migrate/roles/import_keypairs/defaults/main.yml
+++ b/os_migrate/roles/import_keypairs/defaults/main.yml
@@ -1,1 +1,3 @@
 import_keypairs_validate_file: true
+os_migrate_keypairs_filter:
+  - regex: .*

--- a/os_migrate/roles/import_keypairs/tasks/main.yml
+++ b/os_migrate/roles/import_keypairs/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/keypairs.yml"
   register: read_keypairs
 
+- name: filter keypairs to import
+  ansible.builtin.set_fact:
+    filtered_keypairs: "{{ (
+      read_keypairs.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_keypairs_filter,
+                                             attribute='params.name') ) }}"
+
 - name: import keypairs
   os_migrate.os_migrate.import_keypair:
     auth: "{{ os_migrate_dst_auth }}"
@@ -25,4 +32,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_keypairs.resources }}"
+  loop: "{{ filtered_keypairs }}"

--- a/os_migrate/roles/import_networks/defaults/main.yml
+++ b/os_migrate/roles/import_networks/defaults/main.yml
@@ -1,1 +1,3 @@
 import_networks_validate_file: true
+os_migrate_networks_filter:
+  - regex: .*

--- a/os_migrate/roles/import_networks/tasks/main.yml
+++ b/os_migrate/roles/import_networks/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/networks.yml"
   register: read_networks
 
+- name: filter networks to import
+  ansible.builtin.set_fact:
+    filtered_networks: "{{ (
+      read_networks.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_networks_filter,
+                                             attribute='params.name') ) }}"
+
 - name: import networks
   os_migrate.os_migrate.import_network:
     auth: "{{ os_migrate_dst_auth }}"
@@ -26,4 +33,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_networks.resources }}"
+  loop: "{{ filtered_networks }}"

--- a/os_migrate/roles/import_projects/defaults/main.yml
+++ b/os_migrate/roles/import_projects/defaults/main.yml
@@ -1,1 +1,3 @@
 import_projects_validate_file: true
+os_migrate_projects_filter:
+  - regex: .*

--- a/os_migrate/roles/import_projects/tasks/main.yml
+++ b/os_migrate/roles/import_projects/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/projects.yml"
   register: read_projects
 
+- name: filter projects to import
+  ansible.builtin.set_fact:
+    filtered_projects: "{{ (
+      read_projects.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_projects_filter,
+                                             attribute='params.name') ) }}"
+
 - name: import projects
   os_migrate.os_migrate.import_project:
     auth: "{{ os_migrate_dst_auth }}"
@@ -25,4 +32,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_projects.resources }}"
+  loop: "{{ filtered_projects }}"

--- a/os_migrate/roles/import_router_interfaces/defaults/main.yml
+++ b/os_migrate/roles/import_router_interfaces/defaults/main.yml
@@ -1,1 +1,3 @@
 import_router_interfaces_validate_file: true
+os_migrate_routers_filter:
+  - regex: .*

--- a/os_migrate/roles/import_router_interfaces/tasks/main.yml
+++ b/os_migrate/roles/import_router_interfaces/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/router_interfaces.yml"
   register: read_router_interfaces
 
+- name: filter router_interfaces to import
+  ansible.builtin.set_fact:
+    filtered_router_interfaces: "{{ (
+      read_router_interfaces.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,
+                                             attribute='params.device_ref.name') ) }}"
+
 - name: import router interfaces
   os_migrate.os_migrate.import_router_interface:
     auth: "{{ os_migrate_dst_auth }}"
@@ -26,4 +33,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_router_interfaces.resources }}"
+  loop: "{{ filtered_router_interfaces }}"

--- a/os_migrate/roles/import_routers/defaults/main.yml
+++ b/os_migrate/roles/import_routers/defaults/main.yml
@@ -1,1 +1,3 @@
 import_routers_validate_file: true
+os_migrate_routers_filter:
+  - regex: .*

--- a/os_migrate/roles/import_routers/tasks/main.yml
+++ b/os_migrate/roles/import_routers/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/routers.yml"
   register: read_routers
 
+- name: filter routers to import
+  ansible.builtin.set_fact:
+    filtered_routers: "{{ (
+      read_routers.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_routers_filter,
+                                             attribute='params.name') ) }}"
+
 - name: import routers
   os_migrate.os_migrate.import_router:
     auth: "{{ os_migrate_dst_auth }}"
@@ -26,4 +33,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_routers.resources }}"
+  loop: "{{ filtered_routers }}"

--- a/os_migrate/roles/import_security_group_rules/defaults/main.yml
+++ b/os_migrate/roles/import_security_group_rules/defaults/main.yml
@@ -1,1 +1,3 @@
 import_security_group_rules_validate_file: true
+os_migrate_security_groups_filter:
+  - regex: .*

--- a/os_migrate/roles/import_security_group_rules/tasks/main.yml
+++ b/os_migrate/roles/import_security_group_rules/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/security_group_rules.yml"
   register: read_security_group_rules
 
+- name: filter security_group_rules to import
+  ansible.builtin.set_fact:
+    filtered_security_group_rules: "{{ (
+      read_security_group_rules.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,
+                                             attribute='params.security_group_ref.name') ) }}"
+
 - name: import security_group_rules
   os_migrate.os_migrate.import_security_group_rule:
     auth: "{{ os_migrate_dst_auth }}"
@@ -26,4 +33,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_security_group_rules.resources }}"
+  loop: "{{ filtered_security_group_rules }}"

--- a/os_migrate/roles/import_security_groups/defaults/main.yml
+++ b/os_migrate/roles/import_security_groups/defaults/main.yml
@@ -1,1 +1,3 @@
 import_security_groups_validate_file: true
+os_migrate_security_groups_filter:
+  - regex: .*

--- a/os_migrate/roles/import_security_groups/tasks/main.yml
+++ b/os_migrate/roles/import_security_groups/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/security_groups.yml"
   register: read_security_groups
 
+- name: filter security_groups to import
+  ansible.builtin.set_fact:
+    filtered_security_groups: "{{ (
+      read_security_groups.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_security_groups_filter,
+                                             attribute='params.name') ) }}"
+
 - name: import security groups
   os_migrate.os_migrate.import_security_group:
     auth: "{{ os_migrate_dst_auth }}"
@@ -26,4 +33,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_security_groups.resources }}"
+  loop: "{{ filtered_security_groups }}"

--- a/os_migrate/roles/import_subnets/defaults/main.yml
+++ b/os_migrate/roles/import_subnets/defaults/main.yml
@@ -1,1 +1,3 @@
 import_subnets_validate_file: true
+os_migrate_subnets_filter:
+  - regex: .*

--- a/os_migrate/roles/import_subnets/tasks/main.yml
+++ b/os_migrate/roles/import_subnets/tasks/main.yml
@@ -13,7 +13,14 @@
 - name: read subnets resource file
   os_migrate.os_migrate.read_resources:
     path: "{{ os_migrate_data_dir }}/subnets.yml"
-  register: read_networks
+  register: read_subnets
+
+- name: filter subnets to import
+  ansible.builtin.set_fact:
+    filtered_subnets: "{{ (
+      read_subnets.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_subnets_filter,
+                                             attribute='params.name') ) }}"
 
 - name: import subnets
   os_migrate.os_migrate.import_subnet:
@@ -26,4 +33,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_networks.resources }}"
+  loop: "{{ filtered_subnets }}"

--- a/os_migrate/roles/import_users/defaults/main.yml
+++ b/os_migrate/roles/import_users/defaults/main.yml
@@ -1,1 +1,3 @@
 import_users_validate_file: true
+os_migrate_users_filter:
+  - regex: .*

--- a/os_migrate/roles/import_users/tasks/main.yml
+++ b/os_migrate/roles/import_users/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/users.yml"
   register: read_users
 
+- name: filter users to import
+  ansible.builtin.set_fact:
+    filtered_users: "{{ (
+      read_users.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_users_filter,
+                                             attribute='params.name') ) }}"
+
 - name: import users
   os_migrate.os_migrate.import_user:
     auth: "{{ os_migrate_dst_auth }}"
@@ -25,4 +32,4 @@
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
-  loop: "{{ read_users.resources }}"
+  loop: "{{ filtered_users }}"

--- a/os_migrate/roles/import_workloads/defaults/main.yml
+++ b/os_migrate/roles/import_workloads/defaults/main.yml
@@ -3,3 +3,5 @@ os_migrate_conversion_host_name: os_migrate_conv
 os_migrate_conversion_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/ssh.key"
 os_migrate_workload_cleanup_on_failure: true
 os_migrate_workload_boot_volume_prefix: os-migrate-
+os_migrate_workloads_filter:
+  - regex: .*

--- a/os_migrate/roles/import_workloads/tasks/main.yml
+++ b/os_migrate/roles/import_workloads/tasks/main.yml
@@ -15,6 +15,13 @@
     path: "{{ os_migrate_data_dir }}/workloads.yml"
   register: read_workloads
 
+- name: filter workloads to import
+  ansible.builtin.set_fact:
+    filtered_workloads: "{{ (
+      read_workloads.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_workloads_filter,
+                                             attribute='params.name') ) }}"
+
 - name: create directory for workload migration logs
   ansible.builtin.file:
     path: "{{ os_migrate_data_dir }}/workload_logs"
@@ -78,4 +85,4 @@
 
 - name: import workloads
   ansible.builtin.include_tasks: workload.yml
-  loop: "{{ read_workloads.resources }}"
+  loop: "{{ filtered_workloads }}"


### PR DESCRIPTION
The `os_migrate_<resources>_filter` variables that are already used to
filter resources during export, are now respected during import
too. That means user can choose whether they want to filter during
export or during import, or even combine the approaches to export a
subset of the existing resources, and further limit them into smaller
chunks during import.

Resolves: #367 