### PR TITLE
Dev: Use CentOS 8 stream instead of CentOS 8

### DIFF
--- a/tests/e2e/tenant/scenario_variables.yml
+++ b/tests/e2e/tenant/scenario_variables.yml
@@ -12,11 +12,11 @@ os_migrate_conversion_subnet_dns_nameservers: ['10.64.63.6']
 
 os_migrate_src_conversion_external_network_name: public
 os_migrate_src_conversion_flavor_name: m1.medium
-os_migrate_src_conversion_image_name: CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2
+os_migrate_src_conversion_image_name: CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
 
 os_migrate_dst_conversion_external_network_name: public
 os_migrate_dst_conversion_flavor_name: m1.medium
-os_migrate_dst_conversion_image_name: CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2
+os_migrate_dst_conversion_image_name: CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
 
 os_migrate_src_validate_certs: false
 os_migrate_dst_validate_certs: false


### PR DESCRIPTION
This commit moves forward the usage of
CentOS 8 stream in the end-to-end testing
of OS migrate.