### PR TITLE
Dev: Update Vagrant dev env setup

### DIFF
--- a/toolbox/vagrant-run
+++ b/toolbox/vagrant-run
@@ -29,7 +29,7 @@ ROOTLESS_IMAGE_ID=$(podman inspect -f '{{.Id}}' $CONTAINER_IMAGE || true)
 ROOTFUL_IMAGE_ID=$(sudo podman inspect -f '{{.Id}}' $CONTAINER_IMAGE || true)
 if [ "$ROOTLESS_IMAGE_ID" != "$ROOTFUL_IMAGE_ID" ]; then
     echo "Refreshing rootful image $CONTAINER_IMAGE..."
-    podman save $CONTAINER_IMAGE | sudo podman load $CONTAINER_IMAGE
+    podman save $CONTAINER_IMAGE | sudo podman load
 fi
 
 [ -e /usr/lib/passwd ] && USR_LIB_PASSWD="-v /usr/lib/passwd:/usr/lib/passwd:ro" || USR_LIB_PASSWD=""

--- a/toolbox/vagrant/vagrant-config.yml
+++ b/toolbox/vagrant/vagrant-config.yml
@@ -1,13 +1,6 @@
 libvirt:
-  # vagrant box add \
-  #   --name fedora30 \
-  #   https://download.fedoraproject.org/ \
-  #           pub/fedora/linux/releases/30/ \
-  #           Cloud/x86_64/images/ \
-  #           Fedora-Cloud-Base-Vagrant-30-1.2.x86_64.vagrant-libvirt.box
-  box: fedora30
-  default_prefix: os_migrate
-  private_net_name: os_migrate
+  box: fedora32
+  default_prefix: os_migrate_
   storage_pool_name: vagrant
   suspend_mode: managedsave
   qemu_use_session: true
@@ -15,6 +8,3 @@ libvirt:
   system_uri: qemu:///system
   storage_pool_path: ~/.local/share/libvirt/images
   management_network_device: virbr0
-
-devstack:
-  ip: 192.168.10.10

--- a/toolbox/vagrant/vagrant-up
+++ b/toolbox/vagrant/vagrant-up
@@ -5,8 +5,8 @@ set -euxo pipefail
 if ! virsh pool-list | grep vagrant &> /dev/null; then
     virsh pool-create-as vagrant dir --target $HOME/.local/share/libvirt/vagrant
 fi
-if ! vagrant box list | grep fedora30 &> /dev/null; then
-    vagrant box add --name fedora30 https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-30-1.2.x86_64.vagrant-libvirt.box
+if ! vagrant box list | grep fedora32 &> /dev/null; then
+    vagrant box add --name fedora32 https://mirror.karneval.cz/pub/linux/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-32-1.6.x86_64.vagrant-libvirt.box
 fi
 
 vagrant up


### PR DESCRIPTION
Update the vagrant box to a still supported Fedora 32, and solve
issues that popped up after updating to newer Vagrant and Podman.