### PR TITLE
dev: add passlib as requirement

### DIFF
--- a/toolbox/build/venv-requirements.txt
+++ b/toolbox/build/venv-requirements.txt
@@ -1,5 +1,6 @@
 # env
 wheel==0.44.0
+passlib==1.7.4
 
 # runtime
 ansible-core==2.17.5


### PR DESCRIPTION
passlib is required by `password_hash` ansible filter and its absence led to a failure while executing a change password task