### PR TITLE
Dev: Update toolbox and Vagrant base to Fedora 34

### DIFF
--- a/toolbox/Dockerfile
+++ b/toolbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:33-x86_64
+FROM quay.io/fedora/fedora:34-x86_64
 RUN dnf install -y glibc-langpack-en
 ARG NO_VAGRANT=0
 ENV LANG en_US.UTF-8

--- a/toolbox/vagrant/vagrant-config.yml
+++ b/toolbox/vagrant/vagrant-config.yml
@@ -1,5 +1,5 @@
 libvirt:
-  box: fedora32
+  box: fedora34
   default_prefix: os_migrate_
   storage_pool_name: vagrant
   suspend_mode: managedsave

--- a/toolbox/vagrant/vagrant-up
+++ b/toolbox/vagrant/vagrant-up
@@ -5,8 +5,8 @@ set -euxo pipefail
 if ! virsh pool-list | grep vagrant &> /dev/null; then
     virsh pool-create-as vagrant dir --target $HOME/.local/share/libvirt/vagrant
 fi
-if ! vagrant box list | grep fedora32 &> /dev/null; then
-    vagrant box add --name fedora32 https://mirror.karneval.cz/pub/linux/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-32-1.6.x86_64.vagrant-libvirt.box
+if ! vagrant box list | grep fedora34 &> /dev/null; then
+    vagrant box add --name fedora34 https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-34-1.2.x86_64.vagrant-libvirt.box
 fi
 
 vagrant up


### PR DESCRIPTION
The expected Fedora version for Devstack is now 34:

https://opendev.org/openstack/devstack/src/commit/e102559f87b3b2afb5ad0aa874f9bfa98c269624/stack.sh