### PR TITLE
New: Configurable timeout for non-immediate actions

### DIFF
--- a/os_migrate/plugins/module_utils/workload_common.py
+++ b/os_migrate/plugins/module_utils/workload_common.py
@@ -67,7 +67,7 @@ def use_lock(lock_file):
 class OpenStackHostBase():
     def __init__(self, openstack_connection, conversion_host_id, ssh_key_path,
                  ssh_user, transfer_uuid, conversion_host_address=None,
-                 state_file=None, log_file=None):
+                 state_file=None, log_file=None, timeout=DEFAULT_TIMEOUT):
         # Required common parameters:
         # openstack_connection: OpenStack connection object
         # conversion_host_id: ID of conversion host instance
@@ -87,6 +87,7 @@ class OpenStackHostBase():
         self.conversion_host_address = conversion_host_address
         self.state_file = state_file
         self.log_file = log_file
+        self.timeout = timeout
 
         # Configure logging
         self.log = logging.getLogger('osp-osp')
@@ -153,10 +154,10 @@ class OpenStackHostBase():
             self.log.debug('Initial disk list: %s', disks_before)
 
             conn.attach_volume(volume=volume, wait=True, server=host_func(),
-                               timeout=DEFAULT_TIMEOUT)
+                               timeout=self.timeout)
             self.log.info('Waiting for volume to appear in %s wrapper', name)
             self._wait_for_volume_dev_path(conn, volume, host_func(),
-                                           DEFAULT_TIMEOUT)
+                                           self.timeout)
 
             disks_after = ssh_func(['lsblk', '--noheadings', '--list',
                                     '--paths', '--nodeps', '--output NAME'])

--- a/os_migrate/roles/import_workloads/defaults/main.yml
+++ b/os_migrate/roles/import_workloads/defaults/main.yml
@@ -1,6 +1,7 @@
 import_workloads_validate_file: true
 os_migrate_conversion_host_name: os_migrate_conv
 os_migrate_conversion_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/ssh.key"
+os_migrate_timeout: 1800
 os_migrate_workload_cleanup_on_failure: true
 os_migrate_workload_boot_volume_prefix: os-migrate-
 os_migrate_workloads_filter:

--- a/os_migrate/roles/import_workloads/tasks/workload.yml
+++ b/os_migrate/roles/import_workloads/tasks/workload.yml
@@ -63,6 +63,7 @@
       state_file: "{{ prelim.state_file }}"
       ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
       ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+      timeout: "{{ os_migrate_timeout }}"
     register: exports
     when: prelim.changed
 
@@ -86,6 +87,7 @@
       volume_map: "{{ exports.volume_map }}"
       log_file: "{{ prelim.log_file }}"
       state_file: "{{ prelim.state_file }}"
+      timeout: "{{ os_migrate_timeout }}"
     register: transfer
     when: prelim.changed
 
@@ -120,6 +122,7 @@
       volume_map: "{{ exports.volume_map }}"
       log_file: "{{ prelim.log_file }}"
       state_file: "{{ prelim.state_file }}"
+      timeout: "{{ os_migrate_timeout }}"
     when: prelim.changed
 
   rescue:
@@ -140,6 +143,7 @@
         volume_map: "{{ exports.volume_map }}"
         log_file: "{{ prelim.log_file }}"
         state_file: "{{ prelim.state_file }}"
+        timeout: "{{ os_migrate_timeout }}"
       when:
         - prelim.changed
         - os_migrate_workload_cleanup_on_failure
@@ -162,6 +166,7 @@
         volume_map: "{{ transfer.volume_map }}"
         log_file: "{{ prelim.log_file }}"
         state_file: "{{ prelim.state_file }}"
+        timeout: "{{ os_migrate_timeout }}"
       when:
         - prelim.changed
         - os_migrate_workload_cleanup_on_failure


### PR DESCRIPTION
Until now, non-immediate actions and blocking calls to OpenStack SDK
within workload migration have used a hard-coded timeout of 30
minutes. New variable `os_migrate_timeout` has been introduced for
setting the timeout (in seconds), the value is 1800 (= 30 minutes).