### PR TITLE
New: Allow using pre-existing floating IPs for migrated servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install: os_migrate-os_migrate-latest.tar.gz
 		source /root/venv/bin/activate; \
 	fi; \
 	cd releases; \
-	ansible-galaxy collection install --force os_migrate-os_migrate-latest.tar.gz
+	ansible-galaxy collection install $(OS_MIGRATE_INSTALL_ARGS) --force os_migrate-os_migrate-latest.tar.gz
 
 clean:
 	ls releases/os_migrate-os_migrate*.tar.gz | xargs rm

--- a/docs/src/user/migration-params-guide.rst
+++ b/docs/src/user/migration-params-guide.rst
@@ -45,23 +45,33 @@ Workload migration parameters
    parameters. Instead, edit the serialized volume in the ``volumes``
    section of the workload's ``params``.
 
--  ``floating_ip_mode`` controls whether floating IPs should be created
-   for workloads:
-
-   -  ``auto`` (default): Create floating IP(s) on the same
-      interface(s) of destination server where the exported source
-      server had its floating IP(s).
-
-      In the ``workloads.yml`` export, each serialized floating IP
-      contains a ``fixed_ip_address`` property, so a floating IP will
-      be created on the port with this address. (When editing
-      ports/fixed addresses of a workload, make sure to also edit the
-      ``fixed_ip_address`` properties of its floating IPs accordingly.)
-
-      It is important to note that the floating IP address will be
-      automatically selected by the cloud, it will not match the
-      floating IP address of the source server. (In most cases, the
-      floating IP ranges of src/dst clouds don't overlap anyway.)
+-  ``floating_ip_mode`` controls whether and how floating IPs should be
+   created for workloads:
 
    -  ``skip``: Do not create any floating IPs on the destination
       server.
+
+   -  ``new``: Create a new floating IP (auto-assigned address).
+
+   -  ``existing``: Assume the floating IP address as specified in
+      the workload serialization is already assigned to the
+      destination project, but not attached. Attach this floating
+      IP. If this is not possible for some reason, fail.
+
+   -  ``auto`` (default): Attempt the ``existing`` method of floating
+      IP assignment first, but should it fail, fall back to the
+      ``new`` method instead.
+
+   General remarks regarding floating IPs:
+
+   In the ``workloads.yml`` export, each serialized floating IP
+   contains a ``fixed_ip_address`` property, so a floating IP will
+   be created on the port with this address. (When editing
+   ports/fixed addresses of a workload, make sure to also edit the
+   ``fixed_ip_address`` properties of its floating IPs accordingly.)
+
+   It is important to note that the address of a newly created
+   floating IP will be automatically selected by the cloud, it will
+   not match the floating IP address of the source server. (In most
+   cases, the floating IP ranges of src/dst clouds don't overlap
+   anyway.)

--- a/os_migrate/plugins/module_utils/server.py
+++ b/os_migrate/plugins/module_utils/server.py
@@ -95,6 +95,9 @@ class Server(resource.Resource):
 
         self.update_sdk_params_block_device_mapping(sdk_params, block_device_mapping)
         sdk_srv = conn.compute.create_server(**sdk_params)
+        # Wait for the server before we attach Floating IPs, otherwise
+        # we may hit "Instance network is not ready yet" error.
+        sdk_srv = conn.compute.wait_for_server(sdk_srv, failures=['ERROR'], wait=600)
         self._create_floating_ips(conn, sdk_srv)
         return sdk_srv
 

--- a/os_migrate/plugins/module_utils/server_floating_ip.py
+++ b/os_migrate/plugins/module_utils/server_floating_ip.py
@@ -63,20 +63,39 @@ class ServerFloatingIP(resource.Resource):
         raise exc.Unsupported("Direct ServerFloatingIP.create_or_update call is unsupported.")
 
     def create(self, conn, sdk_srv, mode):
-        mode_choices = ['auto', 'skip']
+        mode_choices = ['auto', 'skip', 'new', 'existing']
         if mode not in mode_choices:
             raise exc.UnexpectedChoice('floating_ip_mode', mode_choices, mode)
 
+        my_port = self._find_my_server_port(conn, sdk_srv)
         if mode == 'skip':
             return None
+        elif mode == 'existing':
+            return self._attach_existing(conn, my_port, sdk_srv, required=True)
+        elif mode == 'new':
+            return self._create_new(conn, my_port, sdk_srv)
         elif mode == 'auto':
-            return self._create_auto(conn, sdk_srv)
+            return self._create_auto(conn, my_port, sdk_srv)
 
-    def _create_auto(self, conn, sdk_srv):
-        my_port = self._find_my_server_port(conn, sdk_srv)
+    def _create_auto(self, conn, my_port, sdk_srv):
+        attached = self._attach_existing(conn, my_port, sdk_srv, required=False)
+        if attached:
+            return attached
+        else:
+            return self._create_new(conn, my_port, sdk_srv)
+
+    def _create_new(self, conn, my_port, sdk_srv):
         sdk_params = self._to_sdk_params(self._refs_from_ser(conn))
         sdk_params['port_id'] = my_port['id']
         return conn.network.create_ip(**sdk_params)
+
+    def _attach_existing(self, conn, my_port, sdk_srv, required=False):
+        existing = self._find_specified_detached_floating_ip(conn, required=required)
+        if existing:
+            conn.compute.add_floating_ip_to_server(
+                sdk_srv, existing['floating_ip_address'], self.params()['fixed_ip_address'])
+            return existing
+        return None
 
     def _find_my_server_port(self, conn, sdk_srv, delay=5, retries=5):
         params = self.params()
@@ -96,6 +115,27 @@ class ServerFloatingIP(resource.Resource):
             f"to a port with fixed IP '{params['fixed_ip_address']}', but no such port was found "
             "on that server."
         )
