### PR TITLE
new: allow running scripts in the conversion hosts

### DIFF
--- a/docs/src/user/variables-guide.rst
+++ b/docs/src/user/variables-guide.rst
@@ -217,6 +217,35 @@ following string `weak_password_disabled_by_default`.
 The user enabled to access the conversion hosts with password-based authentication
 is the one defined in the `os_migrate_conversion_host_ssh_user` variable.
 
+Running custom bash scripts in the conversion hosts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to run custom bash scripts in the conversion
+hosts before and after configuring their content.
+The content of the conversion hosts is a set of required packages
+and in the case of using RHEL then the configuration of the
+subscription manager.
+
+The variables allowing to run the custom scripts are::
+
+    os_migrate_src_conversion_host_pre_content_hook
+    os_migrate_src_conversion_host_post_content_hook
+    os_migrate_dst_conversion_host_pre_content_hook
+    os_migrate_dst_conversion_host_post_content_hook
+
+The Ansible module used to achieve this is shell,
+so users can execute a simple one-liner command, or more
+complex scripts like the following examples::
+
+    os_migrate_src_conversion_host_pre_content_hook: |
+      ls -ltah
+      echo "hello world"
+      df -h
+
+or::
+
+    os_migrate_src_conversion_host_pre_content_hook: "echo 'this is a simple command'"
+
 OpenStack REST API TLS variables
 --------------------------------
 

--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -79,7 +79,7 @@
     ansible_become_user: root
     ansible_become: true
 
-- hosts: conversion_hosts
+- hosts: os_migrate_conv_src
   any_errors_fatal: true
   tasks:
     - name: install the conversion host content
@@ -89,3 +89,19 @@
   vars:
     ansible_become_user: root
     ansible_become: true
+    os_migrate_conversion_host_pre_content_hook: "{{ os_migrate_src_conversion_host_pre_content_hook|default(false) }}"
+    os_migrate_conversion_host_post_content_hook: "{{ os_migrate_src_conversion_host_post_content_hook|default(false) }}"
+
+
+- hosts: os_migrate_conv_dst
+  any_errors_fatal: true
+  tasks:
+    - name: install the conversion host content
+      ansible.builtin.include_role:
+        name: os_migrate.os_migrate.conversion_host_content
+      when: os_migrate_conversion_host_content_install|default(true)|bool
+  vars:
+    ansible_become_user: root
+    ansible_become: true
+    os_migrate_conversion_host_pre_content_hook: "{{ os_migrate_dst_conversion_host_pre_content_hook|default(false) }}"
+    os_migrate_conversion_host_post_content_hook: "{{ os_migrate_dst_conversion_host_post_content_hook|default(false) }}"

--- a/os_migrate/roles/conversion_host_content/defaults/main.yml
+++ b/os_migrate/roles/conversion_host_content/defaults/main.yml
@@ -5,3 +5,6 @@ os_migrate_conversion_host_content_install: true
 # os_migrate_conversion_rhsm_password: password
 os_migrate_conversion_rhsm_retries: 5
 os_migrate_conversion_rhsm_delay: 10
+
+os_migrate_conversion_host_pre_content_hook: false
+os_migrate_conversion_host_post_content_hook: false

--- a/os_migrate/roles/conversion_host_content/tasks/main.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/main.yml
@@ -6,6 +6,10 @@
           Conversion Host OS is
           {{ ansible_distribution }} {{ ansible_distribution_version }}
 
+    - name: running pre content hook
+      ansible.builtin.shell: "{{ os_migrate_conversion_host_pre_content_hook }}"
+      when: os_migrate_conversion_host_pre_content_hook is string
+
     - name: Include CentOS tasks
       ansible.builtin.include_tasks: centos.yml
       when: ansible_distribution in ['CentOS']
@@ -13,3 +17,7 @@
     - name: Include RHEL tasks
       ansible.builtin.include_tasks: rhel.yml
       when: ansible_distribution in ['RedHat']
+
+    - name: running post content hook
+      ansible.builtin.shell: "{{ os_migrate_conversion_host_post_content_hook }}"
+      when: os_migrate_conversion_host_post_content_hook is string


### PR DESCRIPTION
This commit allows to run custom bash scripts in
the conversion hosts before and after the content
playbook.