### PR TITLE
Dev: Expand prerequisites for developer environment setup

### DIFF
--- a/docs/src/devel/dev-env-setup.rst
+++ b/docs/src/devel/dev-env-setup.rst
@@ -4,7 +4,8 @@ Development Environment Setup
 Prerequisites
 -------------
 
--  Podman and Buildah for running rootless development environment
+-  Local clone of the os-migrate git repo from https://github.com/os-migrate/os-migrate
+-  `Podman <https://podman.io/>`_ and `Buildah <https://buildah.io/>`_ for running rootless development environment
    containers.
 
 Development environment


### PR DESCRIPTION
Add links to Podman and Buildah for easier discovery and also include
the prerequisite that a git clone of the os-migrate repo is also required