### PR TITLE
oth: Patch to functional ci

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -156,8 +156,9 @@ jobs:
           sudo apt install postgresql-common
           sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
-          # https://github.com/pypa/setuptools/issues/3772
-          sudo python -m pip install --upgrade 'setuptools<66'
+          sudo python -m pip install ovs
+          sudo python -m pip install --upgrade setuptools
+
       - name: Configure podman
         run: |
           mkdir -p ~/.config/containers

--- a/docs/src/devel/dev-env-setup.rst
+++ b/docs/src/devel/dev-env-setup.rst
@@ -256,12 +256,12 @@ Create images
 .. code-block::
 
     # Download images
-    wget https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220913.0.x86_64.qcow2
+    wget https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230116.0.x86_64.qcow2
     wget http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
 
     # Create images in glance from these downloads
     openstack image create --public --disk-format qcow2 --file \
-        CentOS-Stream-GenericCloud-8-20220913.0.x86_64.qcow2 CentOS-Stream-GenericCloud-8-20220913.0.x86_64.qcow2
+        CentOS-Stream-GenericCloud-9-20230116.0.x86_64.qcow2 CentOS-Stream-GenericCloud-9-20230116.0.x86_64.qcow2
     openstack image create --public --disk-format raw --file cirros-0.4.0-x86_64-disk.img cirros-0.4.0-x86_64-disk.img
 
 Create flavors
@@ -328,7 +328,7 @@ Auth URLs and network names will change based on your environment.
 
     os_migrate_data_dir: /root/os_migrate/local/migrate-data
 
-    os_migrate_conversion_host_ssh_user: centos
+    os_migrate_conversion_host_ssh_user: cloud-user
     os_migrate_src_conversion_external_network_name: nova
     os_migrate_dst_conversion_external_network_name: nova
     os_migrate_conversion_flavor_name: m1.large

--- a/os_migrate/README.md
+++ b/os_migrate/README.md
@@ -8,7 +8,7 @@
   <br>
 </h1>
 
-<h4 align="center">OpenStack tenant migration tooling - an Ansible collection</h4>
+<h4 align="center">OpenStack tenant migration tooling - an Ansible collection.</h4>
 
 <p align="center">
   <img src="https://img.shields.io/badge/Python-v3.7+-blue.svg">

--- a/os_migrate/README.md
+++ b/os_migrate/README.md
@@ -8,7 +8,7 @@
   <br>
 </h1>
 
-<h4 align="center">OpenStack tenant migration tooling - an Ansible collection.</h4>
+<h4 align="center">OpenStack tenant migration tooling - an Ansible collection</h4>
 
 <p align="center">
   <img src="https://img.shields.io/badge/Python-v3.7+-blue.svg">

--- a/os_migrate/roles/conversion_host/defaults/main.yml
+++ b/os_migrate/roles/conversion_host/defaults/main.yml
@@ -31,7 +31,7 @@ os_migrate_conversion_keypair_generate: true
 os_migrate_conversion_keypair_name: os_migrate_conv
 os_migrate_conversion_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/ssh.key"
 os_migrate_conversion_link_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/link-ssh.key"
-os_migrate_conversion_host_ssh_user: centos
+os_migrate_conversion_host_ssh_user: cloud-user
 
 os_migrate_conversion_host_deploy_timeout: 180
 os_migrate_src_conversion_host_boot_from_volume: false

--- a/os_migrate/roles/conversion_host/meta/main.yml
+++ b/os_migrate/roles/conversion_host/meta/main.yml
@@ -6,11 +6,11 @@ galaxy_info:
   description: os-migrate resource
   company: Red Hat
   license: Apache-2.0
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   platforms:
     - name: Fedora
       versions:
-        - 30
+        - all
   galaxy_tags: ["osmigrate"]
 dependencies:
   - role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/conversion_host_content/defaults/main.yml
+++ b/os_migrate/roles/conversion_host_content/defaults/main.yml
@@ -13,6 +13,6 @@ os_migrate_conversion_rhsm_manage: true
 
 
 os_migrate_conversion_link_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/link-ssh.key"
-os_migrate_conversion_host_ssh_user: centos
+os_migrate_conversion_host_ssh_user: cloud-user
 os_migrate_conversion_host_ssh_user_enable_password_access: false
 os_migrate_conversion_host_ssh_user_password: weak_password_disabled_by_default

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,9 +15,11 @@ fi
 
 # Apply virtualenv version overrides if defined
 if [ -n "${OS_MIGRATE_REQUIREMENTS_OVERRIDE:-}" ]; then
+    python3 -m pip cache purge && rm -rf $(python3 -m pip cache dir)
     python3 -m pip cache purge && rm -rf $cache_dir
     sleep 1
     python3 -m pip install --upgrade pip
+    sleep 1
     python3 -m pip cache purge && rm -rf $cache_dir
 
     # Workaround for ERROR: Could not install packages due to an


### PR DESCRIPTION
As noted in #637 there seem to be some warning outputs from ansible-lint. This is in relation to galaxy info platforms module and its version for fedora distros. Here is a similar issue found with another distro, https://github.com/ansible/ansible-lint/issues/3067. As of `6.13.0` there is support up to fedora 37, https://github.com/ansible/ansible-lint/blob/v6.13.0/src/ansiblelint/schemas/meta.json. The goal of this PR is to silence the warnings if possible, and update the functional CI given bugs with pip cachecontrol and ovs seen in other work streams. 