### PR TITLE
dev: Fix functional CI

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -142,6 +142,7 @@ jobs:
           sudo locale-gen en_US.UTF-8
           sudo dpkg-reconfigure locales
           sudo apt update
+          sudo apt upgrade -y
           sudo apt remove --purge mysql-server mysql-client mysql-common -y
           sudo apt autoremove -y
           # MySQL requirements


### PR DESCRIPTION
This is an attempt to fix the following error in CI:

The following packages have unmet dependencies:
 postgresql-server-dev-all : Depends: postgresql-common (= 238) but 246.pgdg22.04+1 is to be installed
E: Unable to correct problems, you have held broken packages.