### PR TITLE
fix: increase timeouts when deployment takes more than default

### DIFF
--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -30,6 +30,7 @@ os_migrate_conversion_keypair_name: os_migrate_conv
 os_migrate_conversion_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/ssh.key"
 os_migrate_conversion_link_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/link-ssh.key"
 
+os_migrate_conversion_host_deploy_timeout: 600
 os_migrate_conversion_host_name: os_migrate_conv
 os_migrate_conversion_image_name: os_migrate_conv
 

--- a/os_migrate/roles/conversion_host/tasks/main.yml
+++ b/os_migrate/roles/conversion_host/tasks/main.yml
@@ -108,7 +108,7 @@
       - "{{ os_migrate_conversion_secgroup_name }}"
     auto_ip: yes
     wait: yes
-    timeout: 600
+    timeout: "{{ os_migrate_conversion_host_deploy_timeout }}"
     auth: "{{ os_migrate_conversion_auth }}"
     auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
     region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"


### PR DESCRIPTION
This commit allows to increase the hardwired default timeout of
600 seconds when deploying the conversion hosts.

In this case, when the overlay network provider takes longer to
assign a floating IP, there might be needed to increase this
default.