### PR TITLE
new: keypair resource auth replacement

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -3,6 +3,8 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
+    branches:
+      - main
   pull_request:
   # Run the functional tests every 8 hours.
   # This will help to identify faster if

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ toolbox-build:
 		podman tag localhost/os_migrate_toolbox:latest localhost/os_migrate_toolbox:$$(date "+%Y_%m_%d"); \
 	else \
 		echo "Reusing the toolbox container image"; \
+		python -m pip install --upgrade pip; \
 		podman pull docker.pkg.github.com/os-migrate/os-migrate/os_migrate_toolbox:main; \
 		podman image tag docker.pkg.github.com/os-migrate/os-migrate/os_migrate_toolbox:main localhost/os_migrate_toolbox:latest; \
 		podman image tag localhost/os_migrate_toolbox:latest localhost/os_migrate_toolbox:$$(date "+%Y_%m_%d"); \

--- a/os_migrate/playbooks/delete_conversion_hosts.yml
+++ b/os_migrate/playbooks/delete_conversion_hosts.yml
@@ -1,4 +1,6 @@
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   tasks:
     - name: delete the conversion hosts inventory
       ansible.builtin.include_role:
@@ -11,6 +13,8 @@
   # Unregistration is best-effort. If the conversion hosts faced some
   # issues and are unreachable, we don't want the host deletion to
   # fail too.
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   ignore_unreachable: true
   tasks:
     - name: unregister the conversion hosts
@@ -19,6 +23,8 @@
         tasks_from: rhsm_unregister.yml
 
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   tasks:
     - name: delete the src conversion host
       ansible.builtin.include_role:

--- a/os_migrate/playbooks/deploy_conversion_hosts.yml
+++ b/os_migrate/playbooks/deploy_conversion_hosts.yml
@@ -1,4 +1,6 @@
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   any_errors_fatal: true
   tasks:
     - name: deploy the src conversion host inventory

--- a/os_migrate/playbooks/export_images.yml
+++ b/os_migrate/playbooks/export_images.yml
@@ -1,3 +1,5 @@
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   roles:
     - os_migrate.os_migrate.export_images

--- a/os_migrate/playbooks/export_keypairs.yml
+++ b/os_migrate/playbooks/export_keypairs.yml
@@ -1,3 +1,5 @@
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   roles:
     - os_migrate.os_migrate.export_keypairs

--- a/os_migrate/playbooks/export_networks.yml
+++ b/os_migrate/playbooks/export_networks.yml
@@ -1,3 +1,5 @@
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   roles:
     - os_migrate.os_migrate.export_networks

--- a/os_migrate/playbooks/export_users_keypairs.yml
+++ b/os_migrate/playbooks/export_users_keypairs.yml
@@ -1,3 +1,5 @@
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   roles:
     - os_migrate.os_migrate.export_users_keypairs

--- a/os_migrate/playbooks/import_keypairs.yml
+++ b/os_migrate/playbooks/import_keypairs.yml
@@ -1,3 +1,5 @@
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   roles:
     - os_migrate.os_migrate.import_keypairs

--- a/os_migrate/playbooks/import_users_keypairs.yml
+++ b/os_migrate/playbooks/import_users_keypairs.yml
@@ -1,3 +1,5 @@
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   roles:
     - os_migrate.os_migrate.import_users_keypairs

--- a/os_migrate/plugins/modules/export_image_blob.py
+++ b/os_migrate/plugins/modules/export_image_blob.py
@@ -28,8 +28,8 @@ description:
 options:
   auth:
     description:
-      - Dictionary with parameters for chosen auth type.
-    required: true
+      - Required if 'cloud' param not used.
+    required: false
     type: dict
   auth_type:
     description:
@@ -60,7 +60,8 @@ options:
     type: str
   cloud:
     description:
-      - Ignored. Present for backwards compatibility.
+      - Cloud resource from clouds.yml
+      - Required if 'auth' param not used.
     required: false
     type: raw
 '''
@@ -90,7 +91,6 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import image
 
 def run_module():
     argument_spec = openstack_full_argument_spec(
-        auth=dict(type='dict', no_log=True, required=True),
         blob_path=dict(type='str', required=True),
         name=dict(type='str', required=True),
     )

--- a/os_migrate/plugins/modules/export_image_meta.py
+++ b/os_migrate/plugins/modules/export_image_meta.py
@@ -28,8 +28,8 @@ description:
 options:
   auth:
     description:
-      - Dictionary with parameters for chosen auth type.
-    required: true
+      - Required if 'cloud' param not used.
+    required: false
     type: dict
   auth_type:
     description:
@@ -62,7 +62,8 @@ options:
     type: str
   cloud:
     description:
-      - Ignored. Present for backwards compatibility.
+      - Cloud resource from clouds.yml
+      - Required if 'auth' param not used.
     required: false
     type: raw
 '''
