### PR TITLE
Dev: skip file-changes-action on the scheduled job

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -51,9 +51,12 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
             podman login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-      - id: file_changes
+      - name: Get the changed files list
+        id: file_changes
+        if: github.event_name != 'schedule'
         uses: trilom/file-changes-action@v1.2.4
       - name: Build or reuse the toolbox container image
+        if: github.event_name != 'schedule'
         run: |
           # The following array defines the expressions that
           # when matching the container image for the toolbox
@@ -73,6 +76,14 @@ jobs:
             done
           done
           REUSE_TOOLBOX=$REUSE NO_VAGRANT=1 make toolbox-build
+      - name: Reuse the toolbox container image for the scheduled job
+        if: github.event_name == 'schedule'
+        run: |
+          # In this case we assume that the scheduled job will
+          # pull the container image from the local container
+          # registry because that should be the latest correct
+          # toolbox image.
+          REUSE_TOOLBOX=1 NO_VAGRANT=1 make toolbox-build
       - name: Run all the tests non OpenStack dependant
         run: |
           ./toolbox/run make test-fast

--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -271,6 +271,8 @@ jobs:
           NUMBER_FAKE_NOVA_COMPUTE=2
           CELLSV2_SETUP="singleconductor"
           OS_PLACEMENT_CONFIG_DIR=/etc/nova
+          # Enable only IPv4
+          IP_VERSION=4
           # Horizon is enabled by default, but
           # its not required
           disable_service horizon


### PR DESCRIPTION
This commit skips the execution of the file-changes-action
GitHub action when running the scheduled job. This is because
the file-changes-action action waits for a PR id to determine
which files changed, and when running the scheduled job this
variable will be NaN.