### PR TITLE
Fix: enforce the executable argument when executing shell

### DIFF
--- a/os_migrate/plugins/module_utils/resource.py
+++ b/os_migrate/plugins/module_utils/resource.py
@@ -300,7 +300,7 @@ class Resource():
         """
         Returns: True if resource data is well-formed, False otherwise
         """
-        return self.data_errors() == []
+        return not self.data_errors()
 
     # Not meant to be overriden in majority of subclasses.
     def is_same_resource(self, target):

--- a/os_migrate/roles/conversion_host_content/tasks/main.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/main.yml
@@ -8,6 +8,8 @@
 
     - name: running pre content hook
       ansible.builtin.shell: "{{ os_migrate_conversion_host_pre_content_hook }}"
+      args:
+        executable: /bin/bash
       when: os_migrate_conversion_host_pre_content_hook is string
 
     - name: Include CentOS tasks
@@ -20,4 +22,6 @@
 
     - name: running post content hook
       ansible.builtin.shell: "{{ os_migrate_conversion_host_post_content_hook }}"
+      args:
+        executable: /bin/bash
       when: os_migrate_conversion_host_post_content_hook is string

--- a/os_migrate/roles/prelude_common/tasks/main.yml
+++ b/os_migrate/roles/prelude_common/tasks/main.yml
@@ -18,6 +18,8 @@
   ansible.builtin.shell: |
     set -eo pipefail
     python3 -m pip show openstacksdk | grep Version | cut -d' ' -f 2
+  args:
+    executable: /bin/bash
   register: _installed_openstacksdk
   changed_when: "_installed_openstacksdk.rc == 0"
 

--- a/scripts/check_fqcn.py
+++ b/scripts/check_fqcn.py
@@ -96,6 +96,10 @@ def check_tasks(file):
                 if '.' not in task.action:
                     errors.append((file, task.action, "no dot in namespace"))
 
+                if task.action == 'ansible.builtin.shell':
+                    if 'executable' not in task._attributes['args']:
+                        errors.append((file, task.action, "must define the executable as an args, like /bin/bash"))
+
             except AnsibleParserError:
                 pass
             except Exception:

--- a/tests/e2e/tasks/tenant/clean_workload_existing_fip.yml
+++ b/tests/e2e/tasks/tenant/clean_workload_existing_fip.yml
@@ -5,6 +5,8 @@
 - name: list osm_fip floating IP IDs
   ansible.builtin.shell: |
     openstack floating ip list -f value -c ID --tag osm_fip
+  args:
+    executable: /bin/bash
   environment:
     OS_AUTH_TYPE: token
     OS_AUTH_URL: "{{ os_migrate_dst_auth.auth_url }}"
@@ -19,6 +21,8 @@
 - name: delete osm_fips floating IPs
   ansible.builtin.shell: |
     openstack floating ip delete {{ item }}
+  args:
+    executable: /bin/bash
   register: _result
   changed_when: "_result.rc == 0"
   environment:

--- a/tests/e2e/tasks/tenant/run_workload_existing_fip.yml
+++ b/tests/e2e/tasks/tenant/run_workload_existing_fip.yml
@@ -6,6 +6,8 @@
   ansible.builtin.shell: |
     openstack floating ip create  -f value -c floating_ip_address \
         --tag osm_fip {{ os_migrate_dst_conversion_external_network_name }}
+  args:
+    executable: /bin/bash
   environment:
     OS_AUTH_TYPE: token
     OS_AUTH_URL: "{{ os_migrate_dst_auth.auth_url }}"

--- a/tests/func/tasks/admin/clean/user_keypair.yml
+++ b/tests/func/tasks/admin/clean/user_keypair.yml
@@ -10,6 +10,8 @@
         OSM_USER_ID=$(openstack user show -f value -c id osm_user)
         nova keypair-delete --user $OSM_USER_ID osm_user_keypair
     fi
+  args:
+    executable: /bin/bash
   register: _result
   changed_when: "_result.rc == 0"
   environment:
@@ -33,6 +35,8 @@
         OSMDST_USER_ID=$(openstack user show -f value -c id osmdst_user)
         nova keypair-delete --user $OSMDST_USER_ID osmdst_user_keypair
     fi
+  args:
+    executable: /bin/bash
   register: _result
   changed_when: "_result.rc == 0"
   environment:

--- a/tests/func/tasks/admin/seed/user_keypair.yml
+++ b/tests/func/tasks/admin/seed/user_keypair.yml
@@ -5,6 +5,8 @@
 - name: create keypair for osm_user
   ansible.builtin.shell: |
     openstack keypair create --user osm_user osm_user_keypair >/dev/null
+  args:
+    executable: /bin/bash
   register: _result
   changed_when: "_result.rc == 0"
   environment:

--- a/tests/func/tasks/tenant/independent/validate_data_dir.yml
+++ b/tests/func/tasks/tenant/independent/validate_data_dir.yml
@@ -6,6 +6,8 @@
         -i $OS_MIGRATE/localhost_inventory.yml \
         -e "os_migrate_data_dir=$OS_MIGRATE_DATA" \
         $OS_MIGRATE/playbooks/validate_data_dir.yml
+  args:
+    executable: /bin/bash
   changed_when: true
 
 - name: validate invalid dir
@@ -16,6 +18,8 @@
         -i $OS_MIGRATE/localhost_inventory.yml \
         -e "os_migrate_data_dir=$OS_MIGRATE_DATA" \
         $OS_MIGRATE/playbooks/validate_data_dir.yml
+  args:
+    executable: /bin/bash
   changed_when: true
   failed_when: false
   register: validate_data_dir_invalid_result

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/start.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/start.yml
@@ -2,6 +2,8 @@
   ansible.builtin.shell: |
     cd /home/stack/devstack
     LOGFILE=/home/stack/devstack.log ./stack.sh 2>&1
+  args:
+    executable: /bin/bash
   changed_when: true
   become: true
   become_user: stack


### PR DESCRIPTION
Currently the migrator host is not limited to be only
CentOS, Fedora, or RHEL. In the case a user runs OS
migrate from a Linux distribution which is not using
Bash as the default terminal, options like pipefail
might not be availabe (i.e. Ubuntu and ZSH) for
those cases we need to make explicit that the shell
we will use is Bash.

This commit enforce to use and set explicitly
the executable when running ansible.builtin.shell.