### PR TITLE
New: Ensure Nova server creation is successful and emit detailed info

### DIFF
--- a/os_migrate/plugins/module_utils/server.py
+++ b/os_migrate/plugins/module_utils/server.py
@@ -179,7 +179,7 @@ class Server(resource.Resource):
 
         # There are multiple representations of server in SDK, some of
         # them don't have flavor ID info.
-        flavor_id = sdk_res['flavor'].get('id')
+        flavor_id = (sdk_res.get('flavor') or {}).get('id')
         if flavor_id is None:
             flavor_id = conn.get_server_by_id(sdk_res['id'])['flavor']['id']
 

--- a/os_migrate/plugins/modules/import_workload_create_instance.py
+++ b/os_migrate/plugins/modules/import_workload_create_instance.py
@@ -239,10 +239,15 @@ def run_module():
 
     ser_server = server.Server.from_data(module.params['data'])
     sdk_server = ser_server.create(conn, block_device_mapping)
+    # Some info (e.g. flavor ID) will only become available after the
+    # server is in ACTIVE state, we need to wait for it.
+    sdk_server = conn.compute.wait_for_server(sdk_server, failures=['ERROR'], wait=600)
+    dst_ser_server = server.Server.from_sdk(conn, sdk_server)
 
     if sdk_server:
-        result['server_id'] = sdk_server.id
         result['changed'] = True
+        result['server'] = dst_ser_server.data
+        result['server_id'] = sdk_server.id
 
     module.exit_json(**result)
 


### PR DESCRIPTION
The import_workload_create_instance module now outputs a full workload
serialization of the server created in the destination cloud. When
running Ansible in verbose mode, it can be used as debugging
information, and allows for direct comparison of the destination
workload to the contents of workloads.yml file.

This requires that the import_workload_create_instance module waits
for the Nova server to enter ACTIVE state, to have full information
available. Typically this only adds several seconds to the workload
migration time, which is negligible in the full picture. By waiting,
we can also make sure the server indeed does go ACTIVE and not into
ERROR state, which may have previously gone unnoticed with the "fire
and forget" server creation approach.