### PR TITLE
Fix: Remove unnecessary delay in conversion host reachability check

### DIFF
--- a/os_migrate/roles/import_workloads/tasks/main.yml
+++ b/os_migrate/roles/import_workloads/tasks/main.yml
@@ -72,7 +72,7 @@
     port: 22
     host: '{{ os_dst_conversion_host_info.openstack_conversion_host.address }}'
     search_regex: OpenSSH
-    delay: 10
+    sleep: 5
     timeout: 600
 
 - name: Wait until the src conversion host is reachable
@@ -80,7 +80,7 @@
     port: 22
     host: '{{ os_src_conversion_host_info.openstack_conversion_host.address }}'
     search_regex: OpenSSH
-    delay: 10
+    sleep: 5
     timeout: 600
 
 - name: import workloads


### PR DESCRIPTION
In conversion host reachability check, with the `wait_for` Ansible
module we used `delay` of 10 seconds, which caused a delay before the
first check, causing unnecessary slowdown (20 seconds in total) of the
import_workloads playbook. What we probably meant to use was `sleep`,
which sets the interval between checks. This is now fixed and the
`sleep` property is set to 5 seconds.