### PR TITLE
Fix: Project parent references allow domains too

### DIFF
--- a/os_migrate/plugins/module_utils/project.py
+++ b/os_migrate/plugins/module_utils/project.py
@@ -48,8 +48,14 @@ class Project(resource.Resource):
             conn, sdk_res['domain_id'])
 
         refs['parent_id'] = sdk_res['parent_id']
-        refs['parent_ref'] = reference.project_ref(
-            conn, sdk_res['parent_id'])
+        # Parent can be either a project, or a domain.
+        refs['parent_ref'] = (
+            reference.project_ref(
+                conn, sdk_res['parent_id'], False)
+            or
+            reference.domain_ref(
+                conn, sdk_res['parent_id'])
+        )
 
         return refs
 
@@ -61,8 +67,14 @@ class Project(resource.Resource):
             conn, self.params()['domain_ref'])
 
         refs['parent_ref'] = self.params()['parent_ref']
-        refs['parent_id'] = reference.project_id(
-            conn, self.params()['parent_ref'])
+        # Parent can be either a project, or a domain.
+        refs['parent_id'] = (
+            reference.project_id(
+                conn, self.params()['parent_ref'], False)
+            or
+            reference.domain_id(
+                conn, self.params()['parent_ref'])
+        )
 
         return refs
 

--- a/tests/func/admin/clean/all.yml
+++ b/tests/func/admin/clean/all.yml
@@ -1,3 +1,12 @@
+- name: Include domain tasks
+  ansible.builtin.include_tasks: domain.yml
+  args:
+    apply:
+      tags:
+        - test_domain
+        - test_project
+  tags: always
+
 - name: Include flavor tasks
   ansible.builtin.include_tasks: flavor.yml
   args:

--- a/tests/func/admin/clean/all.yml
+++ b/tests/func/admin/clean/all.yml
@@ -1,29 +1,9 @@
-- name: Include domain tasks
-  ansible.builtin.include_tasks: domain.yml
-  args:
-    apply:
-      tags:
-        - test_domain
-        - test_project
-  tags: always
-
-- name: Include flavor tasks
-  ansible.builtin.include_tasks: flavor.yml
-  args:
-    apply:
-      tags:
-        - test_flavor
-        - test_clean
-  tags:
-    - always
-
 - name: Include user tasks
   ansible.builtin.include_tasks: user.yml
   args:
     apply:
       tags:
         - test_user
-        - test_clean
   tags:
     - always
 
@@ -33,6 +13,26 @@
     apply:
       tags:
         - test_project
+        - test_clean
+  tags:
+    - always
+
+- name: Include domain tasks
+  ansible.builtin.include_tasks: domain.yml
+  args:
+    apply:
+      tags:
+        - test_domain
+        - test_project
+        - test_user
+  tags: always
+
+- name: Include flavor tasks
+  ansible.builtin.include_tasks: flavor.yml
+  args:
+    apply:
+      tags:
+        - test_flavor
         - test_clean
   tags:
     - always

--- a/tests/func/admin/clean/domain.yml
+++ b/tests/func/admin/clean/domain.yml
@@ -1,0 +1,10 @@
+- name: remove src/dst domains
+  openstack.cloud.identity_domain:
+    auth: "{{ item['auth'] }}"
+    name: "{{ item['domain'] }}"
+    state: absent
+  loop:
+    - auth: "{{ os_migrate_src_auth }}"
+      domain: osm_domain
+    - auth: "{{ os_migrate_dst_auth }}"
+      domain: osmdst_domain

--- a/tests/func/admin/idempotence/project.yml
+++ b/tests/func/admin/idempotence/project.yml
@@ -6,6 +6,8 @@
     os_migrate_projects_filter:
       - regex: '^osm_'
 
+# TODO: Set domain to osmdst_domain when we support migrating domains.
+
 - name: set destination project name
   ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/projects.yml"

--- a/tests/func/admin/idempotence/user.yml
+++ b/tests/func/admin/idempotence/user.yml
@@ -6,11 +6,19 @@
     os_migrate_users_filter:
       - regex: '^osm_'
 
+# TODO: Set domain to osmdst_domain when we support migrating domains.
+
 - name: set destination user name
   ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/users.yml"
     regexp: "name: osm_user"
     replace: "name: osmdst_user"
+
+- name: set destination project name
+  ansible.builtin.replace:
+    path: "{{ os_migrate_data_dir }}/users.yml"
+    regexp: "name: osm_project"
+    replace: "name: osmdst_project"
 
 - name: re-load user_resources for idempotency test
   ansible.builtin.set_fact:

