### PR TITLE
Dev: add the conversion hosts to specific groups

### DIFF
--- a/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
@@ -24,6 +24,7 @@
     name: "{{ inventory_name }}"
     groups:
       - conversion_hosts
+      - "{{ inventory_group }}"
     ansible_ssh_host: "{{ _server_info.openstack_servers[0].accessIPv4 }}"
     ansible_ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
     ansible_ssh_private_key_file: "{{ os_migrate_conversion_keypair_private_path }}"

--- a/os_migrate/roles/conversion_host/tasks/conv_hosts_inventory.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_hosts_inventory.yml
@@ -2,6 +2,7 @@
   ansible.builtin.include_tasks: conv_host_inventory.yml
   vars:
     inventory_name: "{{ item.inventory_name }}"
+    inventory_group: "{{ item.inventory_group }}"
     os_migrate_conversion_auth: "{{ item.os_migrate_conversion_auth }}"
     os_migrate_conversion_auth_type: "{{ item.os_migrate_conversion_auth_type }}"
     os_migrate_conversion_region_name: "{{ item.os_migrate_conversion_region_name }}"
@@ -11,6 +12,7 @@
     os_migrate_conversion_client_key: "{{ item.os_migrate_conversion_client_key }}"
   loop:
     - inventory_name: os_migrate_conv_src
+      inventory_group: conversion_hosts_src
       os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
       os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
       os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -19,6 +21,7 @@
       os_migrate_conversion_client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
       os_migrate_conversion_client_key: "{{ os_migrate_src_client_key|default(omit) }}"
     - inventory_name: os_migrate_conv_dst
+      inventory_group: conversion_hosts_dst
       os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
       os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
       os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
@@ -26,3 +29,22 @@
       os_migrate_conversion_ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       os_migrate_conversion_client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       os_migrate_conversion_client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+# If conversion hosts are added succesfully to each group, show them all.
+- name: list src conversion hosts
+  ansible.builtin.debug:
+    msg: "Source conversion host: {{ item }}"
+  with_items: "{{ groups['conversion_hosts_src'] }}"
+  when: "'conversion_hosts_src' in groups"
+
+- name: list dst conversion hosts
+  ansible.builtin.debug:
+    msg: "Destination conversion host: {{ item }}"
+  with_items: "{{ groups['conversion_hosts_dst'] }}"
+  when: "'conversion_hosts_dst' in groups"
+
+- name: list all conversion hosts
+  ansible.builtin.debug:
+    msg: "All conversion host: {{ item }}"
+  with_items: "{{ groups['conversion_hosts'] }}"
+  when: "'conversion_hosts' in groups"


### PR DESCRIPTION
This commit allows having two additional
groups for the conversion hosts.
conversion_hosts_src and conversion_hosts_dst