+
+    def _find_specified_detached_floating_ip(self, conn, required=False):
+        fip_address = self.params()['floating_ip_address']
+        query = {'floating_ip_address': fip_address}
+        fips = list(conn.network.ips(**query))
+        if len(fips) == 1:
+            fip = fips[0]
+        elif len(fips) > 1:
+            raise exc.InconsistentState(
+                f"More than one floating IP found with address {fip_address}")
+        elif required:  # but not found
+            raise exc.CannotConverge(
+                f"No floating IPs found with address {fip_address}")
+        else:  # not found and not required
+            return None
+
+        if fip['port_id'] is not None:
+            raise exc.CannotConverge(
+                f"Floating IP with address {fip_address} is already"
+                f"attached to port {fip['port_id']}")
+        return fip
 
     @staticmethod
     def _refs_from_sdk(conn, sdk_res):

--- a/tests/e2e/tenant/clean_workload.yml
+++ b/tests/e2e/tenant/clean_workload.yml
@@ -111,3 +111,6 @@
       ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
       client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
       client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+- name: Remove osm_fip
+  import_tasks: clean_workload_existing_fip.yml

--- a/tests/e2e/tenant/clean_workload_existing_fip.yml
+++ b/tests/e2e/tenant/clean_workload_existing_fip.yml
@@ -1,0 +1,29 @@
+- name: get dst auth token
+  openstack.cloud.auth:
+    auth: "{{ os_migrate_dst_auth }}"
+
+- name: list osm_fip floating IP IDs
+  ansible.builtin.shell: |
+    openstack floating ip list -f value -c ID --tag osm_fip
+  environment:
+    OS_AUTH_TYPE: token
+    OS_AUTH_URL: "{{ os_migrate_dst_auth.auth_url }}"
+    OS_TOKEN: "{{ auth_token }}"
+    OS_PROJECT_ID: "{{ os_migrate_dst_auth.project_id|default('') }}"
+    OS_PROJECT_NAME: "{{ os_migrate_dst_auth.project_name|default('') }}"
+    OS_PROJECT_DOMAIN_ID: "{{ os_migrate_dst_auth.project_domain_id|default('') }}"
+    OS_PROJECT_DOMAIN_NAME: "{{ os_migrate_dst_auth.project_domain_name|default('') }}"
+  register: osm_fip_ids
+
+- name: delete osm_fips floating IPs
+  ansible.builtin.shell: |
+    openstack floating ip delete {{ item }}
+  environment:
+    OS_AUTH_TYPE: token
+    OS_AUTH_URL: "{{ os_migrate_dst_auth.auth_url }}"
+    OS_TOKEN: "{{ auth_token }}"
+    OS_PROJECT_ID: "{{ os_migrate_dst_auth.project_id|default('') }}"
+    OS_PROJECT_NAME: "{{ os_migrate_dst_auth.project_name|default('') }}"
+    OS_PROJECT_DOMAIN_ID: "{{ os_migrate_dst_auth.project_domain_id|default('') }}"
+    OS_PROJECT_DOMAIN_NAME: "{{ os_migrate_dst_auth.project_domain_name|default('') }}"
+  loop: "{{ osm_fip_ids.stdout_lines }}"

