### PR TITLE
dev: Upgrade of the toolbox container and dependencies bump

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,3 +5,6 @@ skip_list:
   - 'command-instead-of-module'  # Sed used in place of template, replace or lineinfile module
   - 'command-instead-of-shell' # Use shell only when shell functionality is required
   - 'package-latest'  # Package installs should not use latest
+
+# This is a workaround, we need to port ansible files to 2.17.x
+profile: 'min'

--- a/os_migrate/plugins/module_utils/workload_common.py
+++ b/os_migrate/plugins/module_utils/workload_common.py
@@ -23,6 +23,8 @@ PORT_MAP_FILE = '/var/run/v2v-migration-ports'
 PORT_LOCK_FILE = '/var/lock/v2v-migration-lock'  # Lock for the port map
 
 try:
+    # will be fixed in another PR
+    # pylint: disable-next=unused-import
     from subprocess import DEVNULL
 except ImportError:
     DEVNULL = open(os.devnull, 'r+', encoding='utf8')

--- a/scripts/linters.sh
+++ b/scripts/linters.sh
@@ -19,12 +19,13 @@ set -euxo pipefail
 # Flake
 # TODO: Have the Ansible and YAML lint fixed first
 flake8 \
-    --exclude releasenotes,.tox \
+    --exclude releasenotes,.tox,toolbox/vagrant/.vagrant \
     --ignore E125,E251,E402,H405,W503,W504,E501
 
 # Bash hate
 find ./ \
      -not -wholename ".tox/*" \
+     -and -not -wholename "./toolbox/vagrant/.vagrant/*" \
      -and -not -wholename "./local/*" \
      -and -not -wholename "*.test/*" \
      -and -name "*.sh" -print0 \
@@ -33,6 +34,7 @@ find ./ \
 # Yaml lint
 find ./ \
      -not -wholename ".tox/*" \
+     -and -not -wholename "./toolbox/vagrant/.vagrant/*" \
      -and -not -wholename "./local/*" \
      -and -not -wholename "./tests/func/tmp/*" \
      -and -name "*.yml" -print0 \

--- a/tests/e2e/tasks/tenant/scenario_variables.yml
+++ b/tests/e2e/tasks/tenant/scenario_variables.yml
@@ -12,11 +12,11 @@ os_migrate_conversion_subnet_dns_nameservers: ['10.64.63.6']
 
 os_migrate_src_conversion_external_network_name: public
 os_migrate_src_conversion_flavor_name: m1.medium
-os_migrate_src_conversion_image_name: CentOS-Stream-GenericCloud-9-20230116.0.x86_64.qcow2
+os_migrate_src_conversion_image_name: CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
 
 os_migrate_dst_conversion_external_network_name: public
 os_migrate_dst_conversion_flavor_name: m1.medium
-os_migrate_dst_conversion_image_name: CentOS-Stream-GenericCloud-9-20230116.0.x86_64.qcow2
+os_migrate_dst_conversion_image_name: CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2
 
 os_migrate_src_validate_certs: false
 os_migrate_dst_validate_certs: false

--- a/toolbox/Dockerfile
+++ b/toolbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:36-x86_64
+FROM quay.io/fedora/fedora:40-x86_64
 RUN dnf install -y glibc-langpack-en
 ARG NO_VAGRANT=0
 ENV LANG en_US.UTF-8

--- a/toolbox/build/build.sh
+++ b/toolbox/build/build.sh
@@ -4,11 +4,11 @@ set -euxo pipefail
 
 DIR=$(dirname $(realpath $0))
 OS_MIGRATE_DIR=$(realpath "$DIR/../..")
-ANSIBLE_PYTHON=python3.8
+ANSIBLE_PYTHON=python3
 
 ### PACKAGES ###
 
-dnf -y update
+dnf -y upgrade --refresh
 dnf -y install \
     cargo \
     findutils \
@@ -27,7 +27,7 @@ dnf -y install \
 # The below packages are for vagrant-libvirt and take a lot of deps,
 # build with `NO_VAGRANT=1 make toolbox-build` if Vagrant isn't required.
 if [ "${NO_VAGRANT:-0}" != "1" ]; then
