### PR TITLE
dev: fix CI, disable neutron agents not used with OVN

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -253,14 +253,20 @@ jobs:
           NUMBER_FAKE_NOVA_COMPUTE=2
           CELLSV2_SETUP="singleconductor"
           OS_PLACEMENT_CONFIG_DIR=/etc/nova
+          # Horizon is enabled by default, but
+          # its not required
+          disable_service horizon
           # Pre-requisite
           ENABLED_SERVICES=mysql,key
           # Neutron
-          ENABLED_SERVICES+=,q-svc,q-dhcp,q-meta,q-l3,q-agt
+          # Disable Neutron agents not used with OVN (q-agt,q-l3,q-dhcp,q-meta)
+          ENABLED_SERVICES+=,q-svc,q-ovn-metadata-agent
           # Nova
           ENABLED_SERVICES+=,n-sproxy,n-api,n-cond
           # Placement
           ENABLED_SERVICES+=,placement,placement-api,placement-client
+          # OVN
+          ENABLED_SERVICES+=,ovn-controller,ovn-northd,ovs-vswitchd,ovsdb-server
           # Glance
           ENABLED_SERVICES+=,g-api
           [[post-config|/etc/nova/nova.conf]]


### PR DESCRIPTION
DEvstack now uses OVN, this commit disables those
agents not needed.