### PR TITLE
fix: install guestfs-tools on CentOS 9 (#620) debugging ci failure 

### DIFF
--- a/os_migrate/roles/conversion_host_content/tasks/centos.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/centos.yml
@@ -15,7 +15,6 @@
       - nbdkit-basic-plugins
       - qemu-img
       - libguestfs-tools
-      - guestfs-tools
       - libvirt
     state: present
 


### PR DESCRIPTION
Reverts os-migrate/os-migrate#627 causing an error in upstream ci