### PR TITLE
fix: Update Fedora 36 Vagrant image URL

### DIFF
--- a/toolbox/vagrant/vagrant-up
+++ b/toolbox/vagrant/vagrant-up
@@ -6,7 +6,7 @@ if ! virsh pool-list | grep vagrant &> /dev/null; then
     virsh pool-create-as vagrant dir --target $HOME/.local/share/libvirt/vagrant
 fi
 if ! vagrant box list | grep fedora36 &> /dev/null; then
-    vagrant box add --name fedora36 https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-36-1.5.x86_64.vagrant-libvirt.box
+    vagrant box add --name fedora36 https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-36-1.5.x86_64.vagrant-libvirt.box
 fi
 
 vagrant up


### PR DESCRIPTION
Since the older Fedora releases have been migrated to `archives.fedoraproject.org`, the `vagrant-up` command failed because the image wasn't found.