### PR TITLE
Set cloud_vars_src fact

### DIFF
--- a/os_migrate/roles/import_workloads/tasks/workload.yml
+++ b/os_migrate/roles/import_workloads/tasks/workload.yml
@@ -77,7 +77,6 @@
         cloud_vars_src: "{{ cloud_vars.clouds['src'] | combine({'block_storage_api_version' : '2'}) }}"
       when:
         - prelim is defined and prelim.changed
-        - os_migrate_src_block_storage_api_version is defined
         - item["_migration_params"]["data_copy"]|default(true)
 
     - name: expose source volumes


### PR DESCRIPTION
Set cloud_vars_src fact even when os_migrate_src_block_storage_api_version is not defined otherwise the next task failed while trying to reused the cloud_vars_src variable.