--- a/tests/func/admin/run/all.yml
+++ b/tests/func/admin/run/all.yml
@@ -1,10 +1,11 @@
-- name: Include flavor tasks
-  ansible.builtin.include_tasks: flavor.yml
+- name: Include project tasks
+  ansible.builtin.include_tasks: project.yml
   args:
     apply:
       tags:
-        - test_flavor
-  tags: always
+        - test_project
+  tags:
+    - always
 
 - name: Include user tasks
   ansible.builtin.include_tasks: user.yml
@@ -14,11 +15,10 @@
         - test_user
   tags: always
 
-- name: Include project tasks
-  ansible.builtin.include_tasks: project.yml
+- name: Include flavor tasks
+  ansible.builtin.include_tasks: flavor.yml
   args:
     apply:
       tags:
-        - test_project
-  tags:
-    - always
+        - test_flavor
+  tags: always

--- a/tests/func/admin/run/project.yml
+++ b/tests/func/admin/run/project.yml
@@ -9,6 +9,8 @@
     os_migrate_projects_filter:
       - regex: '^osm_'
 
+# TODO: Set domain to osmdst_domain when we support migrating domains.
+
 - name: set destination project name
   ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/projects.yml"

--- a/tests/func/admin/run/user.yml
+++ b/tests/func/admin/run/user.yml
@@ -4,11 +4,19 @@
     os_migrate_users_filter:
       - regex: '^osm_'
 
+# TODO: Set domain to osmdst_domain when we support migrating domains.
+
 - name: set destination user name
   ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/users.yml"
     regexp: "name: osm_user"
     replace: "name: osmdst_user"
+
+- name: set destination project name
+  ansible.builtin.replace:
+    path: "{{ os_migrate_data_dir }}/users.yml"
+    regexp: "name: osm_project"
+    replace: "name: osmdst_project"
 
 - name: load exported data
   ansible.builtin.set_fact:

--- a/tests/func/admin/seed/all.yml
+++ b/tests/func/admin/seed/all.yml
@@ -1,3 +1,12 @@
+- name: Include domain tasks
+  ansible.builtin.include_tasks: domain.yml
+  args:
+    apply:
+      tags:
+        - test_domain
+        - test_project
+  tags: always
+
 - name: Include flavor tasks
   ansible.builtin.include_tasks: flavor.yml
   args:

--- a/tests/func/admin/seed/all.yml
+++ b/tests/func/admin/seed/all.yml
@@ -5,14 +5,16 @@
       tags:
         - test_domain
         - test_project
+        - test_user
   tags: always
 
-- name: Include flavor tasks
-  ansible.builtin.include_tasks: flavor.yml
+- name: Include project tasks
+  ansible.builtin.include_tasks: project.yml
   args:
     apply:
       tags:
-        - test_flavor
+        - test_project
+        - test_user
   tags: always
 
 - name: Include user tasks
@@ -23,10 +25,10 @@
         - test_user
   tags: always
 
-- name: Include project tasks
-  ansible.builtin.include_tasks: project.yml
+- name: Include flavor tasks
+  ansible.builtin.include_tasks: flavor.yml
   args:
     apply:
       tags:
-        - test_project
+        - test_flavor
   tags: always

--- a/tests/func/admin/seed/domain.yml
+++ b/tests/func/admin/seed/domain.yml
@@ -1,0 +1,5 @@
+- name: create osm_domain
+  openstack.cloud.identity_domain:
+    auth: "{{ os_migrate_src_auth }}"
+    state: present
+    name: osm_domain

--- a/tests/func/admin/seed/project.yml
+++ b/tests/func/admin/seed/project.yml
@@ -2,6 +2,6 @@
   openstack.cloud.project:
     auth: "{{ os_migrate_src_auth }}"
     name: osm_project
-    domain: default
+    domain: osm_domain
     description: seeded
     state: present

--- a/tests/func/admin/seed/user.yml
+++ b/tests/func/admin/seed/user.yml
@@ -5,5 +5,5 @@
     email: testuser@example.org
     description: test user
     state: present
-    default_project: admin
-    domain: default
+    default_project: osm_project
+    domain: osm_domain


### PR DESCRIPTION
Keystone has 2 types of domains - domain objects, and project objects
with is_domain=True. OS Migrate correctly worked only with the latter
until now. Domain objects are now working too, and it is tested in
functional tests.

Resolves #403 