### PR TITLE
new: add a floating IP after creating the server instance

### DIFF
--- a/docs/src/user/variables-guide.rst
+++ b/docs/src/user/variables-guide.rst
@@ -133,6 +133,17 @@ The variables to be configured are::
 Usually, ‘m1.medium’ will suffice this requirement, but again, it can
 be different between deployments.
 
+Conversion hosts specific floating IPs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each conversion host needs to have a floating IP,
+this floating IP can be assigned automatically or
+defined by the operator with the usage of the
+following variables::
+
+    os_migrate_src_conversion_floating_ip_address
+    os_migrate_dst_conversion_floating_ip_address
+
 Conversion host image name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -21,6 +21,7 @@
         os_migrate_conversion_net_mtu: "{{ os_migrate_src_conversion_net_mtu|default(omit) }}"
         os_migrate_conversion_subnet_dns_nameservers:
           "{{ os_migrate_src_conversion_subnet_dns_nameservers|default(omit) }}"
+        os_migrate_conversion_floating_ip_address: "{{ os_migrate_src_conversion_floating_ip_address|default(false) }}"
       when: os_migrate_deploy_src_conversion_host|default(true)|bool
 
     - name: deploy the dst conversion host inventory
@@ -43,6 +44,7 @@
         os_migrate_conversion_net_mtu: "{{ os_migrate_dst_conversion_net_mtu|default(omit) }}"
         os_migrate_conversion_subnet_dns_nameservers:
           "{{ os_migrate_dst_conversion_subnet_dns_nameservers|default(omit) }}"
+        os_migrate_conversion_floating_ip_address: "{{ os_migrate_dst_conversion_floating_ip_address|default(false) }}"
       when: os_migrate_deploy_dst_conversion_host|default(true)|bool
 
     - name: prepare the conversion host link

--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -26,7 +26,7 @@ os_migrate_conversion_keypair_name: os_migrate_conv
 os_migrate_conversion_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/ssh.key"
 os_migrate_conversion_link_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/link-ssh.key"
 
-os_migrate_conversion_host_deploy_timeout: 600
+os_migrate_conversion_host_deploy_timeout: 180
 os_migrate_src_conversion_host_name: os_migrate_conv_src
 os_migrate_dst_conversion_host_name: os_migrate_conv_dst
 os_migrate_conversion_image_name: os_migrate_conv
@@ -35,3 +35,5 @@ os_migrate_conversion_host_ssh_user: cloud-user
 os_migrate_conversion_host_ssh_user_enable_password_access: false
 os_migrate_conversion_host_ssh_user_password: weak_password_disabled_by_default
 os_migrate_conversion_host_content_install: true
+
+os_migrate_conversion_floating_ip_address: false

--- a/os_migrate/roles/conversion_host/tasks/main.yml
+++ b/os_migrate/roles/conversion_host/tasks/main.yml
@@ -107,7 +107,7 @@
     network: "{{ os_migrate_conversion_net_name }}"
     security_groups:
       - "{{ os_migrate_conversion_secgroup_name }}"
-    auto_ip: yes
+    auto_ip: no
     wait: yes
     timeout: "{{ os_migrate_conversion_host_deploy_timeout }}"
     auth: "{{ os_migrate_conversion_auth }}"
@@ -117,3 +117,39 @@
     ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
+
+- name: create the conversion host floating IP with a predefined IP
+  openstack.cloud.floating_ip:
+    server: "{{ os_migrate_conversion_host_name }}"
+    nat_destination: "{{ os_migrate_conversion_net_name }}"
+    floating_ip_address: "{{ os_migrate_conversion_floating_ip_address|default(omit) }}"
+    state: present
+    wait: yes
+    timeout: "{{ os_migrate_conversion_host_deploy_timeout }}"
+    reuse: yes
+    auth: "{{ os_migrate_conversion_auth }}"
+    auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"
+    validate_certs: "{{ os_migrate_conversion_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
+  when: os_migrate_conversion_floating_ip_address is defined and os_migrate_conversion_floating_ip_address is string
+
+- name: create the conversion host floating IP with auto IP enabled
+  openstack.cloud.floating_ip:
+    server: "{{ os_migrate_conversion_host_name }}"
+    network: "{{ os_migrate_conversion_external_network_name }}"
+    nat_destination: "{{ os_migrate_conversion_net_name }}"
+    state: present
+    wait: yes
+    timeout: "{{ os_migrate_conversion_host_deploy_timeout }}"
+    reuse: yes
+    auth: "{{ os_migrate_conversion_auth }}"
+    auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"
+    validate_certs: "{{ os_migrate_conversion_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_conversion_client_key|default(omit) }}"
+  when: os_migrate_conversion_floating_ip_address is defined and not os_migrate_conversion_floating_ip_address


### PR DESCRIPTION
This commit disables the auto floating IP allocation when the
conversion host is created and explicitly assigns the floating
IP once the instance is running. Also allows to specify custom
floating IPs.