### PR TITLE
dev: check for unsupported distro

### DIFF
--- a/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
@@ -2,16 +2,14 @@
   ansible.builtin.git:
     repo: "https://opendev.org/openstack/devstack.git"
     dest: /home/stack/devstack
-    single_branch: true
-    version: "b31d70a57612d5ec6d7bde5ddfdffd0a78c657cb"
-    refspec: "stable/zed"
+    version: master
     update: no
   become: true
   become_user: stack
 
 - name: set release to zed
   ansible.builtin.shell: |
-    cd /home/stack/devstack && git fetch -a && git checkout stable/zed
+    cd /home/stack/devstack && git fetch -a && git checkout remotes/origin/stable/2023.1
   become: true
   become_user: stack
 

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
@@ -1,9 +1,17 @@
 - name: clone devstack
   ansible.builtin.git:
-    repo: https://opendev.org/openstack/devstack
-    version: master
+    repo: "https://opendev.org/openstack/devstack.git"
     dest: /home/stack/devstack
+    single_branch: true
+    version: "b31d70a57612d5ec6d7bde5ddfdffd0a78c657cb"
+    refspec: "stable/zed"
     update: no
+  become: true
+  become_user: stack
+
+- name: set release to zed
+  ansible.builtin.shell: |
+    cd /home/stack/devstack && git fetch -a && git checkout stable/zed
   become: true
   become_user: stack
 

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
@@ -30,6 +30,5 @@
 - name: check distro is different than fedora
   ansible.builtin.debug:
     msg: "devstack SUPPORTED_DISTROS=bullseye|focal|jammy|rhel8|rhel9|openEuler-22.03"
-  failed_when: os_facts.ansible_facts['ansible_distribution'] == 'Fedora' 
+  when: os_facts.ansible_facts['ansible_distribution'] == 'Fedora'
   register: unsupported_distro
-

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
@@ -22,3 +22,14 @@
     dest: /etc/sudoers.d/stack
     content: |
       stack ALL=(ALL) NOPASSWD:ALL
+
+- name: get OS information
+  ansible.builtin.setup:
+  register: os_facts
+
+- name: check distro is different than fedora
+  ansible.builtin.debug:
+    msg: "devstack SUPPORTED_DISTROS=bullseye|focal|jammy|rhel8|rhel9|openEuler-22.03"
+  failed_when: os_facts.ansible_facts['ansible_distribution'] == 'Fedora' 
+  register: unsupported_distro
+


### PR DESCRIPTION
Drop Fedora support
Fedora 36 is EOL, also opendev is dropping support for Fedora images
completely since interest in running jobs on that platform is no longer
existing. CentOS 9 Stream has evolved as replacement platform for new
features.

Only drop the Zuul configuration and the tag in stack.sh for now plus
update some docs. Cleanup of the deployment code will be done in a
second step.

Change-Id: Ica483fde27346e3939b5fc0d7e0a6dfeae0e8d1e
changes/67/885467/1
https://opendev.org/openstack/devstack/commit/fbc1865dc4e5b84ebafaf1d30cffc582ae3f0c0f