### PR TITLE
new: allow deleting or detaching the conversion hosts FIPs

### DIFF
--- a/docs/src/user/variables-guide.rst
+++ b/docs/src/user/variables-guide.rst
@@ -137,12 +137,25 @@ Conversion hosts specific floating IPs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Each conversion host needs to have a floating IP,
-this floating IP can be assigned automatically or
+these floating IPs can be assigned automatically or
 defined by the operator with the usage of the
 following variables::
 
     os_migrate_src_conversion_floating_ip_address
     os_migrate_dst_conversion_floating_ip_address
+
+Conversion hosts detach or remove floating IPs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the conversion hosts are removed, the required and
+assigned floating IPs need to be detached or removed.
+
+The following variables allow to change the behavior
+of deleting of detaching the floating IP when deleting the conversion
+hosts (default: yes)::
+
+    os_migrate_src_conversion_host_delete_fip
+    os_migrate_dst_conversion_host_delete_fip
 
 Conversion host image name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/os_migrate/playbooks/delete_conversion_hosts.yml
+++ b/os_migrate/playbooks/delete_conversion_hosts.yml
@@ -26,6 +26,7 @@
         tasks_from: delete.yml
       vars:
         os_migrate_conversion_host_name: "{{ os_migrate_src_conversion_host_name }}"
+        os_migrate_conversion_delete_fip: "{{ os_migrate_src_conversion_host_delete_fip|default(True) }}"
         os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
         os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
         os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -41,6 +42,7 @@
         tasks_from: delete.yml
       vars:
         os_migrate_conversion_host_name: "{{ os_migrate_dst_conversion_host_name }}"
+        os_migrate_conversion_delete_fip: "{{ os_migrate_dst_conversion_host_delete_fip|default(True) }}"
         os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
         os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
         os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"

--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -16,6 +16,8 @@ os_migrate_conversion_subnet_cidr: 192.168.10.0/24
 os_migrate_conversion_subnet_alloc_start: 192.168.10.10
 os_migrate_conversion_subnet_alloc_end: 192.168.10.99
 
+os_migrate_conversion_delete_fip: yes
+
 os_migrate_conversion_router_name: os_migrate_conv
 os_migrate_conversion_router_ip: 192.168.10.1
 

--- a/os_migrate/roles/conversion_host/tasks/delete.yml
+++ b/os_migrate/roles/conversion_host/tasks/delete.yml
@@ -2,7 +2,7 @@
   openstack.cloud.server:
     name: "{{ os_migrate_conversion_host_name }}"
     state: absent
-    delete_fip: yes
+    delete_fip: "{{ os_migrate_conversion_delete_fip|default(omit) }}"
     wait: yes
     auth: "{{ os_migrate_conversion_auth }}"
     auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"


### PR DESCRIPTION
This commit enables users to detach or demove floating IPs
when deleting the conversion hosts.