### PR TITLE
New: Allow ssh access to conversion host using a default password

### DIFF
--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -70,6 +70,18 @@
 - hosts: conversion_hosts
   any_errors_fatal: true
   tasks:
+    - name: enable ssh_user password access to the conversion hosts
+      ansible.builtin.include_role:
+        name: os_migrate.os_migrate.conversion_host
+        tasks_from: enable_password_access.yml
+      when: os_migrate_conversion_host_ssh_user_enable_password_access|default(false)|bool
+  vars:
+    ansible_become_user: root
+    ansible_become: true
+
+- hosts: conversion_hosts
+  any_errors_fatal: true
+  tasks:
     - name: install the conversion host content
       ansible.builtin.include_role:
         name: os_migrate.os_migrate.conversion_host_content

--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -31,4 +31,6 @@ os_migrate_conversion_host_name: os_migrate_conv
 os_migrate_conversion_image_name: os_migrate_conv
 
 os_migrate_conversion_host_ssh_user: cloud-user
+os_migrate_conversion_host_ssh_user_enable_password_access: false
+os_migrate_conversion_host_ssh_user_password: weak_password_disabled_by_default
 os_migrate_conversion_host_content_install: true

--- a/os_migrate/roles/conversion_host/tasks/enable_password_access.yml
+++ b/os_migrate/roles/conversion_host/tasks/enable_password_access.yml
@@ -1,0 +1,17 @@
+- name: Enable password access in sshd
+  ansible.builtin.replace:
+    path: /etc/ssh/sshd_config
+    regexp: 'PasswordAuthentication no'
+    replace: 'PasswordAuthentication yes'
+
+- name: Reload ssh
+  ansible.builtin.service:
+    name: sshd
+    state: reloaded
+
+- name: Change {{ os_migrate_conversion_host_ssh_user }} password
+  ansible.builtin.user:
+    name: "{{ os_migrate_conversion_host_ssh_user }}"
+    update_password: always
+    password: "{{ os_migrate_conversion_host_ssh_user_password|password_hash('sha512') }}"
+  no_log: true


### PR DESCRIPTION
This commit allows to configure a default password in both
centos and cloud-user users, this can help connecting directly
to the hosts with a default password disabled by default.

Added os_migrate_conversion_host_ssh_user_enable_password_access
disabled by default.