@@ -93,7 +94,6 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import image
 
 def run_module():
     argument_spec = openstack_full_argument_spec(
-        auth=dict(type='dict', no_log=True, required=True),
         path=dict(type='str', required=True),
         name=dict(type='str', required=True),
     )

--- a/os_migrate/plugins/modules/export_keypair.py
+++ b/os_migrate/plugins/modules/export_keypair.py
@@ -28,8 +28,8 @@ description:
 options:
   auth:
     description:
-      - Dictionary with parameters for chosen auth type.
-    required: true
+      - Required if 'cloud' parameter not used.
+    required: false
     type: dict
   auth_type:
     description:
@@ -68,7 +68,8 @@ options:
     type: str
   cloud:
     description:
-      - Ignored. Present for backwards compatibility.
+      - Cloud from clouds.yaml to use.
+      - Required if 'auth' parameter is not used.
     required: false
     type: raw
 '''
@@ -100,13 +101,10 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import keypa
 
 def run_module():
     argument_spec = openstack_full_argument_spec(
-        auth=dict(type='dict', no_log=True, required=True),
         path=dict(type='str', required=True),
         name=dict(type='str', required=True),
         user_id=dict(type='str', required=False, default=None),
     )
-    # TODO: check the del
-    # del argument_spec['cloud']
 
     result = dict(
         changed=False,

--- a/os_migrate/plugins/modules/export_network.py
+++ b/os_migrate/plugins/modules/export_network.py
@@ -29,7 +29,8 @@ options:
   auth:
     description:
       - Dictionary with parameters for chosen auth type.
-    required: true
+      - Required if 'cloud' parameter is not used.
+    required: false
     type: dict
   auth_type:
     description:
@@ -62,7 +63,8 @@ options:
     type: str
   cloud:
     description:
-      - Ignored. Present for backwards compatibility.
+      - Cloud from clouds.yaml to use.
+      - Required if 'auth' parameter is not used.
     required: false
     type: raw
 '''
@@ -93,12 +95,9 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import netwo
 
 def run_module():
     argument_spec = openstack_full_argument_spec(
-        auth=dict(type='dict', no_log=True, required=True),
         path=dict(type='str', required=True),
         name=dict(type='str', required=True),
     )
