### PR TITLE
dev: working on failing testcase for role assignment

### DIFF
--- a/os_migrate/plugins/modules/import_user_project_role_assignment.py
+++ b/os_migrate/plugins/modules/import_user_project_role_assignment.py
@@ -99,6 +99,8 @@ def run_module():
 
     sdk, conn = openstack_cloud_from_module(module)
     ser_assignment = user_project_role_assignment.UserProjectRoleAssignment.from_data(module.params['data'])
+    
+    # FIXME: bug found here on creation where assignment is missing
     result['changed'] = ser_assignment.create_or_update(conn, module.params['filters'])
 
     module.exit_json(**result)

--- a/os_migrate/tests/unit/test_user_role_assignment.py
+++ b/os_migrate/tests/unit/test_user_role_assignment.py
@@ -112,3 +112,10 @@ class RoleAssignment(unittest.TestCase):
         self.assertEqual(sdk_params['project_id'], 'uuid-test-project')
         self.assertEqual(sdk_params['role_id'], 'uuid-test-role')
         self.assertEqual(sdk_params['user_id'], 'uuid-test-user')
+
+    def test_assignment_not_found(self):
+        # curate mock output 
+        # test the response given presence 
+        # of user, project, role with 
+        # missing assignment.
+        pass


### PR DESCRIPTION
This PR is a proposed patch to [OSP-22603](https://issues.redhat.com/browse/OSP-22603). The bug is found on import for the user project role assignment module. `the result of import_user_project_role_assignment was "ok" even when the target user, project, and role exist but were not assigned.` This patch will contain a try/except for checking assignment of user project roles on import `create_or_update`, which will include an updated functional test case and unit test. 