### PR TITLE
Prepare release 0.8.3 with recent fixes

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -271,6 +271,8 @@ jobs:
           ENABLED_SERVICES+=,ovn-controller,ovn-northd,ovs-vswitchd,ovsdb-server
           # Glance
           ENABLED_SERVICES+=,g-api
+          # OVN options
+          OVN_L3_CREATE_PUBLIC_NETWORK=false
           [[post-config|/etc/nova/nova.conf]]
           [placement]
           auth_type = password

--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -253,6 +253,8 @@ jobs:
           NUMBER_FAKE_NOVA_COMPUTE=2
           CELLSV2_SETUP="singleconductor"
           OS_PLACEMENT_CONFIG_DIR=/etc/nova
+          # Enable only IPv4
+          IP_VERSION=4
           # Horizon is enabled by default, but
           # its not required
           disable_service horizon

--- a/os_migrate/galaxy.yml
+++ b/os_migrate/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: os_migrate
 name: os_migrate
-version: 0.8.2
+version: 0.8.3
 readme: README.md
 authors:
   - Jiri Stransky <jistr@redhat.com>

--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -1,4 +1,4 @@
-OS_MIGRATE_VERSION = '0.8.2'  # updated by build.sh
+OS_MIGRATE_VERSION = '0.8.3'  # updated by build.sh
 
 # Main serialization sections
 RES_PARAMS = 'params'

--- a/os_migrate/plugins/module_utils/flavor.py
+++ b/os_migrate/plugins/module_utils/flavor.py
@@ -45,11 +45,21 @@ class Flavor(resource.Resource):
         delete_extra_specs = list(set(sdk_extra_specs.keys()) -
                                   set(params_extra_specs.keys()))
         for prop_name in delete_extra_specs:
-            conn.compute.delete_flavor_extra_specs_property(sdk_res, prop_name)
+            # We can use the 'if' variant exclusively after we mandate OpenStack SDK >= 0.51
+            if hasattr(conn.compute, 'delete_flavor_extra_specs_property'):
+                conn.compute.delete_flavor_extra_specs_property(sdk_res['id'], prop_name)
+            else:
+                # Old non-proxy SDK API
+                conn.unset_flavor_specs(sdk_res, [prop_name])
         for prop_name in params_extra_specs.keys():
             if sdk_extra_specs.get(prop_name) != params_extra_specs[prop_name]:
-                conn.compute.update_flavor_extra_specs_property(
-                    sdk_res, prop_name, params_extra_specs[prop_name])
+                # We can use the 'if' variant exclusively after we mandate OpenStack SDK >= 0.51
+                if hasattr(conn.compute, 'update_flavor_extra_specs_property'):
+                    conn.compute.update_flavor_extra_specs_property(
+                        sdk_res, prop_name, params_extra_specs[prop_name])
+                else:
+                    # Old non-proxy SDK API
+                    conn.set_flavor_specs(sdk_res['id'], {prop_name: params_extra_specs[prop_name]})
 
     @staticmethod
     def _create_sdk_res(conn, sdk_params):

--- a/os_migrate/plugins/module_utils/flavor.py
+++ b/os_migrate/plugins/module_utils/flavor.py
@@ -40,15 +40,16 @@ class Flavor(resource.Resource):
             params['swap'] = 0
 
     def _hook_after_update(self, conn, sdk_res, is_create):
-        params = self.params()
-        delete_extra_specs = list(set(sdk_res['extra_specs'].keys()) -
-                                  set(params['extra_specs'].keys()))
+        sdk_extra_specs = sdk_res.get('extra_specs') or {}
+        params_extra_specs = self.params().get('extra_specs') or {}
+        delete_extra_specs = list(set(sdk_extra_specs.keys()) -
+                                  set(params_extra_specs.keys()))
         for prop_name in delete_extra_specs:
             conn.compute.delete_flavor_extra_specs_property(sdk_res, prop_name)
-        for prop_name in params['extra_specs'].keys():
-            if sdk_res['extra_specs'].get(prop_name) != params['extra_specs'][prop_name]:
+        for prop_name in params_extra_specs.keys():
+            if sdk_extra_specs.get(prop_name) != params_extra_specs[prop_name]:
                 conn.compute.update_flavor_extra_specs_property(
-                    sdk_res, prop_name, params['extra_specs'][prop_name])
+                    sdk_res, prop_name, params_extra_specs[prop_name])
 
     @staticmethod
     def _create_sdk_res(conn, sdk_params):