-    # TODO: check the del
-    # del argument_spec['cloud']
 
     result = dict(
         changed=False,

--- a/os_migrate/plugins/modules/import_keypair.py
+++ b/os_migrate/plugins/modules/import_keypair.py
@@ -28,8 +28,8 @@ description:
 options:
   auth:
     description:
-      - Dictionary with parameters for chosen auth type.
-    required: true
+      - Required if 'cloud' parameter not used.
+    required: false
     type: dict
   auth_type:
     description:
@@ -58,7 +58,8 @@ options:
     type: str
   cloud:
     description:
-      - Ignored. Present for backwards compatibility.
+      - Cloud from clouds.yaml to use.
+      - Required if 'auth' parameter is not used.
     required: false
     type: raw
 '''
@@ -91,12 +92,9 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import keypa
 
 def run_module():
     argument_spec = openstack_full_argument_spec(
-        auth=dict(type='dict', no_log=True, required=True),
         data=dict(type='dict', required=True),
         filters=dict(type='dict', required=False, default={}),
     )
-    # TODO: check the del
-    # del argument_spec['cloud']
 
     result = dict(
         changed=False,

--- a/os_migrate/plugins/modules/import_network.py
+++ b/os_migrate/plugins/modules/import_network.py
@@ -29,7 +29,8 @@ options:
   auth:
     description:
       - Dictionary with parameters for chosen auth type.
-    required: true
+      - Required if 'cloud' parameter is not used.
+    required: false
     type: dict
   auth_type:
     description:
@@ -58,7 +59,8 @@ options:
     type: str
   cloud:
     description:
-      - Ignored. Present for backwards compatibility.
+      - Cloud from clouds.yaml to use.
+      - Required if 'auth' parameter is not used.
     required: false
     type: raw
 '''
@@ -91,12 +93,9 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import netwo
 
 def run_module():
     argument_spec = openstack_full_argument_spec(
-        auth=dict(type='dict', no_log=True, required=True),
         data=dict(type='dict', required=True),
         filters=dict(type='dict', required=False, default={}),
     )
-    # TODO: check the del
-    # del argument_spec['cloud']
 
     result = dict(
         changed=False,

--- a/os_migrate/plugins/modules/os_keypairs_info.py
+++ b/os_migrate/plugins/modules/os_keypairs_info.py
@@ -33,7 +33,7 @@ options:
     type: dict
   auth:
     description:
-      - Dictionary with parameters for chosen auth type.
+      - Required if 'cloud' parameter not used.
     required: true
     type: dict
   auth_type:
@@ -53,7 +53,8 @@ options:
     type: str
   cloud:
     description:
-      - Ignored. Present for backwards compatibility.
+      - Cloud from clouds.yaml to use.
+      - Required if 'auth' parameter is not used.
     required: false
     type: raw
 '''
@@ -92,7 +93,6 @@ except ImportError:
 
 def main():
     argument_spec = openstack_full_argument_spec(
-        auth=dict(type='dict', no_log=True, required=True),
         filters=dict(required=False, type='dict', default={}),
     )
 

--- a/os_migrate/plugins/modules/os_keypairs_info.py
+++ b/os_migrate/plugins/modules/os_keypairs_info.py
@@ -34,7 +34,7 @@ options:
   auth:
     description:
       - Required if 'cloud' parameter not used.
-    required: true
+    required: false
     type: dict
   auth_type:
     description:

--- a/os_migrate/roles/conversion_host/tasks/delete.yml
+++ b/os_migrate/roles/conversion_host/tasks/delete.yml
@@ -4,7 +4,9 @@
     state: absent
     delete_fip: "{{ os_migrate_conversion_manage_fip and os_migrate_conversion_delete_fip }}"
     wait: true
-    cloud: src
+    auth: "{{ os_migrate_conversion_auth }}"
+    auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"
     validate_certs: "{{ os_migrate_conversion_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"
@@ -14,7 +16,9 @@
   openstack.cloud.keypair:
     name: "{{ os_migrate_conversion_keypair_name }}"
     state: absent
-    cloud: src
+    auth: "{{ os_migrate_conversion_auth }}"
+    auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"
     validate_certs: "{{ os_migrate_conversion_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"
@@ -24,7 +28,9 @@
   openstack.cloud.security_group:
     name: "{{ os_migrate_conversion_secgroup_name }}"
     state: absent
-    cloud: src
+    auth: "{{ os_migrate_conversion_auth }}"
+    auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
+    region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"
     validate_certs: "{{ os_migrate_conversion_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"

--- a/os_migrate/roles/conversion_host/tasks/delete.yml
+++ b/os_migrate/roles/conversion_host/tasks/delete.yml
@@ -4,9 +4,7 @@
     state: absent
     delete_fip: "{{ os_migrate_conversion_manage_fip and os_migrate_conversion_delete_fip }}"
     wait: true
-    auth: "{{ os_migrate_conversion_auth }}"
-    auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"
+    cloud: src
     validate_certs: "{{ os_migrate_conversion_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"
@@ -16,9 +14,7 @@
   openstack.cloud.keypair:
     name: "{{ os_migrate_conversion_keypair_name }}"
     state: absent
-    auth: "{{ os_migrate_conversion_auth }}"
-    auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"
+    cloud: src
     validate_certs: "{{ os_migrate_conversion_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"
@@ -28,9 +24,7 @@
   openstack.cloud.security_group:
     name: "{{ os_migrate_conversion_secgroup_name }}"
     state: absent
-    auth: "{{ os_migrate_conversion_auth }}"
-    auth_type: "{{ os_migrate_conversion_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_conversion_region_name|default(omit) }}"
+    cloud: src
     validate_certs: "{{ os_migrate_conversion_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_conversion_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_conversion_client_cert|default(omit) }}"

--- a/os_migrate/roles/conversion_host/tasks/link_prepare.yml
+++ b/os_migrate/roles/conversion_host/tasks/link_prepare.yml
@@ -17,7 +17,7 @@
     host: "{{ hostvars['os_migrate_conv_src']['ansible_ssh_host'] }}"
     search_regex: OpenSSH
     sleep: 5
-    timeout: 600
+    timeout: 900
 
 - name: wait for dst conversion host reachability
   ansible.builtin.wait_for:
@@ -25,4 +25,4 @@
     host: "{{ hostvars['os_migrate_conv_dst']['ansible_ssh_host'] }}"
     search_regex: OpenSSH
     sleep: 5
-    timeout: 600
+    timeout: 900

--- a/os_migrate/roles/export_images/tasks/main.yml
+++ b/os_migrate/roles/export_images/tasks/main.yml
@@ -2,9 +2,7 @@
 # the filters manually below.
 - name: scan available images
   openstack.cloud.image_info:
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
@@ -37,9 +35,7 @@
 
 - name: export image metadata
   os_migrate.os_migrate.export_image_meta:
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     path: "{{ os_migrate_data_dir }}/images.yml"
     name: "{{ item['id'] }}"
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
@@ -57,9 +53,7 @@
 
 - name: export image blobs
   os_migrate.os_migrate.export_image_blob:
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     blob_path: "{{ os_migrate_image_blobs_dir }}/{{ item['id'] }}-{{ item['name'] }}"
     name: "{{ item['id'] }}"
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"

--- a/os_migrate/roles/export_keypairs/tasks/main.yml
+++ b/os_migrate/roles/export_keypairs/tasks/main.yml
@@ -1,8 +1,6 @@
 - name: scan available keypairs
   os_migrate.os_migrate.os_keypairs_info:
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
@@ -25,9 +23,7 @@
 
 - name: export keypair
   os_migrate.os_migrate.export_keypair:
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     path: "{{ os_migrate_data_dir }}/keypairs.yml"
     name: "{{ item['id'] }}"
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"

--- a/os_migrate/roles/export_networks/tasks/main.yml
+++ b/os_migrate/roles/export_networks/tasks/main.yml
@@ -1,9 +1,7 @@
 - name: scan available networks
   openstack.cloud.networks_info:
     filters: "{{ os_migrate_src_filters }}"
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
@@ -26,9 +24,7 @@
 
 - name: export network
   os_migrate.os_migrate.export_network:
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     path: "{{ os_migrate_data_dir }}/networks.yml"
     name: "{{ item['id'] }}"
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"

--- a/os_migrate/roles/export_users_keypairs/tasks/export_single_user_keypairs.yml
+++ b/os_migrate/roles/export_users_keypairs/tasks/export_single_user_keypairs.yml
@@ -1,8 +1,6 @@
 - name: scan available keypairs for {{ export_user['name'] }} ({{ export_user['id'] }})
   os_migrate.os_migrate.os_keypairs_info:
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
@@ -27,9 +25,7 @@
 
 - name: export keypair
   os_migrate.os_migrate.export_keypair:
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     path: "{{ os_migrate_data_dir }}/users_keypairs.yml"
     name: "{{ item['id'] }}"
     user_id: "{{ export_user['id'] }}"

--- a/os_migrate/roles/export_users_keypairs/tasks/main.yml
+++ b/os_migrate/roles/export_users_keypairs/tasks/main.yml
@@ -1,8 +1,6 @@
 - name: scan available users
   openstack.cloud.identity_user_info:
-    auth: "{{ os_migrate_src_auth }}"
-    auth_type: "{{ os_migrate_src_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_src_region_name|default(omit) }}"
+    cloud: src
     validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"

--- a/os_migrate/roles/import_keypairs/tasks/main.yml
+++ b/os_migrate/roles/import_keypairs/tasks/main.yml
@@ -12,9 +12,7 @@
 
 - name: import keypairs
   os_migrate.os_migrate.import_keypair:
-    auth: "{{ os_migrate_dst_auth }}"
-    auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
+    cloud: src
     data: "{{ item }}"
     validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"

--- a/os_migrate/roles/import_keypairs/tasks/main.yml
+++ b/os_migrate/roles/import_keypairs/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: import keypairs
   os_migrate.os_migrate.import_keypair:
-    cloud: src
+    cloud: dst
     data: "{{ item }}"
     validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"

--- a/os_migrate/roles/import_users_keypairs/tasks/main.yml
+++ b/os_migrate/roles/import_users_keypairs/tasks/main.yml
@@ -19,9 +19,7 @@
 
 - name: import users_keypairs
   os_migrate.os_migrate.import_keypair:
-    auth: "{{ os_migrate_dst_auth }}"
-    auth_type: "{{ os_migrate_dst_auth_type|default(omit) }}"
-    region_name: "{{ os_migrate_dst_region_name|default(omit) }}"
+    cloud: dst
     data: "{{ item }}"
     validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
     ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"

--- a/os_migrate/roles/prelude_common/tasks/main.yml
+++ b/os_migrate/roles/prelude_common/tasks/main.yml
@@ -40,4 +40,4 @@
 - name: write to auth file
   ansible.builtin.template:
     src: clouds.yaml.j2
-    dest: "{{ os_migrate_data_dir }}/clouds.yaml"
+    dest: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"

--- a/tests/e2e/test_as_admin.yml
+++ b/tests/e2e/test_as_admin.yml
@@ -6,6 +6,8 @@
 
 - name: Migration tests
   hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   tasks:
     - name: clean the environment
       ansible.builtin.include_tasks: tasks/admin/clean.yml

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -25,6 +25,8 @@
 
 - name: Migration tests
   hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   tasks:
     - name: clean workloads
       ansible.builtin.include_tasks: tasks/tenant/clean_workload.yml

--- a/tests/func/tasks/tenant/idempotence/keypair.yml
+++ b/tests/func/tasks/tenant/idempotence/keypair.yml
@@ -43,11 +43,11 @@
 - name: ensure fingerprint for osm_keypair did not change
   ansible.builtin.assert:
     that:
-      - keypair_import_idem_before['openstack_keypairs'] != None
-      - "keypair_import_idem_before['openstack_keypairs'] \
-         == keypair_import_idem_after['openstack_keypairs']"
+      - keypair_import_idem_before['openstack_keypairs'][0].fingerprint != None
+      - "keypair_import_idem_before['openstack_keypairs'][0]['fingerprint'] \
+         == keypair_import_idem_after['openstack_keypairs'][0]['fingerprint']"
     fail_msg: |
       keypair_import_idem_before fingerprint:
-      {{ keypair_import_idem_before['openstack_keypairs'] }}
+      {{ keypair_import_idem_before['openstack_keypairs'][0].fingerprint }}
       keypair_import_idem_after fingerprint:
-      {{ keypair_import_idem_after['openstack_keypairs'] }}
+      {{ keypair_import_idem_after['openstack_keypairs'][0].fingerprint }}

--- a/tests/func/tasks/tenant/idempotence/keypair.yml
+++ b/tests/func/tasks/tenant/idempotence/keypair.yml
@@ -28,7 +28,7 @@
 
 - name: look up osm_keypair dst cloud
   os_migrate.os_migrate.os_keypairs_info:
-    auth: "{{ os_migrate_dst_auth }}"
+    cloud: dst
   register: keypair_import_idem_before
 
 - name: import keypairs
@@ -37,17 +37,17 @@
 
 - name: look up osm_keypair in dst cloud again
   os_migrate.os_migrate.os_keypairs_info:
-    auth: "{{ os_migrate_dst_auth }}"
+    cloud: dst
   register: keypair_import_idem_after
 
 - name: ensure fingerprint for osm_keypair did not change
   ansible.builtin.assert:
     that:
-      - keypair_import_idem_before['openstack_keypairs'][0].fingerprint != None
-      - "keypair_import_idem_before['openstack_keypairs'][0]['fingerprint'] \
-         == keypair_import_idem_after['openstack_keypairs'][0]['fingerprint']"
+      - keypair_import_idem_before['openstack_keypairs'] != None
+      - "keypair_import_idem_before['openstack_keypairs'] \
+         == keypair_import_idem_after['openstack_keypairs']"
     fail_msg: |
       keypair_import_idem_before fingerprint:
-      {{ keypair_import_idem_before['openstack_keypairs'][0].fingerprint }}
+      {{ keypair_import_idem_before['openstack_keypairs'] }}
       keypair_import_idem_after fingerprint:
-      {{ keypair_import_idem_after['openstack_keypairs'][0].fingerprint }}
+      {{ keypair_import_idem_after['openstack_keypairs'] }}

--- a/tests/func/test_as_admin.yml
+++ b/tests/func/test_as_admin.yml
@@ -1,5 +1,7 @@
 - name: Migration tests
   hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   tasks:
     - name: prepare
       ansible.builtin.import_tasks: tasks/global/prep.yml

--- a/tests/func/test_as_tenant.yml
+++ b/tests/func/test_as_tenant.yml
@@ -8,6 +8,8 @@
 
 - name: Migration tests
   hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   tasks:
     - name: prepare
       ansible.builtin.import_tasks: tasks/global/prep.yml


### PR DESCRIPTION
- Made some changes for the testcases against `idempotence/keypairs.yml' 
- Noticed that before when printing out `"{{ keypair_import_idem_before }}"` this returned a dict, and some other data
- With new auth config it is returning nothing for that object with the key `openstack_keypairs`
```
# before
      - keypair_import_idem_before['openstack_keypairs'][0].fingerprint != None
      - "keypair_import_idem_before['openstack_keypairs'][0]['fingerprint'] \
         == keypair_import_idem_after['openstack_keypairs'][0]['fingerprint']"

# notw
      - keypair_import_idem_before['openstack_keypairs'] != None
      - "keypair_import_idem_before['openstack_keypairs'] \
         == keypair_import_idem_after['openstack_keypairs']"
```