### PR TITLE
Fix: in rhsm auto_attach once defaulted will always collide with acti…

### DIFF
--- a/docs/src/user/variables-guide.rst
+++ b/docs/src/user/variables-guide.rst
@@ -147,18 +147,27 @@ When using RHEL as conversion host, set the SSH user name as follows::
     os_migrate_conversion_host_ssh_user: cloud-user
 
 It is also necessary to set RHEL registration variables. The
-``os_migrate_conversion_rhsm_auto_attach`` variable is defaulted to
-``true``, others are defaulted to omitting.
+variables part of this role are set to ``omit`` by default.
+
+The variables `os_migrate_conversion_rhsm_auto_attach`
+and `os_migrate_conversion_rhsm_activationkey` are mutually
+exclusive, given that, they are both defaulted to omit.
 
 Typically the only registration variables to set are::
 
     os_migrate_conversion_rhsm_username
     os_migrate_conversion_rhsm_password
 
+In this case, `os_migrate_conversion_rhsm_auto_attach` should be set to `True`
+in order to fetch automatically the content once the node is registered.
+
 or::
 
     os_migrate_conversion_rhsm_activationkey
     os_migrate_conversion_rhsm_org_id
+
+For this case, `os_migrate_conversion_rhsm_auto_attach` must be left
+undefined with its default value of `omit`.
 
 The complete list of registration variables corresponds to the
 `redhat_subscription <https://docs.ansible.com/ansible/latest/collections/community/general/redhat_subscription_module.html>`_

--- a/os_migrate/roles/conversion_host_content/tasks/rhel.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/rhel.yml
@@ -1,9 +1,8 @@
 - name: register and auto-subscribe to available content.
   community.general.redhat_subscription:
     state: present
-    # These params have defaults specified:
-    auto_attach: "{{ os_migrate_conversion_rhsm_auto_attach|default(true) }}"
     # These params default to omitting:
+    auto_attach: "{{ os_migrate_conversion_rhsm_auto_attach|default(omit) }}"
     activationkey: "{{ os_migrate_conversion_rhsm_activationkey|default(omit) }}"
     consumer_id: "{{ os_migrate_conversion_rhsm_consumer_id|default(omit) }}"
     consumer_name: "{{ os_migrate_conversion_rhsm_consumer_name|default(omit) }}"


### PR DESCRIPTION
…vationkey

Once a variable is defaulted to an existing value it can not
be omited, auto_attach is defaulted to true so if activationkey
it can not be put back to omit.

omit is a special variable for omitting an individual argument
to a module with only that value, and once defined it can not
be omited again.