### PR TITLE
Dev: Fix OVN options

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -269,6 +269,8 @@ jobs:
           ENABLED_SERVICES+=,ovn-controller,ovn-northd,ovs-vswitchd,ovsdb-server
           # Glance
           ENABLED_SERVICES+=,g-api
+          # OVN options
+          OVN_L3_CREATE_PUBLIC_NETWORK=false
           [[post-config|/etc/nova/nova.conf]]
           [placement]
           auth_type = password


### PR DESCRIPTION
OVN_L3_CREATE_PUBLIC_NETWORK is set to true now
by default. This commit disables the L3 public
network.