### PR TITLE
Dev: Fix running tests via Ansible test tools

### DIFF
--- a/os_migrate/plugins/module_utils/workload_common.py
+++ b/os_migrate/plugins/module_utils/workload_common.py
@@ -1,3 +1,4 @@
+# pylint: disable=consider-using-with
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/os_migrate/plugins/modules/import_workload_dst_failure_cleanup.py
+++ b/os_migrate/plugins/modules/import_workload_dst_failure_cleanup.py
@@ -102,6 +102,7 @@ options:
     description:
       - Timeout for long running operations, in seconds.
     required: false
+    default: 1800
     type: int
 '''
 

--- a/os_migrate/plugins/modules/import_workload_export_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_export_volumes.py
@@ -101,6 +101,7 @@ options:
     description:
       - Timeout for long running operations, in seconds.
     required: false
+    default: 1800
     type: int
 '''
 

--- a/os_migrate/plugins/modules/import_workload_src_cleanup.py
+++ b/os_migrate/plugins/modules/import_workload_src_cleanup.py
@@ -108,6 +108,7 @@ options:
     description:
       - Timeout for long running operations, in seconds.
     required: false
+    default: 1800
     type: int
 '''
 

--- a/os_migrate/plugins/modules/import_workload_transfer_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_transfer_volumes.py
@@ -115,6 +115,7 @@ options:
     description:
       - Timeout for long running operations, in seconds.
     required: false
+    default: 1800
     type: int
 '''
 

--- a/os_migrate/tests/unit/test_flavor.py
+++ b/os_migrate/tests/unit/test_flavor.py
@@ -37,7 +37,6 @@ def serialized_flavor():
             'disk': 256,
             'ephemeral': 1,
             'extra_specs': {},
-            'is_disabled': False,
             'is_public': True,
             'links': [
                 {'rel': 'self',
@@ -53,6 +52,7 @@ def serialized_flavor():
         },
         const.RES_INFO: {
             'id': 'uuid-test-flavor',
+            'is_disabled': False,
         },
         const.RES_TYPE: 'openstack.compute.Flavor',
     }
@@ -70,14 +70,7 @@ class TestFlavor(unittest.TestCase):
         self.assertEqual(params['disk'], 256)
         self.assertEqual(params['ephemeral'], 1)
         self.assertEqual(params['extra_specs'], {})
-        self.assertEqual(params['is_disabled'], False)
         self.assertEqual(params['is_public'], True)
-        self.assertEqual(params['links'], [
-            {'rel': 'self',
-             'href': 'http://192.168.122.85/compute/v2.1/flavors/d1'},
-            {'rel': 'bookmark',
-             'href': 'http://192.168.122.85/compute/flavors/d1'}
-        ],)
         self.assertEqual(params['name'], 'test-flavor')
         self.assertEqual(params['ram'], 128)
         self.assertEqual(params['rxtx_factor'], 1.5)
@@ -85,6 +78,7 @@ class TestFlavor(unittest.TestCase):
         self.assertEqual(params['vcpus'], 2)
 
         self.assertEqual(info['id'], 'uuid-test-flavor')
+        self.assertEqual(info['is_disabled'], False)
 
     def test_flavor_sdk_params(self):
         flv = flavor.Flavor.from_data(serialized_flavor())
@@ -93,15 +87,7 @@ class TestFlavor(unittest.TestCase):
         self.assertEqual(sdk_params['description'], '')
         self.assertEqual(sdk_params['disk'], 256)
         self.assertEqual(sdk_params['ephemeral'], 1)
-        self.assertEqual(sdk_params['extra_specs'], {})
-        self.assertEqual(sdk_params['is_disabled'], False)
         self.assertEqual(sdk_params['is_public'], True)
-        self.assertEqual(sdk_params['links'], [
-            {'rel': 'self',
-             'href': 'http://192.168.122.85/compute/v2.1/flavors/d1'},
-            {'rel': 'bookmark',
-             'href': 'http://192.168.122.85/compute/flavors/d1'}
-        ],)
         self.assertEqual(sdk_params['name'], 'test-flavor')
         self.assertEqual(sdk_params['ram'], 128)
         self.assertEqual(sdk_params['rxtx_factor'], 1.5)
@@ -110,3 +96,4 @@ class TestFlavor(unittest.TestCase):
 
         # disallowed params when creating a flavor
         self.assertNotIn('id', sdk_params)
+        self.assertNotIn('is_disabled', sdk_params)

