### PR TITLE
dev: fixes for e2e tests

### DIFF
--- a/os_migrate/playbooks/export_workloads.yml
+++ b/os_migrate/playbooks/export_workloads.yml
@@ -1,6 +1,6 @@
 - hosts: migrator
   environment:
-    OS_BLOCK_STORAGE_DEFAULT_MICROVERSION: 3.10
+    OS_BLOCK_STORAGE_DEFAULT_MICROVERSION: 3.59
     OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   roles:
     - os_migrate.os_migrate.export_workloads

--- a/os_migrate/roles/conversion_host_content/tasks/centos.yml
+++ b/os_migrate/roles/conversion_host_content/tasks/centos.yml
@@ -15,7 +15,7 @@
       - nbdkit
       - nbdkit-basic-plugins
       - qemu-img
-      - libguestfs-tools
+      - guestfs-tools
       - libvirt
     state: present
 

--- a/tests/e2e/tasks/tenant/run_workload.yml
+++ b/tests/e2e/tasks/tenant/run_workload.yml
@@ -52,10 +52,8 @@
     - name: verify data contents
       ansible.builtin.assert:
         that:
-          - (resources |
-            json_query("[?params.name ==
-            'osm_server'].params.name")
-            == ['osm_server'])
+          - ( item | json_query('params.name') == 'osm_server' )
+      loop: "{{ resources }}"
 
     - name: import workloads
       ansible.builtin.include_role:

--- a/tests/e2e/tasks/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tasks/tenant/seed_pre_workload.yml
@@ -139,7 +139,7 @@
 
 - name: fetch cirros image
   ansible.builtin.get_url:
-    url: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+    url: https://download.cirros-cloud.net/0.6.3/cirros-0.6.3-x86_64-disk.img
     dest: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
     mode: 0600
 
@@ -149,7 +149,7 @@
     name: osm_image
     filename: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
     container_format: bare
-    disk_format: raw
+    disk_format: qcow2
     min_disk: 1
     min_ram: 128
     state: present

--- a/tests/e2e/test_as_admin.yml
+++ b/tests/e2e/test_as_admin.yml
@@ -7,7 +7,7 @@
 - name: Migration tests
   hosts: migrator
   environment:
-    OS_BLOCK_STORAGE_DEFAULT_MICROVERSION: 3.10
+    OS_BLOCK_STORAGE_DEFAULT_MICROVERSION: 3.59
     OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   tasks:
     - name: clean the environment

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -26,7 +26,7 @@
 - name: Migration tests
   hosts: migrator
   environment:
-    OS_BLOCK_STORAGE_DEFAULT_MICROVERSION: 3.10
+    OS_BLOCK_STORAGE_DEFAULT_MICROVERSION: 3.59
     OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
   tasks:
     - name: clean workloads

--- a/tests/func/tasks/tenant/seed/image.yml
+++ b/tests/func/tasks/tenant/seed/image.yml
@@ -6,7 +6,7 @@
 
 - name: fetch cirros image
   ansible.builtin.get_url:
-    url: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+    url: https://download.cirros-cloud.net/0.6.3/cirros-0.6.3-x86_64-disk.img
     dest: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
     mode: 0600
 
@@ -16,7 +16,7 @@
     name: osm_image
     filename: "{{ os_migrate_tests_tmp_dir }}/test_inputs/cirros.img"
     container_format: bare
-    disk_format: raw
+    disk_format: qcow2
     min_disk: 1
     min_ram: 128
     state: present


### PR DESCRIPTION
* Bump `OS_BLOCK_STORAGE_DEFAULT_MICROVERSION` variable to `3.59` so the
  `volume attachment` API can be used.
* Fix `guestfs-tools` package name for EL9 based vm.
* Fix assertion for `workloads.yaml` file content.
* Bump `CirrOS` image version to `0.6.3`.
* Fix the value of `disk_format` of the CirrOS image during its import.
