### PR TITLE
Fix: Conversion host network MTUs default to cloud defaults

### DIFF
--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -4,12 +4,8 @@
 
 os_migrate_conversion_net_name: os_migrate_conv
 
-os_migrate_src_conversion_net_mtu: "{{
-  1400 if os_migrate_src_release | int > 10
-  else omit }}"
-os_migrate_dst_conversion_net_mtu: "{{
-  1400 if os_migrate_dst_release | int > 10
-  else omit }}"
+os_migrate_src_conversion_net_mtu: "{{ omit }}"
+os_migrate_dst_conversion_net_mtu: "{{ omit }}"
 
 # If we install packages we need a DNS server working
 os_migrate_src_conversion_subnet_dns_nameservers: ['8.8.8.8']


### PR DESCRIPTION
Previously we had conversion host network MTUs decided by variables
`os_migrate_src_release` and `os_migrate_dst_release` and decided MTUs
for conversion host network based on those. These were test-specific
decisions leaking into production settings. We now default the MTU
parameters to Ansible's `omit` special value, which means the module
responsible for creating the network will not specify any value in the
network creation API request, and the MTU will be autoselected by the
cloud.

If the defaults result in undesirable values, the MTUs can still be
explicitly overriden via `os_migrate_src_conversion_net_mtu` and
`os_migrate_dst_conversion_net_mtu` variables.

This fix also removes dependency of production code on
`os_migrate_src_release` and `os_migrate_dst_release` variables, as
currently OS Migrate does not alter behavior based on src/dst release.