### PR TITLE
Pin `openstack.cloud` collection to the last v2.3.x available version

### DIFF
--- a/.github/workflows/consistency-functional.yml
+++ b/.github/workflows/consistency-functional.yml
@@ -2,7 +2,7 @@ name: consistency-functional
 on:
   push:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
     branches:
       - main
   pull_request:
@@ -11,7 +11,7 @@ on:
   # there is a CI failure related to a
   # problem deploying DevStack.
   schedule:
-    - cron: '0 */8 * * *'
+    - cron: "0 */8 * * *"
 
 jobs:
   # TODO: Add a previous job that:
@@ -24,7 +24,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ansible-version: ['latest']
+        ansible-version: ["latest"]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -93,14 +93,13 @@ jobs:
           git log --oneline | head -n50
           make lint-commit-messages
 
-
   functional:
     needs: build
     runs-on: ubuntu-20.04
     strategy:
       max-parallel: 4
       matrix:
-        ansible-version: ['latest']
+        ansible-version: ["latest"]
     services:
       rabbitmq:
         image: rabbitmq:3
@@ -251,7 +250,7 @@ jobs:
           sudo chown root:root /bin
       - name: Clone devstack
         run: |
-          git clone --single-branch --branch 'stable/2023.1' https://opendev.org/openstack/devstack
+          git clone --single-branch --branch 'unmaintained/2023.1' https://opendev.org/openstack/devstack
       - name: Configure devstack
         run: |
           DIR=$(pwd)

--- a/os_migrate/galaxy.yml
+++ b/os_migrate/galaxy.yml
@@ -18,9 +18,9 @@ tags:
   - openstack
   - migrations
 dependencies:
-  community.crypto: '>=1.4.0'
-  community.general: '<5.0.0'
-  openstack.cloud: '>=2.0.0'
-repository: 'https://github.com/os-migrate/os-migrate'
-homepage: 'https://github.com/os-migrate/os-migrate'
-issues: 'https://github.com/os-migrate/os-migrate/issues'
+  community.crypto: ">=1.4.0"
+  community.general: "<5.0.0"
+  openstack.cloud: ">=2.3.0,<2.4.0"
+repository: "https://github.com/os-migrate/os-migrate"
+homepage: "https://github.com/os-migrate/os-migrate"
+issues: "https://github.com/os-migrate/os-migrate/issues"

--- a/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
+++ b/toolbox/vagrant/ansible/roles/devstack/tasks/config.yml
@@ -2,7 +2,7 @@
   ansible.builtin.git:
     repo: "https://opendev.org/openstack/devstack.git"
     dest: /home/stack/devstack
-    version: stable/2023.1
+    version: unmaintained/2023.1
     update: no
 
 - name: Render devstack config


### PR DESCRIPTION
With the release of the v2.4.x versions of the `openstack.cloud` collection, the support of tags for the `openstack.cloud.server` module has been added, but it seems that it broke our collection somehow.

We will revert this commit when the problem will be found and solved.