--- a/os_migrate/tests/unit/test_keypair.py
+++ b/os_migrate/tests/unit/test_keypair.py
@@ -16,7 +16,6 @@ def sdk_keypair():
         name='test-keypair',
         is_deleted=False,
         fingerprint='TqiTXPRs4cBksWa5pnMTmbEXjgd7bfvuSX7y4sHeMo4',
-        private_key='MIIJKAIBAAKCAgEAw51HtWh2MiRSvL0sPak4G2Qh2kKlfY6hfp0mQN9e=',
         public_key='AAAAB3NzaC1yc2EAAAADAQABAAACAQDDnUe1aHYyJFK8vSw9qTgbZCHa==',
         type='ssh'
     )
@@ -28,7 +27,6 @@ def serialized_keypair():
             'name': 'test-keypair',
             'is_deleted': False,
             'fingerprint': 'TqiTXPRs4cBksWa5pnMTmbEXjgd7bfvuSX7y4sHeMo4',
-            'private_key': 'MIIJKAIBAAKCAgEAw51HtWh2MiRSvL0sPak4G2Qh2kKlfY6hfp0mQN9e=',
             'public_key': 'AAAAB3NzaC1yc2EAAAADAQABAAACAQDDnUe1aHYyJFK8vSw9qTgbZCHa==',
             'type': 'ssh'
         },
@@ -51,11 +49,9 @@ class TestKeypair(unittest.TestCase):
         self.assertEqual(kp.type(), 'openstack.compute.Keypair')
         self.assertEqual(params['name'], 'test-keypair')
         self.assertEqual(
-            params['private_key'],
-            'MIIJKAIBAAKCAgEAw51HtWh2MiRSvL0sPak4G2Qh2kKlfY6hfp0mQN9e=')
-        self.assertEqual(
             params['public_key'],
             'AAAAB3NzaC1yc2EAAAADAQABAAACAQDDnUe1aHYyJFK8vSw9qTgbZCHa==')
+        self.assertEqual(params['type'], 'ssh')
 
         self.assertEqual(info['created_at'], '2020-01-06T15:50:55Z')
         # creating a new Keypair object sets the id to the name in openstacksdk
@@ -64,16 +60,13 @@ class TestKeypair(unittest.TestCase):
         self.assertEqual(info['is_deleted'], False)
         self.assertEqual(info['fingerprint'],
                          'TqiTXPRs4cBksWa5pnMTmbEXjgd7bfvuSX7y4sHeMo4')
-        self.assertEqual(info['type'], 'ssh')
 
     def test_keypair_sdk_params(self):
         kp = keypair.Keypair.from_data(serialized_keypair())
         sdk_params = kp._to_sdk_params(None)
 
         self.assertEqual(sdk_params['name'], 'test-keypair')
-        self.assertEqual(
-            sdk_params['private_key'],
-            'MIIJKAIBAAKCAgEAw51HtWh2MiRSvL0sPak4G2Qh2kKlfY6hfp0mQN9e=')
+        self.assertEqual(sdk_params['type'], 'ssh')
         self.assertEqual(
             sdk_params['public_key'],
             'AAAAB3NzaC1yc2EAAAADAQABAAACAQDDnUe1aHYyJFK8vSw9qTgbZCHa==')
@@ -81,4 +74,3 @@ class TestKeypair(unittest.TestCase):
         # disallowed params when creating a keypair
         self.assertNotIn('is_deleted', sdk_params)
         self.assertNotIn('fingerprint', sdk_params)
-        self.assertNotIn('type', sdk_params)

