### PR TITLE
added OS_CLIENT_CONFIG_FILE environment variable to import_networks 

### DIFF
--- a/os_migrate/playbooks/import_networks.yml
+++ b/os_migrate/playbooks/import_networks.yml
@@ -1,3 +1,5 @@
 - hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   roles:
     - os_migrate.os_migrate.import_networks


### PR DESCRIPTION
added OS_CLIENT_CONFIG_FILE environment variable to import_networks , without the playbook ends in an error that it can't find the cloud "dst"