### PR TITLE
dev: patch to lockfile cleanup

### DIFF
--- a/tests/e2e/ansible.cfg
+++ b/tests/e2e/ansible.cfg
@@ -1,4 +1,4 @@
 [defaults]
 stdout_callback = yaml
-callback_whitelist = json,profile_tasks
+callback_enabled = json,profile_tasks
 json_indent = 4

--- a/tests/func/ansible.cfg
+++ b/tests/func/ansible.cfg
@@ -1,4 +1,4 @@
 [defaults]
 stdout_callback = yaml
-callback_whitelist = json,profile_tasks
+callback_enabled = json,profile_tasks
 json_indent = 4


### PR DESCRIPTION
- Process All Lockfiles: Removed the outer try-except block that could cause an early exit. The method now iterates over all lockfiles regardless of errors encountered with any single one.

- Specific Exception Handling: Changed except Exception to except subprocess.CalledProcessError for more precise error handling.

- Check Return Codes: If cat fails with exit code 1 (file not found), it's logged at the debug level and the loop continues to the next lockfile.

- Logging Improvements: Added more informative logging to help trace the flow and understand which lockfiles were missing, which were held, and which were removed.

- Correct Return Value: The method now only returns True if it actually cleaned up any lockfiles, ensuring that the calling function behaves correctly.