-    dnf -y install ansible libvirt-client rsync openssh-clients vagrant-libvirt
+    dnf -y ansible libvirt-client rsync openssh-clients vagrant-libvirt
 fi
 
 ### VIRTUALENV ###

--- a/toolbox/build/build.sh
+++ b/toolbox/build/build.sh
@@ -27,7 +27,7 @@ dnf -y install \
 # The below packages are for vagrant-libvirt and take a lot of deps,
 # build with `NO_VAGRANT=1 make toolbox-build` if Vagrant isn't required.
 if [ "${NO_VAGRANT:-0}" != "1" ]; then
-    dnf -y ansible libvirt-client rsync openssh-clients vagrant-libvirt
+    dnf -y install ansible libvirt-client rsync openssh-clients vagrant-libvirt
 fi
 
 ### VIRTUALENV ###

--- a/toolbox/build/venv-requirements.txt
+++ b/toolbox/build/venv-requirements.txt
@@ -1,27 +1,27 @@
 # env
-wheel
+wheel==0.44.0
 
 # runtime
-ansible-core
-openstacksdk==1.0.0 # testing incremental bumps
+ansible-core==2.17.5
+openstacksdk==1.0.2
 
 # test
-python-openstackclient
+python-openstackclient==6.2.1
 
-ansible-lint==6.2.1
-bashate==2.1.0
-flake8==4.0.1
-mock==4.0.3
-pylint==2.13.9
-pycodestyle==2.8.0
-pytest==7.1.2
-pytest-mock==3.7.0
-pytest-xdist==2.5.0
-voluptuous==0.13.1
-yamllint==1.26.3
+ansible-lint==24.9.2
+bashate==2.1.1
+flake8==7.1.1
+mock==5.1.0
+pylint==3.3.1
+pycodestyle==2.12.1
+pytest==8.3.3
+pytest-mock==3.14.0
+pytest-xdist==3.6.1
+voluptuous==0.15.2
+yamllint==1.35.1
 
 # docs
 gitchangelog==3.0.4
-markdown==3.3.7
-ruamel.yaml==0.17.21
-sphinx-rtd-theme==1.0.0
+markdown==3.7
+ruamel.yaml==0.18.6
+sphinx-rtd-theme==3.0.0

--- a/toolbox/vagrant/Vagrantfile
+++ b/toolbox/vagrant/Vagrantfile
@@ -1,32 +1,29 @@
 require 'yaml'
 
-VAGRANTFILE_API_VERSION = "2"
 CONFIG_FILE_NAME = ENV["VAGRANT_CONFIG"] || File.dirname(__FILE__) + '/vagrant-config.yml'
 CFG = YAML.load(File.read(CONFIG_FILE_NAME))
 
-Vagrant.require_version ">= 1.6.2"
+Vagrant.require_version ">= 2.0"
 
 # === Vagrant config ===
 
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+Vagrant.configure("2") do |config|
 
-  # Fedora
-  config.ssh.username = 'root'
-
-  # CentOS
-  # config.ssh.insert_key = true
-  # config.ssh.password = 'vagrant'
+  config.ssh.insert_key = true
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder './vagrant-sync', '/vagrant-sync', type: 'rsync'
 
   config.vm.provider :libvirt do |libvirt, override|
     libvirt.driver = 'kvm'
     libvirt.connect_via_ssh = false
     libvirt.username = 'root'
+    libvirt.emulator_path = CFG["libvirt"]["emulator_path"]
+    libvirt.machine_type = CFG["libvirt"]["machine_type"]
     libvirt.default_prefix = CFG["libvirt"]["default_prefix"]
     libvirt.storage_pool_name = CFG["libvirt"]["storage_pool_name"]
     libvirt.qemu_use_session = CFG["libvirt"]["qemu_use_session"]
+    libvirt.video_type = CFG["libvirt"]["video_type"]
+    libvirt.graphics_type = CFG["libvirt"]["graphics_type"]
     libvirt.uri = CFG["libvirt"]["uri"]
     libvirt.system_uri = CFG["libvirt"]["system_uri"]
     libvirt.storage_pool_path = CFG["libvirt"]["storage_pool_path"]
