### PR TITLE
Dev: Fix toolbox build by installing Rust

### DIFF
--- a/toolbox/build/build.sh
+++ b/toolbox/build/build.sh
@@ -9,7 +9,18 @@ OS_MIGRATE_DIR=$(realpath "$DIR/../..")
 
 dnf clean all
 dnf -y update
-dnf -y install findutils ansible gcc make python3-devel python3-openstackclient jq shyaml iputils
+dnf -y install \
+    ansible \
+    cargo \
+    findutils \
+    gcc \
+    iputils \
+    jq \
+    make \
+    python3-devel \
+    python3-openstackclient \
+    shyaml \
+
 # The below packages are for vagrant-libvirt and take a lot of deps,
 # build with `NO_VAGRANT=1 make toolbox-build` if Vagrant isn't required.
 if [ "${NO_VAGRANT:-}" != "1" ]; then


### PR DESCRIPTION
The new version of Python's cryptography package has a native
extension written in Rust, so we need Rust toolchain to be able to
install Ansible from pip.

Also splitting the dependencies to one per line, going forward this
will make it easier to track why some dependency was added.