--- a/os_migrate/tests/unit/test_project.py
+++ b/os_migrate/tests/unit/test_project.py
@@ -10,9 +10,9 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils \
 
 def sdk_project():
     return openstack.identity.v3.project.Project(
-        domain_id=None,
+        domain_id='uuid-test-domain',
         is_enabled=True,
-        parent_id=None,
+        parent_id='uuid-test-parent-project',
         description='',
         is_domain=False,
         name='test-project',
@@ -23,23 +23,62 @@ def serialized_project():
     return {
         const.RES_PARAMS: {
             'description': '',
+            'domain_ref': {
+                'domain_name': None,
+                'name': 'test-domain',
+                'project_name': None,
+            },
             'is_domain': False,
             'is_enabled': True,
             'name': 'test-project',
+            'parent_ref': {
+                'domain_name': 'test-domain',
+                'name': 'test-parent-project',
+                'project_name': None,
+            },
         },
         const.RES_INFO: {
-            'domain_id': None,
-            'parent_id': None,
+            'domain_id': 'uuid-test-domain',
+            'parent_id': 'uuid-test-parent-project',
         },
         const.RES_TYPE: 'openstack.identity.Project',
     }
+
+
+def project_refs():
+    return {
+        'domain_id': 'uuid-test-domain',
+        'domain_ref': {
+            'domain_name': None,
+            'name': 'test-domain',
+            'project_name': None,
+        },
+        'project_id': 'uuid-test-parent-project',
+        'parent_ref': {
+            'domain_name': 'test-domain',
+            'name': 'test-parent-project',
+            'project_name': None,
+        },
+    }
+
+
+# "Disconnected" variant of Project resource where we make sure not to
+# make requests using `conn`.
+class Project(project.Project):
+
+    def _refs_from_ser(self, conn):
+        return project_refs()
+
+    @staticmethod
+    def _refs_from_sdk(conn, sdk_res):
+        return project_refs()
 
 
 class TestProject(unittest.TestCase):
 
     def test_serialize_project(self):
         sdk_proj = sdk_project()
-        proj = project.Project.from_sdk(None, sdk_proj)  # conn=None
+        proj = Project.from_sdk(None, sdk_proj)  # conn=None
         params, info = proj.params_and_info()
 
         self.assertEqual(proj.type(), 'openstack.identity.Project')
@@ -47,13 +86,23 @@ class TestProject(unittest.TestCase):
         self.assertEqual(params['is_domain'], False)
         self.assertEqual(params['is_enabled'], True)
         self.assertEqual(params['name'], 'test-project')
+        self.assertEqual(params['domain_ref'], {
+            'domain_name': None,
+            'name': 'test-domain',
+            'project_name': None,
+        })
+        self.assertEqual(params['parent_ref'], {
+            'domain_name': 'test-domain',
+            'name': 'test-parent-project',
+            'project_name': None,
+        })
 
-        self.assertEqual(info['domain_id'], None)
-        self.assertEqual(info['parent_id'], None)
+        self.assertEqual(info['domain_id'], 'uuid-test-domain')
+        self.assertEqual(info['parent_id'], 'uuid-test-parent-project')
 
     def test_project_sdk_params(self):
-        proj = project.Project.from_data(serialized_project())
-        sdk_params = proj._to_sdk_params(None)
+        proj = Project.from_data(serialized_project())
+        sdk_params = proj._to_sdk_params(proj._refs_from_ser(None))
 
         self.assertEqual(sdk_params['description'], '')
         self.assertEqual(sdk_params['is_domain'], False)

--- a/os_migrate/tests/unit/test_server.py
+++ b/os_migrate/tests/unit/test_server.py
@@ -111,6 +111,15 @@ def server_refs():
                 'domain_name': 'Default',
             },
         ],
+        'volume_attachments_info': [
+            {
+                'device': '/dev/vdb',
+                'id': 'uuid-test-volume-attachment',
+                'volume_id': 'uuid-test-volume',
+                'volume_name': 'test-volume',
+                'volume_project_id': 'uuid-test-project',
+            }
+        ],
     }
 
 

--- a/toolbox/build/build.sh
+++ b/toolbox/build/build.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 
 DIR=$(dirname $(realpath $0))
 OS_MIGRATE_DIR=$(realpath "$DIR/../..")
+ANSIBLE_PYTHON=python3.8
 
 ### PACKAGES ###
 
@@ -19,6 +20,7 @@ dnf -y install \
     make \
     python3-devel \
     python3-openstackclient \
+    "$ANSIBLE_PYTHON" \
     shyaml \
 
 # The below packages are for vagrant-libvirt and take a lot of deps,
@@ -31,7 +33,7 @@ dnf clean all
 
 ### VIRTUALENV ###
 
-python3 -m venv /root/venv
+"$ANSIBLE_PYTHON" -m venv /root/venv
 set +x
 source /root/venv/bin/activate
 set -x


### PR DESCRIPTION
All tests running via the `ansible-test` tool were not run for some
time. This was due to Ansible looking for specific Python versions to
run the tests with. The latest version it was looking for was Python
3.8, but in the toolbox container we had Python 3.9. This caused
ansible-test to silently skip running all tests and still return 0, so
this went completely unnoticed in CI.

The toolbox container now explicitly install Python 3.8 and uses it to
create the virtualenv. This caused all the tests to start running
again, and they failed, so minimal fixes to make them pass again are
included in the commit too.