### PR TITLE
fix: install guestfs-tools on CentOS 9 (#620)

### DIFF
--- a/os_migrate/roles/conversion_host_content/tasks/centos.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/centos.yml
@@ -15,6 +15,7 @@
       - nbdkit-basic-plugins
       - qemu-img
       - libguestfs-tools
+      - guestfs-tools
       - libvirt
     state: present
 


### PR DESCRIPTION
Change install content task on conversion hosts to install guestfs-tools for CentOS 9 systems (guestfs-tools provides virt-sparsify) - rebased branch from #620 to include changes for functional patch 