### PR TITLE
Dev: Fix ansible-lint by uninstalling Ansible RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,13 @@ os_migrate-os_migrate-latest.tar.gz:
 
 # TESTS
 
+# FIXME: Get rid of `dnf -y remove ansible` when possible.
+# Ref: https://github.com/ansible-community/ansible-lint-action/issues/41#issuecomment-933663572
 test-lint: reinstall
 	set -euo pipefail; \
+	if [ -e /.os-migrate-toolbox ]; then \
+		dnf -y remove ansible; \
+	fi; \
 	if [ -z "$${VIRTUAL_ENV:-}" ]; then \
 		echo "Sourcing venv."; \
 		source /root/venv/bin/activate; \

--- a/os_migrate/galaxy.yml
+++ b/os_migrate/galaxy.yml
@@ -8,6 +8,7 @@ authors:
   - Ryan Brady <rbrady@redhat.com>
   - Sagi Shnaidman <sshnaidm@redhat.com>
   - Matthew Arnold <marnold@redhat.com>
+  - Adrian Brown <adrbrown@redhat.com>
   # Keep this at the bottom
   - os-migrate (https://github.com/os-migrate)
 description: OpenStack tenant migration tooling


### PR DESCRIPTION
There is an issue with ansible-lint - it fails with "ImportError:
cannot import name 'AnsibleCollectionLoader' from
'ansible.utils.collection_loader'" when Ansible is installed on the
host and we're running lint in a venv.

We're working around it by uninstalling Ansible in the `test-lint`
make target. We're checking that we run in a toolbox container before
doing the uninstall.

https://github.com/ansible-community/ansible-lint-action/issues/41#issuecomment-933663572

Co-Authored-By: Adrian Brown <adrbrown@redhat.com>