### PR TITLE
do not merge -- testing previous commit "dev: changes for stable 0.17 galaxy release"

### DIFF
--- a/os_migrate/galaxy.yml
+++ b/os_migrate/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: os_migrate
 name: os_migrate
-version: 0.17.0
+version: 0.16.0
 readme: README.md
 authors:
   - Jiri Stransky <jistr@redhat.com>

--- a/os_migrate/plugins/module_utils/const.py
+++ b/os_migrate/plugins/module_utils/const.py
@@ -1,4 +1,4 @@
-OS_MIGRATE_VERSION = '0.17.0'  # updated by build.sh
+OS_MIGRATE_VERSION = '0.16.0'  # updated by build.sh
 
 # Main serialization sections
 RES_PARAMS = 'params'

--- a/tests/func/tasks/tenant/data/validate_data_dir/invalid/networks-duplicate.yml
+++ b/tests/func/tasks/tenant/data/validate_data_dir/invalid/networks-duplicate.yml
@@ -1,4 +1,4 @@
-os_migrate_version: 0.17.0
+os_migrate_version: 0.16.0
 resources:
   - _info:
       availability_zones: []

--- a/tests/func/tasks/tenant/data/validate_data_dir/invalid/networks.yml
+++ b/tests/func/tasks/tenant/data/validate_data_dir/invalid/networks.yml
@@ -1,4 +1,4 @@
-os_migrate_version: 0.17.0
+os_migrate_version: 0.16.0
 resources:
   - _info:
       availability_zones: []

--- a/tests/func/tasks/tenant/data/validate_data_dir/valid/networks.yml
+++ b/tests/func/tasks/tenant/data/validate_data_dir/valid/networks.yml
@@ -1,4 +1,4 @@
-os_migrate_version: 0.17.0
+os_migrate_version: 0.16.0
 resources:
   - _info:
       availability_zones: []


### PR DESCRIPTION
Reverts os-migrate/os-migrate#662 to older version before ansible upgrades