### PR TITLE
Docs: fix link on install-from-galaxy which address to install-from-source

### DIFF
--- a/docs/src/user/install-from-galaxy.rst
+++ b/docs/src/user/install-from-galaxy.rst
@@ -3,7 +3,7 @@ Installation from Galaxy (recommended)
 
 This document describes the recommended method of installing OS Migrate,
 from Ansible Galaxy. Alternatively, you can `install from
-source <install-from-source.md>`__.
+source <install-from-source.html>`__.
 
 Prerequisites
 -------------


### PR DESCRIPTION
The link on the user/install-from-galaxy.html address to user/install-from-source.md, which does not exit,  instead of user/install-from-source.html