### PR TITLE
dev: make sure pip is installed

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,7 @@ fi
 
 # Apply virtualenv version overrides if defined
 if [ -n "${OS_MIGRATE_REQUIREMENTS_OVERRIDE:-}" ]; then
+    python3 -m pip cache purge && rm -rf $(python3 -m pip cache dir)
     python3 -m pip install --upgrade pip
 
     # Workaround for ERROR: Could not install packages due to an


### PR DESCRIPTION
This commit fixes the
`ERROR: Could not install packages due to an OSError: [Errno 39] Directory not empty: 'cachecontrol'`
error in the functional tests execution.