--- a/os_migrate/plugins/module_utils/keypair.py
+++ b/os_migrate/plugins/module_utils/keypair.py
@@ -29,7 +29,11 @@ class Keypair(resource.Resource):
 
     @staticmethod
     def _create_sdk_res(conn, sdk_params):
-        return conn.compute.create_keypair(**sdk_params)
+        try:
+            return conn.compute.create_keypair(**sdk_params)
+        except openstack.exceptions.BadRequestException:
+            sdk_params_no_type = {k: v for k, v in sdk_params.items() if k != 'type'}
+            return conn.compute.create_keypair(**sdk_params_no_type)
 
     @staticmethod
     def _find_sdk_res(conn, name_or_id, filters=None):

--- a/os_migrate/roles/import_workloads/tasks/main.yml
+++ b/os_migrate/roles/import_workloads/tasks/main.yml
@@ -72,7 +72,7 @@
     port: 22
     host: '{{ os_dst_conversion_host_info.openstack_conversion_host.address }}'
     search_regex: OpenSSH
-    delay: 10
+    sleep: 5
     timeout: 600
 
 - name: Wait until the src conversion host is reachable
@@ -80,7 +80,7 @@
     port: 22
     host: '{{ os_src_conversion_host_info.openstack_conversion_host.address }}'
     search_regex: OpenSSH
-    delay: 10
+    sleep: 5
     timeout: 600
 
 - name: import workloads

--- a/scripts/linters.sh
+++ b/scripts/linters.sh
@@ -41,7 +41,7 @@ find ./ \
         rules: {
             truthy: disable,
             document-start: disable,
-            line-length: { max: 100 },
+            line-length: { max: 150 },
         }
     }' {}
 

--- a/tests/func/admin/clean/flavor.yml
+++ b/tests/func/admin/clean/flavor.yml
@@ -8,3 +8,7 @@
       flavor: osm_flavor
     - auth: "{{ os_migrate_dst_auth }}"
       flavor: osmdst_flavor
+    - auth: "{{ os_migrate_src_auth }}"
+      flavor: osm_flavor_specless
+    - auth: "{{ os_migrate_dst_auth }}"
+      flavor: osmdst_flavor_specless

--- a/tests/func/admin/seed/flavor.yml
+++ b/tests/func/admin/seed/flavor.yml
@@ -10,3 +10,13 @@
     extra_specs:
       os_migrate:some_property: asdf
       os_migrate:other_property: ghij
+
+- name: create osm_flavor_specless
+  openstack.cloud.compute_flavor:
+    auth: "{{ os_migrate_src_auth }}"
+    state: present
+    name: osm_flavor_specless
+    ram: 2048
+    vcpus: 2
+    disk: 20
+    ephemeral: 0

--- a/tests/func/tenant/data/validate_data_dir/invalid/networks-duplicate.yml
+++ b/tests/func/tenant/data/validate_data_dir/invalid/networks-duplicate.yml
@@ -1,4 +1,4 @@
-os_migrate_version: 0.8.2
+os_migrate_version: 0.8.3
 resources:
   - _info:
       availability_zones: []

--- a/tests/func/tenant/data/validate_data_dir/invalid/networks.yml
+++ b/tests/func/tenant/data/validate_data_dir/invalid/networks.yml
@@ -1,4 +1,4 @@
-os_migrate_version: 0.8.2
+os_migrate_version: 0.8.3
 resources:
   - _info:
       availability_zones: []

--- a/tests/func/tenant/data/validate_data_dir/valid/networks.yml
+++ b/tests/func/tenant/data/validate_data_dir/valid/networks.yml
@@ -1,4 +1,4 @@
-os_migrate_version: 0.8.2
+os_migrate_version: 0.8.3
 resources:
   - _info:
       availability_zones: []


### PR DESCRIPTION
Fix: Handle when flavor extra_specs are reported as None from API
Fix: Flavor extra_specs import with OpenStack SDK older than 0.51
Fix: Only use 'type' on keypairs when it is supported
Fix: Remove unnecessary delay in conversion host reachability check

+ 'Dev' patches which look like they may be required to keep tests passing