### PR TITLE
Fixed container tag in `toolbox-build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,8 @@ toolbox-build:
 		podman tag localhost/os_migrate_toolbox:latest localhost/os_migrate_toolbox:$$(date "+%Y_%m_%d"); \
 	else \
 		echo "Reusing the toolbox container image"; \
-		podman pull ghcr.io/os-migrate/os-migrate/os_migrate_toolbox:main; \
-		podman image tag ghcr.io/os-migrate/os-migrate/os_migrate_toolbox:main localhost/os_migrate_toolbox:latest; \
+		podman pull ghcr.io/os-migrate/os-migrate/os_migrate_toolbox:latest; \
+		podman image tag ghcr.io/os-migrate/os-migrate/os_migrate_toolbox:latest localhost/os_migrate_toolbox:latest; \
 		podman image tag localhost/os_migrate_toolbox:latest localhost/os_migrate_toolbox:$$(date "+%Y_%m_%d"); \
 		podman image list -a; \
 	fi; \


### PR DESCRIPTION
While specifying `REUSE_TOOLBOX=1` the right tag will be used.