### PR TITLE
Fix: Ensure new security groups don't have auto-created rules

### DIFF
--- a/tests/func/tenant/run/security_group.yml
+++ b/tests/func/tenant/run/security_group.yml
@@ -27,3 +27,25 @@
 
 - ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_security_groups
+
+- name: scan security group rules from osm_security_group
+  os_migrate.os_migrate.os_security_groups_info:
+    filters: "{{ os_migrate_dst_filters }}"
+    auth: "{{ os_migrate_dst_auth }}"
+    auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+  register: dst_sg_after_create
+
+- name: ensure imported osm_security_group has no rules
+  ansible.builtin.assert:
+    that:
+      - dst_sg_after_create['openstack_security_groups'] | json_query(
+        "[?name=='osm_security_group'].security_group_rules[0]") | length == 0
+    fail_msg: >-
+      Expected osm_security_group to have no rules, but found:
+        {{ dst_sg_after_create['openstack_security_groups'] |
+           json_query("[?name=='osm_security_group'].security_group_rules[0]") }}


### PR DESCRIPTION
When creating a security group, OpenStack automatically inserts 2
basic rules to allow all egress traffic (one for IPv4, one for
IPv6). Creating these blanket-allow rules automatically in destination
is undesirable, as the user may have replaced the default rules with
some more restrictive ones in the source security group.

When creating a new destination security group, we now immediately
delete the auto-created rules. If the source security group kept the
default rules, they got exported like any other rules, and will be
imported into destination during rule import.