### PR TITLE
Cap openstacksdk below 0.99

### DIFF
--- a/docs/src/user/install-from-galaxy.rst
+++ b/docs/src/user/install-from-galaxy.rst
@@ -30,7 +30,7 @@ you can use virtualenv, e.g.::
 
    python3 -m venv $HOME/os_migrate_venv
    source $HOME/os_migrate_venv/bin/activate
-   python3 -m pip install --upgrade 'openstacksdk>=0.36'
+   python3 -m pip install --upgrade 'openstacksdk>=0.36,<0.99'
    python3 -m pip install --upgrade 'ansible>=2.9.1,<2.10'
 
 


### PR DESCRIPTION
Release 0.99.0 of openstacksdk brings major breaking interface changes.