--- a/tests/e2e/tenant/run_workload.yml
+++ b/tests/e2e/tenant/run_workload.yml
@@ -21,7 +21,11 @@
         path: "{{ os_migrate_data_dir }}/workloads.yml"
         regexp: "boot_disk_copy: false"
         replace: "boot_disk_copy: true"
-      when: set_boot_volume_copy|default(false)|bool
+      when: set_boot_disk_copy|default(false)|bool
+
+    - name: create and set existing FIP
+      ansible.builtin.include_tasks: run_workload_existing_fip.yml
+      when: set_floating_ip_mode|default('') == 'existing'
 
     - name: load exported data
       ansible.builtin.set_fact:

--- a/tests/e2e/tenant/run_workload_existing_fip.yml
+++ b/tests/e2e/tenant/run_workload_existing_fip.yml
@@ -1,0 +1,29 @@
+- name: get dst auth token
+  openstack.cloud.auth:
+    auth: "{{ os_migrate_dst_auth }}"
+
+- name: create osm_fip in destination
+  ansible.builtin.shell: |
+    openstack floating ip create  -f value -c floating_ip_address \
+        --tag osm_fip {{ os_migrate_dst_conversion_external_network_name }}
+  environment:
+    OS_AUTH_TYPE: token
+    OS_AUTH_URL: "{{ os_migrate_dst_auth.auth_url }}"
+    OS_TOKEN: "{{ auth_token }}"
+    OS_PROJECT_ID: "{{ os_migrate_dst_auth.project_id|default('') }}"
+    OS_PROJECT_NAME: "{{ os_migrate_dst_auth.project_name|default('') }}"
+    OS_PROJECT_DOMAIN_ID: "{{ os_migrate_dst_auth.project_domain_id|default('') }}"
+    OS_PROJECT_DOMAIN_NAME: "{{ os_migrate_dst_auth.project_domain_name|default('') }}"
+  register: existing_fip
+
+- name: set floating_ip_mode
+  ansible.builtin.replace:
+    path: "{{ os_migrate_data_dir }}/workloads.yml"
+    regexp: "floating_ip_mode: .*"
+    replace: "floating_ip_mode: existing"
+
+- name: set floating_ip_address
+  ansible.builtin.replace:
+    path: "{{ os_migrate_data_dir }}/workloads.yml"
+    regexp: "floating_ip_address: .*"
+    replace: "floating_ip_address: {{ existing_fip.stdout }}"

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -63,8 +63,16 @@
           tags: test_pre_workload
       tags: always
 
-    # server from tenant-owned image with attached volume,
-    # migration w/o boot volume copy
+    # Workload migration scenario:
+    #
+    # * Attached volume
+    #
+    # * From tenant-owned image
+    #
+    # * boot_disk_copy: false
+    #
+    # * floating_ip_mode: auto
+    #
     - name: seed the workloads
       ansible.builtin.include_tasks: tenant/seed_workload.yml
       args:
@@ -96,8 +104,16 @@
             - test_image_workload_boot_nocopy_clean
       tags: always
 
-    # server from public image with attached volume,
-    # migration with boot volume copy
+    # Workload migration scenario:
+    #
+    # * Attached volume
+    #
+    # * From public image
+    #
+    # * boot_disk_copy: true
+    #
+    # * floating_ip_mode: existing
+    #
     - name: seed the workloads
       ansible.builtin.include_tasks: tenant/seed_workload.yml
       args:
@@ -118,7 +134,8 @@
             - test_image_workload_boot_copy
       tags: always
       vars:
-        set_boot_volume_copy: true
+        set_boot_disk_copy: true
+        set_floating_ip_mode: 'existing'
 
     - name: clean the workloads
       ansible.builtin.include_tasks: tenant/clean_workload.yml


### PR DESCRIPTION
Two new floating_ip_mode migration parameter values are introduced:
'new' and 'existing'. The modes now behave this way:

* 'skip' - Do not create any floating IPs.

* 'new' - Create a new floating IP (auto-assigned address).

* 'existing' - Assume the floating IP address specified in the
  workload serialization is already assigned to the destination
  project, but not attached. Attach this floating IP. If this is not
  possible for some reason, fail.

* 'auto' - Attempt the 'existing' method of floating IP assignment,
  but instead of failing, fall back to the 'new' method.