@@ -47,9 +44,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       libvirt.cpus = 4
     end
 
-    vm_config.vm.provision "shell", inline: "/vagrant-sync/preconfigure.sh"
     vm_config.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible/configure.yml"
+      ansible.compatibility_mode = "2.0"
     end
 
     vm_config.trigger.after :up do |trigger|

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
@@ -1,21 +1,12 @@
-- name: clone devstack
+- name: Clone devstack repository
   ansible.builtin.git:
     repo: "https://opendev.org/openstack/devstack.git"
     dest: /home/stack/devstack
-    version: master
+    version: stable/2023.1
     update: no
-  become: true
-  become_user: stack
 
-- name: set release to zed
-  ansible.builtin.shell: |
-    cd /home/stack/devstack && git fetch -a && git checkout remotes/origin/stable/2023.1
-  become: true
-  become_user: stack
-
-- name: write devstack config
+- name: Render devstack config
   ansible.builtin.template:
     src: local.conf.j2
     dest: /home/stack/devstack/local.conf
-  become: true
-  become_user: stack
+    mode: "0644"

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/main.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/main.yml
@@ -1,6 +1,19 @@
-- name: install prereqs
-  ansible.builtin.include: prereqs.yml
-- name: config
-  ansible.builtin.include: config.yml
-- name: start
-  ansible.builtin.include: start.yml
+- name: Install prereqs
+  ansible.builtin.include_tasks:
+    file: prereqs.yml
+    apply:
+      become: true
+
+- name: Configuration tasks
+  ansible.builtin.include_tasks:
+    file: config.yml
+    apply:
+      become: true
+      become_user: stack
+
+- name: Run devstack
+  ansible.builtin.include_tasks:
+    file: run.yml
+    apply:
+      become: true
+      become_user: stack

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/prereqs.yml
@@ -1,33 +1,59 @@
-- name: install packages for devstack
-  ansible.builtin.package:
+- name: Upgrade all packages
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest
+    update_cache: true
+
+- name: Disable SELinux
+  ansible.posix.selinux:
+    state: disabled
+    update_kernel_param: true
+  register: _selinux_state
+
+- name: Reboot vm to disable SELinux
+  ansible.builtin.reboot:
+    msg: "Rebooting to disable SELinux..."
+  when: _selinux_state.reboot_required
+
+- name: Install packages for devstack
+  ansible.builtin.dnf:
     name:
       - git
-      - python2
       - python3-devel
       - tmux
+      - httpd
     state: present
 
-- name: remove packages which devstack does not like
-  ansible.builtin.package:
+- name: Enable httpd service
+  ansible.builtin.systemd_service:
+    name: httpd
+    enabled: true
+
+- name: Remove packages which devstack does not like
+  ansible.builtin.dnf:
     name:
       - python3-pyyaml
+      - firewalld
     state: absent
 
-- name: create stack user
+- name: Create stack user
   ansible.builtin.user:
     name: stack
 
-- name: create sudoers entry for stack
-  ansible.builtin.copy:
-    dest: /etc/sudoers.d/stack
-    content: |
-      stack ALL=(ALL) NOPASSWD:ALL
+- name: Add stack entry in sudoers
+  community.general.sudoers:
+    name: stack
+    commands: ALL
+    host: ALL
+    nopassword: true
+    user: stack
+    validation: detect
 
-- name: get OS information
+- name: Get OS information
   ansible.builtin.setup:
   register: os_facts
 
-- name: check distro is different than fedora
+- name: Check distro is different than fedora
   ansible.builtin.debug:
     msg: "devstack SUPPORTED_DISTROS=bullseye|focal|jammy|rhel8|rhel9|openEuler-22.03"
   when: os_facts.ansible_facts['ansible_distribution'] == 'Fedora'

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/run.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/run.yml
@@ -1,0 +1,6 @@
+- name: Run devstack
+  ansible.builtin.command:
+  args:
+    chdir: /home/stack/devstack
+    cmd: /home/stack/devstack/stack.sh
+  changed_when: true

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/start.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/start.yml
@@ -1,9 +1,0 @@
-- name: start devstack
-  ansible.builtin.shell: |
-    cd /home/stack/devstack
-    LOGFILE=/home/stack/devstack.log ./stack.sh 2>&1
-  args:
-    executable: /bin/bash
-  changed_when: true
-  become: true
-  become_user: stack

