### PR TITLE
fix: make sure the src/dst release is an integer

### DIFF
--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -5,10 +5,10 @@
 os_migrate_conversion_net_name: os_migrate_conv
 
 os_migrate_src_conversion_net_mtu: "{{
-  1400 if os_migrate_src_release > 10
+  1400 if os_migrate_src_release | int > 10
   else omit }}"
 os_migrate_dst_conversion_net_mtu: "{{
-  1400 if os_migrate_dst_release > 10
+  1400 if os_migrate_dst_release | int > 10
   else omit }}"
 
 # If we install packages we need a DNS server working

--- a/tests/e2e/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tenant/seed_pre_workload.yml
@@ -7,7 +7,7 @@
     # description: osm_net test network
     state: present
     mtu: "{{
-      omit if os_migrate_src_release == 10
+      omit if os_migrate_src_release | int == 10
       else 1400 }}"
     validate_certs: "{{ item.validate_certs }}"
     ca_cert: "{{ item.ca_cert }}"


### PR DESCRIPTION
This commit cast the os_migrate_src_release and
os_migrate_dst_release variables to integers.

Fixes: #408