### PR TITLE
Chg: Improve error message on data version mismatch

### DIFF
--- a/os_migrate/plugins/module_utils/exc.py
+++ b/os_migrate/plugins/module_utils/exc.py
@@ -14,12 +14,18 @@ class CannotConverge(Exception):
 
 
 class DataVersionMismatch(Exception):
-    """Data version does not match OS-Migrate version."""
+    """Data file version does not match OS Migrate runtime version."""
 
-    msg_format = "Expected data with os_migrate_version '{}' but got '{}'."
+    msg_format = (
+        "OS Migrate runtime is version '{}', but tried to parse data "
+        "file '{}' with os_migrate_version field set to '{}'. "
+        "(Exported data is not guaranteed to be compatible across versions. "
+        "After upgrading OS Migrate, make sure to remove the old "
+        "YAML exports from the data directory.)"
+    )
 
-    def __init__(self, got_version):
-        message = self.msg_format.format(const.OS_MIGRATE_VERSION, got_version)
+    def __init__(self, file_path, got_version):
+        message = self.msg_format.format(const.OS_MIGRATE_VERSION, file_path, got_version)
         super().__init__(message)
 
 

--- a/os_migrate/plugins/module_utils/filesystem.py
+++ b/os_migrate/plugins/module_utils/filesystem.py
@@ -40,7 +40,7 @@ def load_resources_file(file_path):
 
     file_os_migrate_version = file_struct.get('os_migrate_version', None)
     if file_os_migrate_version != const.OS_MIGRATE_VERSION:
-        raise exc.DataVersionMismatch(file_os_migrate_version)
+        raise exc.DataVersionMismatch(file_path, file_os_migrate_version)
 
     return file_struct
 


### PR DESCRIPTION
After upgrading without clearing old exported data, OS Migrate refuses
to parse the old data files. The resulting error message was not clear
enough about the likely root cause and solution. Path to the
problematic file and extra hints are now added to the exception
message, as this is a relatively common pitfall.