### PR TITLE
fix: set default username to centos reversion for ci triage

### DIFF
--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -31,7 +31,7 @@ os_migrate_conversion_keypair_generate: true
 os_migrate_conversion_keypair_name: os_migrate_conv
 os_migrate_conversion_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/ssh.key"
 os_migrate_conversion_link_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/link-ssh.key"
-os_migrate_conversion_host_ssh_user: centos
+os_migrate_conversion_host_ssh_user: cloud-user
 
 os_migrate_conversion_host_deploy_timeout: 180
 os_migrate_src_conversion_host_boot_from_volume: false

--- a/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_host_inventory.yml
@@ -28,8 +28,8 @@
     ansible_ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
     ansible_ssh_private_key_file: "{{ os_migrate_conversion_keypair_private_path }}"
     ansible_ssh_extra_args: '-o StrictHostKeyChecking=no'
-    # Generally conversion hosts act as centos, not as
-    # root. E.g. link ssh keys need to be added to centos.
+    # Generally conversion hosts act as cloud-user, not as
+    # root. E.g. link ssh keys need to be added to cloud-user.
     ansible_become: false
   when:
     - _server_info.openstack_servers|length > 0

--- a/os_migrate/roles/conversion_host_content/defaults/main.yml
+++ b/os_migrate/roles/conversion_host_content/defaults/main.yml
@@ -13,6 +13,6 @@ os_migrate_conversion_rhsm_manage: true
 
 
 os_migrate_conversion_link_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/link-ssh.key"
-os_migrate_conversion_host_ssh_user: centos
+os_migrate_conversion_host_ssh_user: cloud-user
 os_migrate_conversion_host_ssh_user_enable_password_access: false
 os_migrate_conversion_host_ssh_user_password: weak_password_disabled_by_default


### PR DESCRIPTION
Reverts os-migrate/os-migrate#625