--- a/toolbox/vagrant/ansible/roles/devstack/templates/local.conf.j2
+++ b/toolbox/vagrant/ansible/roles/devstack/templates/local.conf.j2
@@ -3,5 +3,7 @@ ADMIN_PASSWORD=password
 DATABASE_PASSWORD=password
 RABBIT_PASSWORD=password
 SERVICE_PASSWORD=password
+LOGFILE=/home/stack/logs/stack.sh.log
+VERBOSE=false
 
 disable_service horizon

--- a/toolbox/vagrant/vagrant-config.yml
+++ b/toolbox/vagrant/vagrant-config.yml
@@ -8,7 +8,7 @@ libvirt:
   uri: qemu:///session
   system_uri: qemu:///system
   storage_pool_path: ~/.local/share/libvirt/images
-  emulator_path: /usr/libexec/qemu-kvm
+  emulator_path: /usr/bin/qemu-kvm
   management_network_device: virbr0
   video_type: virtio
   graphics_type: vnc

--- a/toolbox/vagrant/vagrant-config.yml
+++ b/toolbox/vagrant/vagrant-config.yml
@@ -1,10 +1,14 @@
 libvirt:
-  box: fedora36
+  box: centos-stream9
   default_prefix: os_migrate_
   storage_pool_name: vagrant
+  machine_type: q35
   suspend_mode: managedsave
   qemu_use_session: true
   uri: qemu:///session
   system_uri: qemu:///system
   storage_pool_path: ~/.local/share/libvirt/images
+  emulator_path: /usr/libexec/qemu-kvm
   management_network_device: virbr0
+  video_type: virtio
+  graphics_type: vnc

--- a/toolbox/vagrant/vagrant-sync/preconfigure.sh
+++ b/toolbox/vagrant/vagrant-sync/preconfigure.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-dnf -y update

--- a/toolbox/vagrant/vagrant-up
+++ b/toolbox/vagrant/vagrant-up
@@ -5,8 +5,12 @@ set -euxo pipefail
 if ! virsh pool-list | grep vagrant &> /dev/null; then
     virsh pool-create-as vagrant dir --target $HOME/.local/share/libvirt/vagrant
 fi
-if ! vagrant box list | grep fedora36 &> /dev/null; then
-    vagrant box add --name fedora36 https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-36-1.5.x86_64.vagrant-libvirt.box
+if ! vagrant box list | grep centos-stream9 &> /dev/null; then
+    vagrant box add --name centos-stream9 https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-latest.x86_64.vagrant-libvirt.box
+fi
+
+if ! vagrant plugin list | grep vagrant-libvirt &> /dev/null; then
+    vagrant plugin install vagrant-libvirt
 fi
 
 vagrant up

--- a/toolbox/vagrant/vagrant-up
+++ b/toolbox/vagrant/vagrant-up
@@ -9,8 +9,8 @@ if ! vagrant box list | grep centos-stream9 &> /dev/null; then
     vagrant box add --name centos-stream9 https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-latest.x86_64.vagrant-libvirt.box
 fi
 
-if ! vagrant plugin list | grep vagrant-libvirt &> /dev/null; then
-    vagrant plugin install vagrant-libvirt
+if ! vagrant plugin list --local | grep vagrant-libvirt &> /dev/null; then
+    vagrant plugin install --local --plugin-version 0.12.2 vagrant-libvirt
 fi
 
 vagrant up


### PR DESCRIPTION
- The base image for the toolbox container has been updated to Fedora 40.
- The base image for Vagrant has been switched from Fedora 36 to CentOS Stream 9.
- Python packages have been updated and pinned to their latest stable versions.
- Official vagrant build will be used and vagrant-livirt plugin will be installed from upstream.
- Devstack is now configured on `2023.1` branch.