### PR TITLE
Dev: Add minimal runtime.yml for the Ansible collection

### DIFF
--- a/os_migrate/meta/runtime.yml
+++ b/os_migrate/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.9,<2.10"

--- a/scripts/linters.sh
+++ b/scripts/linters.sh
@@ -91,9 +91,12 @@ fi
 python ./scripts/check_fqcn.py
 
 # Ansible lint
-find ./ \
-     -not -wholename ".tox/*" \
-     -and -not -wholename "./local/*" \
-     -and -not -wholename "./tests/func/tmp/*" \
-     -and -name "*.yml" -print0 \
-    | xargs -0 ansible-lint
+# runtime.yml is skipped until ansible-lint is compatible with it
+find \
+    ./os_migrate \
+    ./tests \
+    -name "*.yml" \
+    -and -not -wholename "./os_migrate/meta/runtime.yml" \
+    -and -not -wholename "./tests/func/tmp/*" \
+    -print0 \
+    | xargs -0 ansible-lint --exclude=os_migrate/meta/runtime.yml

--- a/toolbox/Dockerfile
+++ b/toolbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/fedora:33
+FROM quay.io/fedora/fedora:33-x86_64
 RUN dnf install -y glibc-langpack-en
 ARG NO_VAGRANT=0
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
Publishing 0.9.0 failed with:

ERROR! Galaxy import process failed: 'requires_ansible' in
meta/runtime.yml is mandatory, but no meta/runtime.yml found (Code:
None)

It seems there is a new requirement for Ansible collections of adding
meta/runtime.yml [1], and the minimal runtime.yml seems to consist of
supported range of Ansible versions. Let's start defensively with 2.9
only, as that's what we currently CI, and expand/move the list
according to what we test.

[1] https://github.com/ansible/ansible/commit/a9eb8b04882669bd17cd82780c908863e7504886