### PR TITLE
dev: fix encondings

### DIFF
--- a/os_migrate/plugins/module_utils/filesystem.py
+++ b/os_migrate/plugins/module_utils/filesystem.py
@@ -35,7 +35,7 @@ def load_resources_file(file_path):
 
     Returns: Structure (dict) of the loaded file.
     """
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', encoding='utf8') as f:
         file_struct = yaml.load(f)
 
     file_os_migrate_version = file_struct.get('os_migrate_version', None)
@@ -49,5 +49,5 @@ def _write_resources_file(file_path, file_struct):
     """Write `file_struct` resources file structure into a file at
     `file_path`.
     """
-    with open(file_path, 'w') as f:
+    with open(file_path, 'w', encoding='utf8') as f:
         f.write(yaml.dump(file_struct))

--- a/os_migrate/plugins/module_utils/workload_common.py
+++ b/os_migrate/plugins/module_utils/workload_common.py
@@ -25,7 +25,7 @@ PORT_LOCK_FILE = '/var/lock/v2v-migration-lock'  # Lock for the port map
 try:
     from subprocess import DEVNULL
 except ImportError:
-    DEVNULL = open(os.devnull, 'r+')
+    DEVNULL = open(os.devnull, 'r+', encoding='utf8')
 
 
 def use_lock(lock_file):
@@ -128,7 +128,7 @@ class OpenStackHostBase():
         if self.state_file is None:
             return
         self.volume_map[dev_path]['progress'] = progress
-        with open(self.state_file, 'w') as state:
+        with open(self.state_file, 'w', encoding='utf8') as state:
             all_progress = {}
             for path, mapping in self.volume_map.items():
                 all_progress[path] = mapping['progress']

--- a/os_migrate/plugins/modules/import_workload_transfer_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_transfer_volumes.py
@@ -525,7 +525,7 @@ class OpenStackDestinationHost(OpenStackHostBase):
 
                 cmd = ['sudo', '--preserve-env=LIBGUESTFS_BACKEND',
                        'virt-sparsify', '--in-place', overlay]
-                with open(self.log_file, 'a') as log_fd:
+                with open(self.log_file, 'a', encoding='utf8') as log_fd:
                     img_sub = self.shell.cmd_sub(cmd,
                                                  stdout=log_fd,
                                                  stderr=subprocess.STDOUT,

--- a/os_migrate/tests/unit/test_filesystem.py
+++ b/os_migrate/tests/unit/test_filesystem.py
@@ -32,7 +32,7 @@ class TestFilesystem(unittest.TestCase):
     def test_write_or_replace_resource_existing_file(self):
         with utils.tmp_dir_context() as tmp_dir:
             file_path = path.join(tmp_dir, 'resources.yml')
-            with open(file_path, 'w') as f:
+            with open(file_path, 'w', encoding='utf8') as f:
                 f.write(yaml.dump(fixtures.minimal_resource_file_struct()))
 
             minimal2 = fixtures.MinimalResource.from_data(
@@ -65,18 +65,18 @@ class TestFilesystem(unittest.TestCase):
             file_path = path.join(tmp_dir, 'resources.yml')
 
             struct = fixtures.minimal_resource_file_struct()
-            with open(file_path, 'w') as f:
+            with open(file_path, 'w', encoding='utf8') as f:
                 f.write(yaml.dump(struct))
             self.assertEqual(filesystem.load_resources_file(file_path), struct)
 
             struct['os_migrate_version'] = '0.0.never-released'
-            with open(file_path, 'w') as f:
+            with open(file_path, 'w', encoding='utf8') as f:
                 f.write(yaml.dump(struct))
             with self.assertRaises(exc.DataVersionMismatch):
                 filesystem.load_resources_file(file_path)
 
             del struct['os_migrate_version']
-            with open(file_path, 'w') as f:
+            with open(file_path, 'w', encoding='utf8') as f:
                 f.write(yaml.dump(struct))
             with self.assertRaises(exc.DataVersionMismatch):
                 filesystem.load_resources_file(file_path)


### PR DESCRIPTION
Lint checks are failing because of
unspecified-encoding: Using open
without explicitly specifying an encoding