### PR TITLE
Dev: Do not install podman

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -16,7 +16,6 @@ jobs:
           sudo python -m pip install --upgrade pip
           sudo pip install tox
           sudo apt install software-properties-common build-essential findutils -y
-          sudo apt install podman -y
       - name: Build os-migrate image
         run: |
           # The default tag is localhost/os_migrate_toolbox:latest


### PR DESCRIPTION
Podman is already installed in the
Ubuntu latest image used in the CI.

If we trigger a package update the
CI breaks because the newer version
can not be found in kubic.