### PR TITLE
Dev: Fix functional tests after a Devstack auth change

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -364,7 +364,7 @@ jobs:
           ./toolbox/run ./scripts/auth-from-clouds.sh \
               --config tests/clouds.yaml \
               --src devstack \
-              --dst devstack-alt \
+              --dst devstack-alt-member \
               > tests/auth_tenant.yml && \
           ./toolbox/run ./scripts/auth-from-clouds.sh \
               --config tests/clouds.yaml \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test-setup-vagrant-devstack:
 	./scripts/auth-from-clouds.sh \
 		--config toolbox/vagrant/env/clouds.yaml \
 		--src devstack \
-		--dst devstack-alt \
+		--dst devstack-alt-member \
 		> tests/auth_tenant.yml
 
 test-setup-vagrant-devstack-admin:


### PR DESCRIPTION
Devstack recently changed [1] the default authorizations on the demo
users, so we adapt the usage of accounts to get the original behavior.
This means using member+reader accounts for the tests.

[1] https://github.com/openstack/devstack/commit/9c81321bfc694bd511dee8dd5d04273e368e5545