### PR TITLE
Dev: Add intellij '.idea' directory to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /toolbox/vagrant/.vagrant
 /toolbox/vagrant/env
 /toolbox/build/galaxy.yml
+/.idea/


### PR DESCRIPTION
For developers using any of the intellij suite of IDEs adding
'.idea' to git ignore makes development a little cleaner.