### PR TITLE
Fix: Flavor export/import

### DIFF
--- a/tests/func/admin/clean/flavor.yml
+++ b/tests/func/admin/clean/flavor.yml
@@ -1,8 +1,10 @@
-- name: remove osm_flavor
+- name: remove src/dst flavors
   openstack.cloud.compute_flavor:
-    auth: "{{ item }}"
-    name: osm_flavor
+    auth: "{{ item['auth'] }}"
+    name: "{{ item['flavor'] }}"
     state: absent
   loop:
-    - "{{ os_migrate_src_auth }}"
-    - "{{ os_migrate_dst_auth }}"
+    - auth: "{{ os_migrate_src_auth }}"
+      flavor: osm_flavor
+    - auth: "{{ os_migrate_dst_auth }}"
+      flavor: osmdst_flavor

--- a/tests/func/admin/idempotence/flavor.yml
+++ b/tests/func/admin/idempotence/flavor.yml
@@ -6,6 +6,12 @@
     os_migrate_flavors_filter:
       - regex: '^osm_'
 
+- name: set destination flavor name
+  ansible.builtin.replace:
+    path: "{{ os_migrate_data_dir }}/flavors.yml"
+    regexp: "name: osm_flavor"
+    replace: "name: osmdst_flavor"
+
 - name: re-load resources for idempotency test
   ansible.builtin.set_fact:
     flavor_resources_idem: "{{ (lookup('file',
@@ -25,29 +31,29 @@
 
 ### IMPORT IDEMPOTENCE ###
 
-- name: look up osm_flavor dst cloud
+- name: look up osmdst_flavor dst cloud
   openstack.cloud.compute_flavor_info:
     auth: "{{ os_migrate_dst_auth }}"
-    name: "osm_flavor"
+    name: "osmdst_flavor"
   register: flavor_import_idem_before
 
 - ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_flavors
 
-- name: look up osm_flavor in dst cloud again
+- name: look up osmdst_flavor in dst cloud again
   openstack.cloud.compute_flavor_info:
     auth: "{{ os_migrate_dst_auth }}"
-    name: "osm_flavor"
+    name: "osmdst_flavor"
   register: flavor_import_idem_after
 
-- name: ensure ram for osm_flavor did not change
+- name: ensure extra_specs for osmdst_flavor did not change
   ansible.builtin.assert:
     that:
       - flavor_import_idem_before['openstack_flavors'][0].ram != None
-      - "flavor_import_idem_before['openstack_flavors'][0]['ram'] \
-         == flavor_import_idem_after['openstack_flavors'][0]['ram']"
+      - "flavor_import_idem_before['openstack_flavors'][0]['extra_specs'] \
+         == flavor_import_idem_after['openstack_flavors'][0]['extra_specs']"
     fail_msg: |
-      flavor_import_idem_before ram:
-      {{ flavor_import_idem_before['openstack_flavors'][0].ram }}
-      flavor_import_idem_after ram:
-      {{ flavor_import_idem_after['openstack_flavors'][0].ram }}
+      flavor_import_idem_before extra_specs:
+      {{ flavor_import_idem_before['openstack_flavors'][0].extra_specs }}
+      flavor_import_idem_after extra_specs:
+      {{ flavor_import_idem_after['openstack_flavors'][0].extra_specs }}

--- a/tests/func/admin/run/flavor.yml
+++ b/tests/func/admin/run/flavor.yml
@@ -4,6 +4,12 @@
     os_migrate_flavors_filter:
       - regex: '^osm_'
 
+- name: set destination flavor name
+  ansible.builtin.replace:
+    path: "{{ os_migrate_data_dir }}/flavors.yml"
+    regexp: "name: osm_flavor"
+    replace: "name: osmdst_flavor"
+
 - name: load exported data
   ansible.builtin.set_fact:
     flavor_resources: "{{ (lookup('file',
@@ -16,8 +22,8 @@
     that:
       - (flavor_resources |
         json_query("[?params.name ==
-        'osm_flavor'].params.name")
-        == ['osm_flavor'])
+        'osmdst_flavor'].params.ram")
+        == [1024])
 
 - ansible.builtin.include_role:
     name: os_migrate.os_migrate.import_flavors

--- a/tests/func/admin/seed/flavor.yml
+++ b/tests/func/admin/seed/flavor.yml
@@ -7,3 +7,6 @@
     vcpus: 1
     disk: 10
     ephemeral: 10
+    extra_specs:
+      os_migrate:some_property: asdf
+      os_migrate:other_property: ghij


### PR DESCRIPTION
Flavors were prevented from importing due to several issues around
parameters passed into the flavor creation API request, this is now
fixed. Extra specs are now being set after the flavor is created.