### PR TITLE
New: Allow creating conversion hosts as boot-from-volume servers

### DIFF
--- a/docs/src/user/variables-guide.rst
+++ b/docs/src/user/variables-guide.rst
@@ -180,6 +180,26 @@ should be a
 or
 `RHEL 8 KVM Guest Image <https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.3/x86_64/product-software>`_.
 
+Conversion host boot from volume
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The conversion hosts can be created as boot-from-volume servers in
+either cloud. The variables that control the behavior are::
+
+    os_migrate_src_conversion_host_boot_from_volume
+    os_migrate_dst_conversion_host_boot_from_volume
+
+The default is `false` (meaning boot from Nova local disk).
+
+When creating boot-from-volume conversion hosts, it is possible to
+customize the size in GB for the boot volume::
+
+    os_migrate_src_conversion_host_volume_size
+    os_migrate_dst_conversion_host_volume_size
+
+The size should be 20 or more, the default is 20.
+
+
 Conversion host RHEL variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -6,6 +6,8 @@
         name: os_migrate.os_migrate.conversion_host
       vars:
         os_migrate_conversion_host_name: "{{ os_migrate_src_conversion_host_name }}"
+        os_migrate_conversion_host_boot_from_volume: "{{ os_migrate_src_conversion_host_boot_from_volume|default(omit) }}"
+        os_migrate_conversion_host_volume_size: "{{ os_migrate_src_conversion_host_volume_size|default(omit) }}"
         os_migrate_conversion_auth: "{{ os_migrate_src_auth }}"
         os_migrate_conversion_auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
         os_migrate_conversion_region_name: "{{ os_migrate_src_region_name|default(omit) }}"
@@ -29,6 +31,8 @@
         name: os_migrate.os_migrate.conversion_host
       vars:
         os_migrate_conversion_host_name: "{{ os_migrate_dst_conversion_host_name }}"
+        os_migrate_conversion_host_boot_from_volume: "{{ os_migrate_dst_conversion_host_boot_from_volume|default(omit) }}"
+        os_migrate_conversion_host_volume_size: "{{ os_migrate_dst_conversion_host_volume_size|default(omit) }}"
         os_migrate_conversion_auth: "{{ os_migrate_dst_auth }}"
         os_migrate_conversion_auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
         os_migrate_conversion_region_name: "{{ os_migrate_dst_region_name|default(omit) }}"

--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -29,6 +29,10 @@ os_migrate_conversion_keypair_private_path: "{{ os_migrate_data_dir }}/conversio
 os_migrate_conversion_link_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/link-ssh.key"
 
 os_migrate_conversion_host_deploy_timeout: 180
+os_migrate_src_conversion_host_boot_from_volume: false
+os_migrate_dst_conversion_host_boot_from_volume: false
+os_migrate_src_conversion_host_volume_size: 20
+os_migrate_dst_conversion_host_volume_size: 20
 os_migrate_src_conversion_host_name: os_migrate_conv_src
 os_migrate_dst_conversion_host_name: os_migrate_conv_dst
 os_migrate_conversion_image_name: os_migrate_conv

--- a/os_migrate/roles/conversion_host/tasks/main.yml
+++ b/os_migrate/roles/conversion_host/tasks/main.yml
@@ -103,6 +103,8 @@
     flavor: "{{ os_migrate_conversion_flavor_name }}"
     image: "{{ os_migrate_conversion_image_name }}"
     key_name: "{{ os_migrate_conversion_keypair_name }}"
+    boot_from_volume: "{{ os_migrate_conversion_host_boot_from_volume|default(omit) }}"
+    volume_size: "{{ os_migrate_conversion_host_volume_size|default(omit) }}"
     terminate_volume: true
     network: "{{ os_migrate_conversion_net_name }}"
     security_groups:


### PR DESCRIPTION
The operator can now control if conversion hosts are backed by a local
Nova disk (still the default), or if they are created as
boot-from-volume. The parameters which control the behavior are:

    os_migrate_src_conversion_host_boot_from_volume
    os_migrate_dst_conversion_host_boot_from_volume