### PR TITLE
Fix: Handle when flavor extra_specs are reported as None from API

### DIFF
--- a/os_migrate/plugins/module_utils/flavor.py
+++ b/os_migrate/plugins/module_utils/flavor.py
@@ -40,15 +40,16 @@ class Flavor(resource.Resource):
             params['swap'] = 0
 
     def _hook_after_update(self, conn, sdk_res, is_create):
-        params = self.params()
-        delete_extra_specs = list(set(sdk_res['extra_specs'].keys()) -
-                                  set(params['extra_specs'].keys()))
+        sdk_extra_specs = sdk_res.get('extra_specs') or {}
+        params_extra_specs = self.params().get('extra_specs') or {}
+        delete_extra_specs = list(set(sdk_extra_specs.keys()) -
+                                  set(params_extra_specs.keys()))
         for prop_name in delete_extra_specs:
             conn.compute.delete_flavor_extra_specs_property(sdk_res, prop_name)
-        for prop_name in params['extra_specs'].keys():
-            if sdk_res['extra_specs'].get(prop_name) != params['extra_specs'][prop_name]:
+        for prop_name in params_extra_specs.keys():
+            if sdk_extra_specs.get(prop_name) != params_extra_specs[prop_name]:
                 conn.compute.update_flavor_extra_specs_property(
-                    sdk_res, prop_name, params['extra_specs'][prop_name])
+                    sdk_res, prop_name, params_extra_specs[prop_name])
 
     @staticmethod
     def _create_sdk_res(conn, sdk_params):

--- a/tests/func/admin/clean/flavor.yml
+++ b/tests/func/admin/clean/flavor.yml
@@ -8,3 +8,7 @@
       flavor: osm_flavor
     - auth: "{{ os_migrate_dst_auth }}"
       flavor: osmdst_flavor
+    - auth: "{{ os_migrate_src_auth }}"
+      flavor: osm_flavor_specless
+    - auth: "{{ os_migrate_dst_auth }}"
+      flavor: osmdst_flavor_specless

--- a/tests/func/admin/seed/flavor.yml
+++ b/tests/func/admin/seed/flavor.yml
@@ -10,3 +10,13 @@
     extra_specs:
       os_migrate:some_property: asdf
       os_migrate:other_property: ghij
+
+- name: create osm_flavor_specless
+  openstack.cloud.compute_flavor:
+    auth: "{{ os_migrate_src_auth }}"
+    state: present
+    name: osm_flavor_specless
+    ram: 2048
+    vcpus: 2
+    disk: 20
+    ephemeral: 0


### PR DESCRIPTION
Most recent APIs+SDKs always give empty hash for extra_specs. However,
some older versions may also return extra_specs as None. This could
break OS Migrate. The issue is now fixed by making sure we set
internal variables to {} whenever some extra_specs parameter (either
loaded from YAML or queried from SDK) is None.