### PR TITLE
fix: patch for network param missing from fip creation

### DIFF
--- a/os_migrate/roles/conversion_host/tasks/create_fip.yml
+++ b/os_migrate/roles/conversion_host/tasks/create_fip.yml
@@ -2,6 +2,7 @@
   openstack.cloud.floating_ip:
     server: "{{ os_migrate_conversion_host_name }}"
     nat_destination: "{{ os_migrate_conversion_net_name }}"
+    network: "{{ os_migrate_conversion_external_network_name }}"
     floating_ip_address: "{{ os_migrate_conversion_floating_ip_address|default(omit) }}"
     state: present
     wait: true

--- a/tests/e2e/tasks/tenant/run_workload_existing_fip.yml
+++ b/tests/e2e/tasks/tenant/run_workload_existing_fip.yml
@@ -25,10 +25,6 @@
     regexp: "floating_ip_mode: .*"
     replace: "floating_ip_mode: existing"
 
-- name: print workloads file for debug
-  ansible.builtin.fail:
-    msg: "{{ os_migrate_data_dir }}/workloads.yml"
-
 - name: set floating_ip_address
   ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/workloads.yml"

--- a/tests/e2e/tasks/tenant/run_workload_existing_fip.yml
+++ b/tests/e2e/tasks/tenant/run_workload_existing_fip.yml
@@ -25,6 +25,10 @@
     regexp: "floating_ip_mode: .*"
     replace: "floating_ip_mode: existing"
 
+- name: print workloads file for debug
+  ansible.builtin.fail:
+    msg: "{{ os_migrate_data_dir }}/workloads.yml"
+
 - name: set floating_ip_address
   ansible.builtin.replace:
     path: "{{ os_migrate_data_dir }}/workloads.yml"


### PR DESCRIPTION
We observed the floating IP creation for conversion hosts fail when trying to use the code path that uses predefined IP address rather than an auto-generated one. This module call is missing a 'network' parameter:

https://github.com/os-migrate/os-migrate/blob/426121f307bf0078c1c72b6dd48980849db2c768/os_migrate/roles/conversion_host/tasks/create_fip.yml#L2