### PR TITLE
dev: patch to ci pip platformdirs and github action

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -3,6 +3,8 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
+    branches:
+      - main
   pull_request:
   # Run the functional tests every 8 hours.
   # This will help to identify faster if

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ toolbox-build:
 		podman tag localhost/os_migrate_toolbox:latest localhost/os_migrate_toolbox:$$(date "+%Y_%m_%d"); \
 	else \
 		echo "Reusing the toolbox container image"; \
+		python -m pip install --upgrade pip; \
 		podman pull docker.pkg.github.com/os-migrate/os-migrate/os_migrate_toolbox:main; \
 		podman image tag docker.pkg.github.com/os-migrate/os-migrate/os_migrate_toolbox:main localhost/os_migrate_toolbox:latest; \
 		podman image tag localhost/os_migrate_toolbox:latest localhost/os_migrate_toolbox:$$(date "+%Y_%m_%d"); \


### PR DESCRIPTION
Issue is related to pip - pushed a fix #556 to handle pip failure, another breakage in the files change action due to that code handling 2 different events from GitHub Actions push & pull_request. When creating a new branch for a PR, push will be triggered immediately before the PR gets created The GitHub API / GitHub context base commit is then 0000000000000000000000000000000000000000, The get-changed-files action needs to have a non 0/empty base commit to be able to diff, Defining both push (and specify the branches) and pull_request solves the problem, I recall running into this problem before with pip and we ended up adding the -no-cache flag somewhere, from docs looks like upgrading pip before we do anything fixes that other breakage. 

Error of file change action:
```
Run trilom/file-changes-action@v1.2.4
Error: undefined
Exception: {
  "error": "404/HttpError",
  "from": "undefined/Error",
  "message": "There was an error getting change files for repo:os-migrate owner:os-migrate base:0000000000000000000000000000000000000000 head:ec6aa73b4526327cd2b51[8](https://github.com/os-migrate/os-migrate/runs/7509167712?check_suite_focus=true#step:8:9)2cea1651[9](https://github.com/os-migrate/os-migrate/runs/7509167712?check_suite_focus=true#step:8:10)c1eba85a2",
  "payload": {
    "name": "HttpError",
    "status": 404,
```

Error for pip failure:
```
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 22.1.2
    Uninstalling pip-22.1.2:
ERROR: Could not install packages due to an OSError: [Errno 39] Directory not empty: 'platformdirs'
```