### PR TITLE
dev: detached cinder volumes migration feature

### DIFF
--- a/docs/src/images/plantuml/detached-volume-migration-data-flow.plantuml
+++ b/docs/src/images/plantuml/detached-volume-migration-data-flow.plantuml
@@ -1,0 +1,44 @@
+@startuml
+
+participant Migrator as p_mig
+participant "Destination\nCloud" as p_dst_cloud
+participant "Destination\nConv. Host" as p_dst_host
+participant "Source\nCloud" as p_src_cloud
+participant "Source\nConv. Host" as p_src_host
+
+activate p_mig
+p_mig -> p_mig: Validate
+p_mig -> p_mig: Filter
+p_mig --> p_dst_host: Connectivity check
+p_mig --> p_src_host: Connectivity check
+
+p_mig -> p_mig: Initialize logs
+p_mig --> p_dst_cloud: Check prerequisites
+
+p_mig -> p_src_cloud ++: Attach volumes to source conv. host
+return
+p_mig -> p_src_host ++: Export volumes as localhost NBDs (network block devices)
+return
+p_mig -> p_dst_cloud ++: Create empty volumes
+return
+p_mig -> p_dst_cloud ++: Attach volumes to destination conv. host
+return
+p_mig -> p_dst_host ++: Copy volume data
+p_dst_host --> p_src_host: SSH-forward NBD ports
+p_dst_host --> p_src_host: Sparsify data
+p_dst_host --> p_src_host: Copy data (NBD => volume)
+p_dst_host --> p_src_host: Stop SSH port forwarding
+return
+
+
+p_mig -> p_src_host ++: Stop NBD exports
+return
+p_mig -> p_src_cloud ++: Detach the volumes
+return
+
+' Hidden message to make the above hnote appear before deactivation of p_mig
+p_mig -[hidden]-> p_dst_cloud
+
+deactivate p_mig
+
+@enduml

--- a/docs/src/modules/module-export_detached_volume.rst
+++ b/docs/src/modules/module-export_detached_volume.rst
@@ -1,0 +1,14 @@
+========================
+Module - export_detached_volume
+========================
+
+
+This module provides for the following ansible plugin:
+
+    * export_detached_volume
+
+
+.. ansibleautoplugin::
+   :module: os_migrate/plugins/modules/export_detached_volume.py
+   :documentation: true
+   :examples: true

--- a/docs/src/modules/module-import_volumes_export.rst
+++ b/docs/src/modules/module-import_volumes_export.rst
@@ -1,0 +1,14 @@
+=======================================
+Module - import_volumes_export
+=======================================
+
+
+This module provides for the following ansible plugin:
+
+    * import_volumes_export
+
+
+.. ansibleautoplugin::
+   :module: os_migrate/plugins/modules/import_volumes_export.py
+   :documentation: true
+   :examples: true

--- a/docs/src/modules/module-import_volumes_src_cleanup.rst
+++ b/docs/src/modules/module-import_volumes_src_cleanup.rst
@@ -1,0 +1,14 @@
+====================================
+Module - import_volumes_src_cleanup
+====================================
+
+
+This module provides for the following ansible plugin:
+
+    * import_volumes_src_cleanup
+
+
+.. ansibleautoplugin::
+   :module: os_migrate/plugins/modules/import_volumes_src_cleanup.py
+   :documentation: true
+   :examples: true

--- a/docs/src/modules/module-import_volumes_transfer.rst
+++ b/docs/src/modules/module-import_volumes_transfer.rst
@@ -1,0 +1,14 @@
+=========================================
+Module - import_volumes_transfer
+=========================================
+
+
+This module provides for the following ansible plugin:
+
+    * import_volumes_transfer
+
+
+.. ansibleautoplugin::
+   :module: os_migrate/plugins/modules/import_volumes_transfer.py
+   :documentation: true
+   :examples: true

--- a/docs/src/roles/role-export_detached_volumes.rst
+++ b/docs/src/roles/role-export_detached_volumes.rst
@@ -1,0 +1,6 @@
+=======================
+Role - export_detached_volumes
+=======================
+
+.. ansibleautoplugin::
+  :role: os_migrate/roles/export_detached_volumes

--- a/docs/src/roles/role-import_detached_volumes.rst
+++ b/docs/src/roles/role-import_detached_volumes.rst
@@ -1,0 +1,6 @@
+=======================
+Role - import_detached_volumes
+=======================
+
+.. ansibleautoplugin::
+  :role: os_migrate/roles/import_detached_volumes

--- a/docs/src/user/walkthrough.rst
+++ b/docs/src/user/walkthrough.rst
@@ -247,6 +247,69 @@ Demo
 
 |Watch the video1|
 
+Detached volume migration
+-------------------------
+
+It is possible to migrate detached volumes in the same way as we do 
+with other openstack resource types. The migration process includes 
+exporting these volumes from the source cloud onto the migrator machine,
+attaching the volume to the conversion host in source cloud, creating 
+the volume in the destination cloud and transferring the content 
+of the volumes.
+It is possible to choose the volumes to migrate using the reource filter
+
+.. code:: yaml
+
+   os_migrate_detached_volumes_filter:
+   - detached_volume1
+   - detached_volume2
+   - regex: ^myprefix_.**
+
+The above example says: Export only volumes named ``detached_volume1`` **or**
+``detached_volume2`` **or** starting with ``myprefix_``.
+
+To export the volumes it is needed to execute the playbook:
+
+.. code:: bash
+
+   $OSM_CMD $OSM_DIR/playbooks/export_detached_volumes.yml
+
+This will create detached_volumes.yml file in the data directory, similar to
+this:
+
+.. code:: yaml
+   os_migrate_version: 1.0.1
+   resources:
+   - _info:
+       attachments: []
+       id: 0e9ff1ab-fb8d-4c12-81c4-29d519d09cb9
+       is_bootable: false
+       size: 5
+     _migration_params: {}
+     params:
+       availability_zone: nova
+       description: null
+       name: test-detached-volume
+       volume_type: tripleo
+     type: openstack.network.ServerVolume
+
+You may edit the file as needed and then run the “import_detached_volumes”
+playbook to import the volumes from this file into the destination
+cloud:
+
+.. code:: bash
+
+   $OSM_CMD $OSM_DIR/playbooks/import_detached_volumes.yml
+
+Diagram
+~~~~~~~
+
+.. figure:: ../images/plantuml/render/detached-volume-migration-data-flow.png
+   :alt: Detached volume migration (data flow)
+   :width: 50%
+
+   Detached volume Migration (data flow)
+
 Workload migration
 ------------------
 

--- a/os_migrate/playbooks/export_detached_volumes.yml
+++ b/os_migrate/playbooks/export_detached_volumes.yml
@@ -1,0 +1,6 @@
+- hosts: migrator
+  environment:
+    OS_BLOCK_STORAGE_DEFAULT_MICROVERSION: 3.59
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
+  roles:
+    - os_migrate.os_migrate.export_detached_volumes

--- a/os_migrate/playbooks/import_detached_volumes.yml
+++ b/os_migrate/playbooks/import_detached_volumes.yml
@@ -1,0 +1,5 @@
+- hosts: migrator
+  environment:
+    OS_CLIENT_CONFIG_FILE: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
+  roles:
+    - os_migrate.os_migrate.import_detached_volumes

--- a/os_migrate/plugins/module_utils/resource_map.py
+++ b/os_migrate/plugins/module_utils/resource_map.py
@@ -14,6 +14,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import \
     server, \
     server_floating_ip, \
     server_port, \
+    server_volume, \
     subnet, \
     user
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
@@ -31,6 +32,7 @@ RESOURCE_MAP = {
     const.RES_TYPE_SERVER: server.Server,
     const.RES_TYPE_SERVER_FLOATING_IP: server_floating_ip.ServerFloatingIP,
     const.RES_TYPE_SERVER_PORT: server_port.ServerPort,
+    const.RES_TYPE_SERVER_VOLUME: server_volume.ServerVolume,
     const.RES_TYPE_SUBNET: subnet.Subnet,
     const.RES_TYPE_USER: user.User,
 }

--- a/os_migrate/plugins/module_utils/volume_common.py
+++ b/os_migrate/plugins/module_utils/volume_common.py
@@ -1,0 +1,1003 @@
+# pylint: disable=consider-using-with
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.server_volume \
+    import ServerVolume
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc
+import json
+import logging
+import os
+import subprocess
+import time
+import fcntl
+import errno
+
+# Default timeout for OpenStack operations
+DEFAULT_TIMEOUT = 1800
+
+# Lock to serialize volume attachments. This helps prevent device path
+# mismatches between the OpenStack SDK and /dev in the VM.
+ATTACH_LOCK_FILE_SOURCE = '/var/lock/v2v-source-volume-lock'
+ATTACH_LOCK_FILE_DESTINATION = '/var/lock/v2v-destination-volume-lock'
+
+# File containing ports used by all the nbdkit processes running on the source
+# conversion host. There is a check to see if the port is available, but this
+# should speed things up.
+PORT_MAP_FILE = '/var/run/v2v-migration-ports'
+PORT_LOCK_FILE = '/var/lock/v2v-migration-lock'  # Lock for the port map
+
+try:
+    # will be fixed in another PR
+    # pylint: disable-next=unused-import
+    from subprocess import DEVNULL
+except ImportError:
+    DEVNULL = open(os.devnull, 'r+', encoding='utf8')
+
+
+def use_lock(lock_file):
+    """ Boilerplate for functions that need to take a lock. """
+    def _decorate_lock(function):
+        def wait_for_lock(self):
+            if self.check_and_cleanup_lockfiles():
+                self.log.info("Cleaned up unused lockfiles before start")
+            for second in range(DEFAULT_TIMEOUT):
+                try:
+                    self.log.info('Waiting for lock %s...', lock_file)
+                    lock = lock_file + '.lock'
+                    pid = str(os.getpid())
+                    cmd = ['sudo', 'flock', '--timeout', '1',
+                           '--conflict-exit-code', '16', lock_file, '-c',
+                           '"( test ! -e ' + lock + ' || exit 17 ) ' +
+                           '&& echo ' + pid + ' | sudo ' + ' tee ' + lock + '"']
+                    result = self.shell.cmd_val(cmd)
+                    if result == 16:
+                        self.log.info('Another conversion has the lock.')
+                    elif result == 17:
+                        self.log.info('Another conversion is holding the lock.')
+                    elif result == 0:
+                        break
+                    time.sleep(1)
+                except subprocess.CalledProcessError as err:
+                    time.sleep(1)
+                    self.log.info('Error waiting for lock: %s', str(err))
+            else:
+                raise RuntimeError('Unable to acquire lock ' + lock_file)
+            try:
+                return function(self)
+            finally:
+                try:
+                    lock = lock_file + '.lock'
+                    result = self.shell.cmd_out(['sudo', 'rm', '-f', lock])
+                    self.log.debug('Released lock: %s', result)
+                except subprocess.CalledProcessError as err:
+                    self.log.error('Error releasing lock: %s', str(err))
+
+        return wait_for_lock
+    return _decorate_lock
+
+
+class OpenStackVolumeBase():
+    def __init__(self, openstack_connection, conversion_host_id, ssh_key_path,
+                 ssh_user, transfer_uuid, conversion_host_address=None,
+                 state_file=None, log_file=None, timeout=DEFAULT_TIMEOUT):
+        # Required common parameters:
+        # openstack_connection: OpenStack connection object
+        # conversion_host_id: ID of conversion host instance
+        # ssh_key_path: Path to SSH key authorized on conversion host
+        # ssh_user: Username to create the SSH connection
+        # transfer_uuid: UUID to mark processes on conversion hosts
+        self.conn = openstack_connection
+        self.conversion_host_id = conversion_host_id
+        self.ssh_key_path = ssh_key_path
+        self.ssh_user = ssh_user
+        self.transfer_uuid = transfer_uuid
+
+        # Optional parameters:
+        # conversion_host_address: Optional address used to override 'access_ipv4'
+        # state_file: File to hold current disk transfer state
+        # log_file: Debug log path for volume migration
+        self.conversion_host_address = conversion_host_address
+        self.state_file = state_file
+        self.log_file = log_file
+        self.timeout = timeout
+        # Configure logging
+        self.log = logging.getLogger('osp-osp')
+        log_format = logging.Formatter('%(asctime)s:%(levelname)s: ' +
+                                       '%(message)s (%(module)s:%(lineno)d)')
+        if log_file:
+            log_handler = logging.FileHandler(log_file)
+        else:
+            log_handler = logging.NullHandler()
+        log_handler.setFormatter(log_format)
+        self.log.addHandler(log_handler)
+        self.log.setLevel(logging.DEBUG)
+
+        if self._converter() is None:
+            raise RuntimeError(f'Cannot find instance {self.conversion_host_id}')
+
+        self.shell = RemoteShell(self._converter_address(), ssh_user, ssh_key_path)
+        self.shell.test_ssh_connection()
+
+        # Ports chosen for NBD export
+        self.claimed_ports = []
+
+    def _source_vm(self):
+        """
+        Changes to the VM returned by get_server_by_id are not necessarily
+        reflected in existing objects, so just get a new one every time.
+        """
+        return self.conn.get_server_by_id(self.source_instance_id)
+
+    def _test_source_vm_shutdown(self):
+        """ Make sure the source VM is shutdown, and fail if it isn't. """
+        server = self.conn.compute.get_server(self._source_vm().id)
+        if server.status != 'SHUTOFF':
+            raise RuntimeError('Source VM is not shut down!')
+
+    def delete_migrated_volumes(self):
+        """ Detach destination volumes from converter and delete them. """
+        self._detach_volumes_from_destination_converter()
+        self._delete_volumes()
+
+    def _volume_still_attached(self, volume, vm):
+        """ Check if a volume is still attached to a VM. """
+        for attachment in volume.attachments:
+            if attachment['server_id'] == vm.id:
+                return True
+        return False
+
+    def _get_volume_maybe(self, id_maybe):
+        """ Get volume by id, or None if id_maybe is None or if volume doesn't exist. """
+        if not id_maybe:
+            return None
+        return self.conn.get_volume_by_id(id_maybe)
+
+    @use_lock(ATTACH_LOCK_FILE_DESTINATION)
+    def _detach_volumes_from_destination_converter(self):
+        """ Detach volumes from conversion host. """
+        self.log.info('Detaching volumes from the destination conversion host.')
+        converter = self._converter()
+        for path, mapping in self.volume_map.items():
+            volume = self._get_volume_maybe(mapping['dest_id'])
+            if not volume:
+                continue
+            if not self._volume_still_attached(volume, converter):
+                self.log.info('Volume %s is not attached to conversion host, skipping detach.',
+                              volume['id'])
+                continue
+
+            self.log.info('Detaching volume %s.', volume['id'])
+            self.conn.detach_volume(server=converter, volume=volume,
+                                    timeout=self.timeout, wait=True)
+            for second in range(self.timeout):
+                converter = self._converter()
+                volume = self.conn.get_volume_by_id(mapping['dest_id'])
+                if not self._volume_still_attached(volume, converter):
+                    break
+                time.sleep(1)
+            else:
+                raise RuntimeError('Timed out waiting to detach volumes from '
+                                   'destination conversion host!')
+
+    def _converter_close_exports(self):
+        """
+        SSH to source conversion host and close the NBD export process.
+        """
+        self.log.info('Stopping exports from source conversion host...')
+        try:
+            pattern = "'" + self.transfer_uuid + "'"
+            pids = self.shell.cmd_out(['pgrep', '-f', pattern]).split('\n')
+            if len(pids) > 0:
+                self.log.debug('Stopping NBD export PIDs (%s)', str(pids))
+                try:
+                    self.shell.cmd_out(['sudo', 'pkill', '-f', pattern])
+                except subprocess.CalledProcessError as err:
+                    self.log.debug('Error stopping exports! %s', str(err))
+        except subprocess.CalledProcessError as err:
+            self.log.debug('Unable to get remote NBD PID! %s', str(err))
+
+        self._release_ports()
+
+    def _delete_volumes(self):
+        """ Delete destination volumes. """
+        self.log.info('Deleting migrated volumes from destination.')
+        for path, mapping in self.volume_map.items():
+            volume = self._get_volume_maybe(mapping['dest_id'])
+            if not volume:
+                continue
+            if volume.attachments:
+                self.log.warning('Volume %s is still has attachments, skipping delete.',
+                                 volume['id'])
+                continue
+
+            self.log.info('Deleting volume %s.', volume['id'])
+            self.conn.delete_volume(volume['id'], timeout=self.timeout, wait=True)
+
+    def check_process(self, pid):
+        """Check whether pid exists in the current process table."""
+        if not pid:
+            return False
+        try:
+            self.shell.cmd_val(['sudo', 'kill', '-0', str(pid)])
+        except subprocess.CalledProcessError:
+            return False
+        else:
+            return True
+
+    def check_and_cleanup_lockfiles(self):
+        """
+        Removes lockfiles found in specific directories.
+        If a lockfile is not being used by a process,
+        it is either deleted or not being used.
+        """
+        # Remove specific lockfiles
+        try:
+            # Remove specific lockfiles
+            for lockfile in [ATTACH_LOCK_FILE_SOURCE, ATTACH_LOCK_FILE_DESTINATION, PORT_LOCK_FILE]:
+                pid = None
+                try:
+                    # Use self.shell.cmd_out to run the following command on the conversion host
+                    pid = self.shell.cmd_out(['sudo', 'cat', f'{lockfile}.lock'])
+                except Exception as err:
+                    self.log.debug("Lockfile doesn't exist %s", err)
+
+                if pid:
+                    if self.check_process(pid):
+                        continue
+
+                    # The lockfile is not being used by a process, so we can remove it
+                    self.shell.cmd_val(['sudo', 'rm', '-f', lockfile + '.lock'])
+                    return True
+        except FileNotFoundError:
+            return False
+
+    def _converter(self):
+        """ Refresh server object to pick up any changes. """
+        return self.conn.get_server_by_id(self.conversion_host_id)
+
+    def _converter_address(self):
+        """ Get IP address of conversion host. """
+        if self.conversion_host_address:
+            return self.conversion_host_address
+        else:
+            return self._converter().access_ipv4
+
+    def _update_progress(self, dev_path, progress):
+        self.log.info('Transfer progress for %s: %s%%', dev_path, str(progress))
+        if self.state_file is None:
+            return
+        self.volume_map[dev_path]['progress'] = progress
+        with open(self.state_file, 'w', encoding='utf8') as state:
+            all_progress = {}
+            for path, mapping in self.volume_map.items():
+                all_progress[path] = mapping['progress']
+            json.dump(all_progress, state)
+
+    def _attach_volumes(self, conn, name, funcs):
+        """
+        Attach all volumes in the volume map to the specified conversion host.
+        Check the list of disks before and after attaching to be absolutely
+        sure the right source data gets copied to the right destination disk.
+        This is here because _attach_destination_volumes and
+        _attach_volumes_to_converter looked almost identical.
+        """
+        self.log.info('Attaching volumes to %s wrapper', name)
+        self.log.info('Volumes: %s', self.volume_map)
+        host_func, ssh_func, update_func, volume_id_func = funcs
+        self.log.info('FUNCS: %s, %s, %s, %s', host_func, ssh_func, update_func, volume_id_func)
+        for path, mapping in sorted(self.volume_map.items()):
+            volume_id = volume_id_func(mapping)
+            volume = conn.get_volume_by_id(volume_id)
+            self.log.info('Attaching %s to %s conversion host', volume_id, name)
+
+            disks_before = ssh_func(['lsblk', '--noheadings', '--list',
+                                     '--paths', '--nodeps', '--output NAME'])
+            disks_before = set(disks_before.split())
+            self.log.debug('Initial disk list: %s', disks_before)
+
+            conn.attach_volume(volume=volume, wait=True, server=host_func(),
+                               timeout=self.timeout)
+            self.log.info('Waiting for volume to appear in %s wrapper', name)
+            self._wait_for_volume_dev_path(conn, volume, host_func(),
+                                           self.timeout)
+
+            disks_after = ssh_func(['lsblk', '--noheadings', '--list',
+                                    '--paths', '--nodeps', '--output NAME'])
+            disks_after = set(disks_after.split())
+            self.log.debug('Updated disk list: %s', disks_after)
+
+            new_disks = disks_after - disks_before
+            volume = conn.get_volume_by_id(volume_id)
+            attachment = self._get_attachment(volume, host_func())
+            dev_path = attachment['device']
+            if len(new_disks) == 1:
+                if dev_path in new_disks:
+                    self.log.debug('Successfully attached new disk %s, and %s '
+                                   'conversion host path matches OpenStack.',
+                                   dev_path, name)
+                else:
+                    dev_path = new_disks.pop()
+                    self.log.debug('Successfully attached new disk %s, but %s '
+                                   'conversion host path does not match the  '
+                                   'result from OpenStack. Using internal '
+                                   'device path %s.', attachment['device'],
+                                   name, dev_path)
+            else:
+                raise RuntimeError('Got unexpected disk list after attaching '
+                                   f'volume to {name} conversion host instance. '
+                                   'Failing migration procedure to avoid '
+                                   'assigning volumes incorrectly. New '
+                                   f'disks(s) inside VM: {new_disks}, disk provided by '
+                                   f'OpenStack: {dev_path}')
+            self.volume_map[path] = update_func(mapping, dev_path)
+
+    def _get_attachment(self, volume, vm):
+        """
+        Get the attachment object from the volume with the matching server ID.
+        Convenience method for use only when the attachment is already certain.
+        """
+        for attachment in volume.attachments:
+            if attachment['server_id'] == vm.id:
+                return attachment
+        raise RuntimeError('Volume is not attached to the specified instance!')
+
+    def _wait_for_volume_dev_path(self, conn, volume, vm, timeout):
+        volume_id = volume.id
+        for second in range(timeout):
+            volume = conn.get_volume_by_id(volume_id)
+            if volume.attachments:
+                attachment = self._get_attachment(volume, vm)
+                if attachment['device'].startswith('/dev/'):
+                    return
+            time.sleep(1)
+        raise RuntimeError('Timed out waiting for volume device path!')
+
+    def __read_used_ports(self):
+        """
+        Should only be called from functions locking the port list file, e.g.
+        _find_free_port and _release_ports. Returns a set containing the ports
+        currently used by all the migrations running on this conversion host.
+        """
+        try:
+            cmd = ['sudo', 'bash', '-c',
+                   f'"test -e {PORT_MAP_FILE} || echo [] > {PORT_MAP_FILE}"']
+            result = self.shell.cmd_out(cmd)
+            if result:
+                self.log.debug('Port write result: %s', result)
+        except subprocess.CalledProcessError as err:
+            raise RuntimeError('Unable to initialize port map file!') from err
+
+        try:  # Try to read in the set of used ports
+            cmd = ['sudo', 'cat', PORT_MAP_FILE]
+            result = self.shell.cmd_out(cmd)
+            used_ports = set(json.loads(result))
+        except ValueError:
+            self.log.info('Unable to read port map from %s, re-initializing '
+                          'it...', PORT_MAP_FILE)
+            used_ports = set()
+        except subprocess.CalledProcessError as err:
+            self.log.debug('Unable to get port map! %s', str(err))
+
+        self.log.info('Currently used ports: %s', str(list(used_ports)))
+        return used_ports
+
+    def __write_used_ports(self, used_ports):
+        """
+        Should only be called from functions locking the port list file, e.g.
+        _find_free_port and _release_ports. Writes out the given port list to
+        the port list file on the current conversion host.
+        """
+        try:  # Write out port map to destination conversion host
+            cmd = ['-T', 'sudo', 'bash', '-c', '"cat > ' + PORT_MAP_FILE + '"']
+            input_json = json.dumps(list(used_ports))
+            sub = self.shell.cmd_sub(cmd, stdin=subprocess.PIPE,
+                                     stderr=subprocess.PIPE,
+                                     stdout=subprocess.PIPE,
+                                     universal_newlines=True)
+            out, err = sub.communicate(input_json)
+            if out:
+                self.log.debug('Wrote port file, stdout: %s', out)
+            if err:
+                self.log.debug('Wrote port file, stderr: %s', err)
+        except subprocess.CalledProcessError as err:
+            self.log.debug('Unable to write port map to conversion host! '
+                           'Error was: %s', str(err))
+
+    @use_lock(PORT_LOCK_FILE)
+    def _find_free_port(self):
+        """
+        Reserve ports on the current conversion host. Lock a file containing
+        the used ports, select some ports from the range that is unused, and
+        check that the port is available on the conversion host. Add this to
+        the locked file and unlock it for the next conversion.
+        """
+        used_ports = self.__read_used_ports()
+
+        # Choose ports from the available possibilities, and try to bind
+        ephemeral_ports = set(range(49152, 65535))
+        available_ports = ephemeral_ports - used_ports
+
+        try:
+            port = available_ports.pop()
+            while not self._test_port_available(port):
+                self.log.info('Port %d not available, trying another.', port)
+                used_ports.add(port)  # Mark used to avoid trying again
+                port = available_ports.pop()
+        except KeyError as err:
+            raise RuntimeError('No free ports on conversion host!') from err
+        used_ports.add(port)
+        self.__write_used_ports(used_ports)
+        self.log.info('Allocated port %d, all used: %s', port, used_ports)
+
+        self.claimed_ports.append(port)
+        return port
+
+    @use_lock(PORT_LOCK_FILE)
+    def _release_ports(self):
+        used_ports = self.__read_used_ports()
+
+        for port in self.claimed_ports:
+            try:
+                used_ports.remove(port)
+            except KeyError:
+                self.log.debug('Port already released? %d', port)
+
+        self.log.info('Cleaning used ports: %s', used_ports)
+        self.__write_used_ports(used_ports)
+
+    def _test_port_available(self, port):
+        """
+        See if a port is open on the source conversion host by trying to listen
+        on it.
+        """
+        result = self.shell.cmd_val(['timeout', '1', 'nc', '-l', str(port)])
+        # The 'timeout' command returns 124 when the command times out, meaning
+        # nc was successful and the port is free.
+        return result == 124
+
+
+class RemoteShell():
+    def __init__(self, address, ssh_user, key_path=None):
+        self.address = address
+        self.ssh_user = ssh_user
+        self.key_path = key_path
+
+    def _default_options(self):
+        options = [
+            '-o', 'BatchMode=yes',
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'ConnectTimeout=10',
+        ]
+        if self.key_path:
+            options.extend(['-i', self.key_path])
+        return options
+
+    def ssh_preamble(self):
+        """ Common options to SSH into a conversion host. """
+        preamble = ['ssh']
+        preamble.extend(self._default_options())
+        preamble.extend([self.ssh_user + '@' + self.address])
+        return preamble
+
+    def cmd_out(self, command, **kwargs):
+        """ Run command on the target conversion host and get the output. """
+        args = self.ssh_preamble()
+        args.extend(command)
+        return subprocess.check_output(args, **kwargs).decode('utf-8').strip()
+
+    def cmd_val(self, command, **kwargs):
+        """ Run command on the target conversion host and get return code. """
+        args = self.ssh_preamble()
+        args.extend(command)
+        return subprocess.call(args, **kwargs)
+
+    def cmd_sub(self, command, **kwargs):
+        """ Start a long-running command on the target conversion host. """
+        args = self.ssh_preamble()
+        args.extend(command)
+        return subprocess.Popen(args, **kwargs)
+
+    def scp_to(self, source, destination):
+        """ Copy a file to the target conversion host. """
+        command = ['scp']
+        command.extend(self._default_options())
+        remote_path = self.ssh_user + '@' + self.address + ':' + destination
+        command.extend([source, remote_path])
+        return subprocess.call(command)
+
+    def scp_from(self, source, destination, recursive=False):
+        """ Copy a file from the source conversion host. """
+        command = ['scp']
+        command.extend(self._default_options())
+        if recursive:
+            command.extend(['-r'])
+        remote_path = self.ssh_user + '@' + self.address + ':' + source
+        command.extend([remote_path, destination])
+        return subprocess.call(command)
+
+    def test_ssh_connection(self):
+        """ Quick SSH connectivity check. """
+        out = self.cmd_out(['echo connected'])
+        if out != 'connected':
+            raise RuntimeError(self.address + ': SSH test unsuccessful!')
+
+
+class OpenstackVolumeExport(OpenStackVolumeBase):
+    """ Export volumes from an OpenStack instance over NBD. """
+    def prepare_exports(self):
+        """
+        Prepare the volumes to be exported. This method needs to be implemented in the
+        class that exports the VM or the list of detached volumes
+        """
+        raise NotImplementedError("Please Implement this method")
+
+    def _get_root_and_data_volumes(self):
+        """
+        Volume mapping step one: get the IDs and sizes of all volumes.
+        Key off the original device path to eventually preserve this
+        order on the destination. This method needs to be implemented in the
+        class that exports the VM or the list of detached volumes
+        """
+        raise NotImplementedError("Please Implement this method")
+
+    def _validate_volumes_match_data(self):
+        """
+        Check that the volumes as exported into the workload metadata YAML
+        still match what is actually attached on the source VM, raise
+        an error if not.
+        """
+        scanned_volume_ids = set(map(lambda vol: vol['source_id'],
+                                     self.volume_map.values()))
+        data_volume_ids = set(map(lambda vol: vol.get('_info', {}).get('id'),
+                                  self.ser_server.params()['volumes']))
+        if data_volume_ids != scanned_volume_ids:
+            message = (
+                f"The scanned set of volumes on instance '{self.source_instance_id}' is not the same "
+                f"as in the exported data. Scanned: {scanned_volume_ids}. In data: {data_volume_ids}."
+            )
+            raise exc.InconsistentState(message)
+
+    def _detach_data_volumes_from_source(self):
+        """
+        Detach data volumes from source VM, and pretend to "detach" the boot
+        volume by creating a new volume from a snapshot of the VM. If the VM is
+        booted directly from an image, take a VM snapshot and create the new
+        volume from that snapshot.
+        Volume map step two: replace boot disk ID with this new volume's ID,
+        and record snapshot/image ID for later deletion.
+        """
+        sourcevm = self._source_vm()
+        if '/dev/vda' in self.volume_map:
+            mapping = self.volume_map['/dev/vda']
+            volume_id = mapping['source_id']
+
+            # Create a snapshot of the root volume
+            self.log.info('Boot-from-volume instance, creating boot volume snapshot')
+            root_snapshot = self.conn.create_volume_snapshot(
+                force=True, wait=True, volume_id=volume_id,
+                name=f'{self.boot_volume_prefix}{volume_id}',
+                timeout=self.timeout)
+
+            # Create a new volume from the snapshot
+            self.log.info('Creating new volume from boot volume snapshot')
+            root_volume_copy = self.conn.create_volume(
+                wait=True, name=f'{self.boot_volume_prefix}{volume_id}',
+                snapshot_id=root_snapshot.id, size=root_snapshot.size,
+                timeout=self.timeout)
+
+            # Update the volume map with the new volume ID
+            self.volume_map['/dev/vda']['source_id'] = root_volume_copy.id
+            self.volume_map['/dev/vda']['snap_id'] = root_snapshot.id
+        elif sourcevm.image and self.ser_server.migration_params()['boot_disk_copy']:
+            self.log.info('Image-based instance, boot_disk_copy enabled: creating snapshot')
+            image = self.conn.compute.create_server_image(
+                name=f'{self.boot_volume_prefix}{sourcevm.name}',
+                server=sourcevm.id,
+                wait=True,
+                timeout=self.timeout)
+            image = self.conn.get_image_by_id(image.id)  # refresh
+            if image.status != 'active':
+                raise RuntimeError(
+                    'Could not create new image of image-based instance!')
+            volume = self.conn.create_volume(
+                image=image.id, bootable=True, wait=True, name=image.name,
+                timeout=self.timeout, size=image.min_disk)
+            self.volume_map['/dev/vda'] = dict(
+                source_dev=None, source_id=volume['id'], dest_dev=None,
+                dest_id=None, snap_id=None, image_id=image.id, name=volume['name'],
+                size=volume['size'], port=None, url=None, progress=None,
+                bootable=volume['bootable'])
+            self._update_progress('/dev/vda', 0.0)
+        elif sourcevm.image and not self.ser_server.migration_params()['boot_disk_copy']:
+            self.log.info('Image-based instance, boot_disk_copy disabled: skipping boot volume')
+        else:
+            raise RuntimeError('No known boot device found for this instance!')
+
+        for path, mapping in self.volume_map.items():
+            if path != '/dev/vda':  # Detach non-root volumes
+                volume_id = mapping['source_id']
+                volume = self.conn.get_volume_by_id(volume_id)
+                self.log.info('Detaching %s from %s', volume['id'], sourcevm.id)
+                self.conn.detach_volume(server=sourcevm, volume=volume,
+                                        wait=True, timeout=self.timeout)
+
+    # Lock this part to have a better chance of the OpenStack device path
+    # matching the device path seen inside the conversion host.
+    @use_lock(ATTACH_LOCK_FILE_SOURCE)
+    def _attach_volumes_to_converter(self):
+        """
+        Attach all the source volumes to the conversion host. Volume mapping
+        step 3: fill in the volume's device path on the source conversion host.
+        """
+        def update_source(volume_mapping, dev_path):
+            volume_mapping['source_dev'] = dev_path
+            return volume_mapping
+
+        def volume_id(volume_mapping):
+            return volume_mapping['source_id']
+
+        self._attach_volumes(self.conn, 'source', (self._converter,
+                                                   self.shell.cmd_out,
+                                                   update_source, volume_id))
+
+    def _export_volumes_from_converter(self):
+        """
+        SSH to source conversion host and start an NBD export. Volume mapping
+        step 4: fill in the URL to the volume's matching NBD export.
+        """
+        self.log.info('Exporting volumes from source conversion host...')
+        for path, mapping in self.volume_map.items():
+            port = self._find_free_port()
+            volume_id = mapping['source_id']
+            disk = mapping['source_dev']
+            self.log.info('Exporting %s from volume %s', disk, volume_id)
+
+            # Fall back to qemu-nbd if nbdkit is not present
+            qemu_nbd_present = (self.shell.cmd_val(['which', 'qemu-nbd']) == 0)
+            nbdkit_present = (self.shell.cmd_val(['which', 'nbdkit']) == 0)
+            if nbdkit_present:
+                dump_plugin = ['nbdkit', '--dump-plugin', 'file']
+                file_plugin_present = (self.shell.cmd_val(dump_plugin) == 0)
+                if not file_plugin_present:
+                    self.log.info('Found nbdkit, but without file plugin.')
+            else:
+                file_plugin_present = False
+
+            if nbdkit_present and file_plugin_present:
+                cmd = ['sudo', 'nbdkit', '--exportname', self.transfer_uuid,
+                       '--ipaddr', '127.0.0.1', '--port', str(port), 'file',
+                       'file=' + disk]
+                self.log.info('Using nbdkit for export command: %s', cmd)
+            elif qemu_nbd_present:
+                cmd = ['sudo', 'qemu-nbd', '-p', str(port), '-b', '127.0.0.1',
+                       '--fork', '--verbose', '--read-only', '--persistent',
+                       '-x', self.transfer_uuid, disk]
+                self.log.info('Using qemu-nbd for export command: %s', cmd)
+            else:
+                raise RuntimeError('No supported NBD export tool available!')
+
+            self.log.info('Exporting %s over NBD, port %s', disk, str(port))
+            result = self.shell.cmd_out(cmd)
+            if result:
+                self.log.debug('Result from NBD exporter: %s', result)
+
+            # Check qemu-img info on this disk to make sure it is ready
+            self.log.info('Waiting for valid qemu-img info on all exports...')
+            for second in range(self.timeout):
+                try:
+                    cmd = ['qemu-img', 'info', 'nbd://localhost:' + str(port) +
+                           '/' + self.transfer_uuid]
+                    image_info = self.shell.cmd_out(cmd)
+                    self.log.info('qemu-img info for %s: %s', disk, image_info)
+                except subprocess.CalledProcessError as error:
+                    self.log.info('Got exception: %s', error)
+                    self.log.info('Trying again.')
+                    time.sleep(1)
+                else:
+                    self.log.info('All volume exports ready.')
+                    break
+            else:
+                raise RuntimeError('Timed out starting nbdkit exports!')
+
+            # pylint: disable=unnecessary-dict-index-lookup
+            self.volume_map[path]['port'] = port
+            self.log.info('Volume map so far: %s', self.volume_map)
+
+
+class OpenstackVolumeTransfer(OpenStackVolumeBase):
+
+    def transfer_exports(self):
+        """
+        Method to transfer volumes. This method needs to be implemented in the
+        class that transfers the VM or the list of detached volumes
+        """
+        raise NotImplementedError("Please Implement this method")
+
+    def _create_forwarding_process(self):
+        """
+        Find free ports on the destination conversion host and set up SSH
+        forwarding to the NBD ports listening on the source conversion host.
+        """
+        # It is expected that key authorization has already been set up from
+        # the destination conversion host to the source conversion host!
+        source_shell = RemoteShell(self.source_conversion_host_address,
+                                   ssh_user=self.shell.ssh_user)
+        forward_ports = ['-N', '-T']
+        for path, mapping in self.volume_map.items():
+            port = self._find_free_port()
+            forward = f"{port}:localhost:{mapping['port']}"
+            forward_ports.extend(['-L', forward])
+            url = 'nbd://localhost:' + str(port) + '/' + self.transfer_uuid
+            self.volume_map[path]['url'] = url
+        command = source_shell.ssh_preamble()
+        command.extend(forward_ports)
+        self.log.debug('SSH forwarding command: %s', ' '.join(command))
+        self.forwarding_process = self.shell.cmd_sub(command)
+        self.forwarding_process_command = ' '.join(command)
+
+        # Check qemu-img info on all the disks to make sure everything is ready
+        self.log.info('Waiting for valid qemu-img info on all exports...')
+        pending_disks = set(self.volume_map.keys())
+        for second in range(self.timeout):
+            try:
+                for disk in pending_disks.copy():
+                    mapping = self.volume_map[disk]
+                    url = mapping['url']
+                    cmd = ['qemu-img', 'info', url]
+                    image_info = self.shell.cmd_out(cmd)
+                    self.log.info('qemu-img info for %s: %s', disk, image_info)
+                    pending_disks.remove(disk)
+            except subprocess.CalledProcessError as error:
+                self.log.info('Got exception: %s', error)
+                self.log.info('Trying again.')
+                time.sleep(1)
+            else:
+                self.log.info('All volume exports ready.')
+                break
+        else:
+            raise RuntimeError('Timed out starting nbdkit exports!')
+
+    def _stop_forwarding_process(self):
+        self.log.info('Stopping export forwarding on source conversion host...')
+        self.log.debug('(PID was %s)', self.forwarding_process.pid)
+        if self.forwarding_process:
+            self.forwarding_process.terminate()
+
+        if self.forwarding_process_command:
+            self.log.info('Stopping forwarding from source conversion host...')
+            try:
+                pattern = 'pgrep -f "' + self.forwarding_process_command + '"'
+                pids = self.shell.cmd_out([pattern]).split('\n')
+                for pid in pids:  # There should really only be one of these
+                    try:
+                        out = self.shell.cmd_out(['sudo', 'kill', pid])
+                        self.log.debug('Stopped forwarding PID (%s). %s',
+                                       pid, out)
+                    except subprocess.CalledProcessError as err:
+                        self.log.debug('Unable to stop PID %s! %s',
+                                       pid, str(err))
+            except subprocess.CalledProcessError as err:
+                self.log.debug('Unable to get forwarding PID! %s', str(err))
+
+    def _create_destination_volumes(self):
+        """
+        Volume mapping step 5: create new volumes on the destination OpenStack,
+        and fill in dest_id with the new volumes.
+        """
+        self.log.info('Creating volumes on destination cloud')
+        attached_volumes = hasattr(self, 'ser_server')
+        if attached_volumes:
+            volumes = list(map(ServerVolume.from_data, self.ser_server.params()['volumes']))
+            src_id_volumes = {vol.info()['id']: vol for vol in volumes}
+        for path, mapping in self.volume_map.items():
+            source_id = mapping['source_id']
+            sdk_params = {
+                'name': mapping['name'],
+                'bootable': mapping['bootable'],
+                'size': mapping['size'],
+                'wait': True,
+                'timeout': self.timeout,
+            }
+            if attached_volumes:
+                if source_id in src_id_volumes:
+                    sdk_params.update(src_id_volumes[source_id].sdk_params(self.conn))
+                elif path == '/dev/vda':
+                    # This code path is exercised when the source VM has
+                    # no boot volume but is being migrated with
+                    # `boot_disk_copy: true` and a boot volume is being
+                    # created in the destination.
+                    # `None` value in boot_volume_params means we do not
+                    # want to override that parameter.
+                    boot_volume_params_defined = \
+                        dict(filter(lambda item: item[1] is not None,
+                                    self.ser_server.migration_params()['boot_volume_params'].items()))
+                    sdk_params.update(boot_volume_params_defined)
+            sdk_params.pop('volume_type', None)
+            new_volume = self.conn.create_volume(**sdk_params)
+            self.volume_map[path]['dest_id'] = new_volume.id
+
+    @use_lock(ATTACH_LOCK_FILE_DESTINATION)
+    def _attach_destination_volumes(self):
+        """
+        Volume mapping step 6: attach the new destination volumes to the
+        destination conversion host. Fill in the destination device name.
+        """
+        def update_dest(volume_mapping, dev_path):
+            volume_mapping['dest_dev'] = dev_path
+            return volume_mapping
+
+        def volume_id(volume_mapping):
+            return volume_mapping['dest_id']
+
+        self._attach_volumes(self.conn, 'destination', (self._converter,
+                                                        self.shell.cmd_out,
+                                                        update_dest,
+                                                        volume_id))
+
+    def _convert_destination_volumes(self):
+        """
+        Finally run the commands to copy the exported source volumes to the
+        local destination volumes. Attempt to sparsify the volumes to minimize
+        the amount of data sent over the network.
+        """
+        self.log.info('Converting volumes...')
+        for path, mapping in self.volume_map.items():
+            self.log.info('Converting source VM\'s %s: %s', path, str(mapping))
+            devname = os.path.basename(mapping['dest_dev'])
+            overlay = '/tmp/' + devname + '-' + self.transfer_uuid + '.qcow2'
+
+            def _log_convert(source_disk, source_format, mapping):
+                """ Write qemu-img convert progress to the wrapper log. """
+                self.log.info('Copying volume data...')
+                cmd = ['sudo', 'qemu-img', 'convert', '-p', '-f', source_format,
+                       '-O', 'host_device', source_disk, mapping['dest_dev']]
+                # Non-blocking output processing stolen from pre_copy.py
+                img_sub = self.shell.cmd_sub(cmd,
+                                             stdout=subprocess.PIPE,
+                                             stderr=subprocess.STDOUT,
+                                             stdin=DEVNULL,
+                                             universal_newlines=True, bufsize=1)
+                flags = fcntl.fcntl(img_sub.stdout, fcntl.F_GETFL)
+                flags |= os.O_NONBLOCK
+                fcntl.fcntl(img_sub.stdout, fcntl.F_SETFL, flags)
+                buf = b''
+                while img_sub.poll() is None:
+                    try:
+                        buf += os.read(img_sub.stdout.fileno(), 1)
+                    except (IOError, OSError) as err:
+                        if err.errno != errno.EAGAIN:
+                            raise
+                        time.sleep(1)
+                        continue
+                    if buf:
+                        try:
+                            matches = self.qemu_progress_re.search(buf.decode())
+                            if matches is not None:
+                                progress = float(matches.group(1))
+                                self._update_progress(path, progress)
+                                buf = b''
+                        except ValueError:
+                            self.log.debug('No match yet. %s', str(buf))
+                    else:
+                        time.sleep(1)
+                self.log.info('Conversion return code: %d', img_sub.returncode)
+                if img_sub.returncode != 0:
+                    try:
+                        out = img_sub.stdout.read()
+                    except (IOError, OSError) as err:
+                        self.log.debug('Error reading stderr? %s', str(err))
+                    raise RuntimeError('Failed to convert volume! ' + out)
+                # Just in case qemu-img returned before readline got to 100%
+                self._update_progress(path, 100.0)
+
+            try:
+                self.log.info('Attempting initial sparsify...')
+                environment = os.environ.copy()
+                environment['LIBGUESTFS_BACKEND'] = 'direct'
+
+                cmd = ['sudo', 'qemu-img', 'create', '-f', 'qcow2', '-b',
+                       mapping['url'], '-F', 'raw', overlay]
+                out = self.shell.cmd_out(cmd)
+                self.log.info('Overlay output: %s', out)
+
+                cmd = ['sudo', '--preserve-env=LIBGUESTFS_BACKEND',
+                       'virt-sparsify', '--in-place', overlay]
+                with open(self.log_file, 'a', encoding='utf8') as log_fd:
+                    img_sub = self.shell.cmd_sub(cmd,
+                                                 stdout=log_fd,
+                                                 stderr=subprocess.STDOUT,
+                                                 stdin=DEVNULL,
+                                                 env=environment)
+                    returncode = img_sub.wait()
+                    self.log.info('Sparsify return code: %d', returncode)
+                    if returncode != 0:
+                        raise RuntimeError('Failed to convert volume!')
+
+                _log_convert(overlay, 'qcow2', mapping)
+            except (OSError, RuntimeError, subprocess.CalledProcessError):
+                self.log.info('Sparsify failed, converting whole device...')
+                self.shell.cmd_val(['sudo', 'rm', '-f', overlay])
+                _log_convert(mapping['url'], 'raw', mapping)
+
+    @use_lock(ATTACH_LOCK_FILE_DESTINATION)
+    def _detach_destination_volumes(self):
+        """ Disconnect new volumes from destination conversion host. """
+        self.log.info('Detaching volumes from destination wrapper.')
+        for path, mapping in self.volume_map.items():
+            volume_id = mapping['dest_id']
+            volume = self.conn.get_volume_by_id(volume_id)
+            self.conn.detach_volume(server=self._converter(),
+                                    timeout=self.timeout,
+                                    volume=volume,
+                                    wait=True)
+
+
+class OpenstackVolumeClean(OpenStackVolumeBase):
+
+    def close_exports(self):
+        """ Put the source VM's volumes back where they were. """
+        self._converter_close_exports()
+        self._detach_volumes_from_source_converter()
+        self._attach_data_volumes_to_source()
+
+    @use_lock(ATTACH_LOCK_FILE_SOURCE)
+    def _detach_volumes_from_source_converter(self):
+        """ Detach volumes from conversion host. """
+        self.log.info('Detaching volumes from the source conversion host.')
+        converter = self._converter()
+        for path, mapping in self.volume_map.items():
+            volume = self.conn.get_volume_by_id(mapping['source_id'])
+            self.log.info('Inspecting volume %s', volume.id)
+            if mapping['source_dev'] is None:
+                self.log.info('Volume is not attached to conversion host, '
+                              'skipping detach.')
+                continue
+            self.conn.detach_volume(server=converter, volume=volume,
+                                    timeout=self.timeout, wait=True)
+            for second in range(self.timeout):
+                converter = self._converter()
+                volume = self.conn.get_volume_by_id(mapping['source_id'])
+                if not self._volume_still_attached(volume, converter):
+                    break
+                time.sleep(1)
+            else:
+                raise RuntimeError('Timed out waiting to detach volumes from '
+                                   'source conversion host!')
+
+    def _attach_data_volumes_to_source(self):
+        """ Clean up the copy of the root volume and reattach data volumes. """
+        self.log.info('Re-attaching volumes to source VM...')
+        for path, mapping in sorted(self.volume_map.items()):
+            if path == '/dev/vda':
+                # Delete the temporary copy of the source root disk
+                self.log.info('Removing copy of root volume')
+                self.conn.delete_volume(name_or_id=mapping['source_id'],
+                                        wait=True, timeout=self.timeout)
+
+                # Remove the root volume snapshot
+                if mapping['snap_id']:
+                    self.log.info('Deleting temporary root device snapshot')
+                    self.conn.delete_volume_snapshot(
+                        timeout=self.timeout, wait=True,
+                        name_or_id=mapping['snap_id'])
+
+                # Remove root image copy, for image-launched instances
+                if mapping['image_id']:
+                    self.log.info('Deleting temporary root device image')
+                    self.conn.delete_image(
+                        timeout=self.timeout, wait=True,
+                        name_or_id=mapping['image_id'])
+            else:
+                # Attach data volumes back to source VM
+                volume = self.conn.get_volume_by_id(mapping['source_id'])
+                sourcevm = self._source_vm()
+                try:
+                    self._get_attachment(volume, sourcevm)
+                except RuntimeError:
+                    self.log.info('Attaching %s back to source VM', volume.id)
+                    self.conn.attach_volume(volume=volume, server=sourcevm,
+                                            wait=True, timeout=self.timeout)
+                else:
+                    self.log.info('Volume %s is already attached to source VM',
+                                  volume.id)
+                    continue

--- a/os_migrate/plugins/modules/export_detached_volume.py
+++ b/os_migrate/plugins/modules/export_detached_volume.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: export_network
+
+short_description: Export OpenStack network
+
+extends_documentation_fragment: openstack
+
+version_added: "2.9.0"
+
+author: "OpenStack tenant migration tools (@os-migrate)"
+
+description:
+  - "Export OpenStack network definition into an OS-Migrate YAML"
+
+options:
+  auth:
+    description:
+      - Dictionary with parameters for chosen auth type.
+      - Required if 'cloud' parameter is not used.
+    required: false
+    type: dict
+  auth_type:
+    description:
+      - Auth type plugin for OpenStack. Can be omitted if using password authentication.
+    required: false
+    type: str
+  region_name:
+    description:
+      - OpenStack region name. Can be omitted if using default region.
+    required: false
+    type: str
+  path:
+    description:
+      - Resources YAML file to where network will be serialized.
+      - In case the resource file already exists, it must match the
+        os-migrate version.
+      - In case the resource of same type and name exists in the file,
+        it will be replaced.
+    required: true
+    type: str
+  name:
+    description:
+      - Name (or ID) of a Network to export.
+    required: true
+    type: str
+  availability_zone:
+    description:
+      - Availability zone.
+    required: false
+    type: str
+  cloud:
+    description:
+      - Cloud from clouds.yaml to use.
+      - Required if 'auth' parameter is not used.
+    required: false
+    type: raw
+'''
+
+EXAMPLES = '''
+- name: Export mynetwork into /opt/os-migrate/networks.yml
+  os_migrate.os_migrate.export_network:
+    path: /opt/os-migrate/networks.yml
+    name: mynetwork
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+# Import openstack module utils from ansible_collections.openstack.cloud.plugins as per ansible 3+
+try:
+    from ansible_collections.openstack.cloud.plugins.module_utils.openstack \
+        import openstack_full_argument_spec, openstack_cloud_from_module
+except ImportError:
+    # If this fails fall back to ansible < 3 imports
+    from ansible.module_utils.openstack \
+        import openstack_full_argument_spec, openstack_cloud_from_module
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import filesystem
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils import server_volume
+
+
+def run_module():
+    argument_spec = openstack_full_argument_spec(
+        path=dict(type='str', required=True),
+        volume_id=dict(type='str', required=True),
+    )
+
+    result = dict(
+        changed=False,
+        errors=[],
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        # TODO: Consider check mode. We'd fetch the resource and check
+        # if the file representation matches it.
+        # supports_check_mode=True,
+    )
+
+    sdk, conn = openstack_cloud_from_module(module)
+    sdk_volume = conn.block_storage.get_volume(module.params['volume_id'])
+    data = server_volume.ServerVolume.from_sdk(conn, sdk_volume)
+
+    if (not sdk_volume['attachments']):
+        result['changed'] = filesystem.write_or_replace_resource(
+            module.params['path'], data)
+    else:
+        result['failed'] = True
+        result['errors'] = "Volume " + module.params['volume_id'] + " is not detached"
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/import_volumes_export.py
+++ b/os_migrate/plugins/modules/import_volumes_export.py
@@ -1,0 +1,298 @@
+#!/usr/bin/python
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: import_volumes_export_volumes
+
+short_description: Create NBD exports of OpenStack volumes
+
+extends_documentation_fragment: openstack
+
+version_added: "2.9.0"
+
+author: "OpenStack tenant migration tools (@os-migrate)"
+
+description:
+  - "Take a volume from an OS-Migrate YAML structure, and export its volumes over NBD."
+
+options:
+  auth:
+    description:
+      - Required if 'cloud' param not used.
+    required: false
+    type: dict
+  auth_type:
+    description:
+      - Auth type plugin for destination OpenStack cloud. Can be omitted if using password authentication.
+    required: false
+    type: str
+  cloud:
+    description:
+      - Cloud resource from clouds.yml
+      - Required if 'auth' param not used
+    required: false
+    type: raw
+  conversion_host:
+    description:
+      - Dictionary with information about the source conversion host (address, status, name, id)
+    required: true
+    type: dict
+  data:
+    description:
+      - Data structure with server parameters as loaded from OS-Migrate volumes YAML file.
+    required: true
+    type: dict
+  ssh_key_path:
+    description:
+      - Path to an SSH private key authorized on the source cloud.
+    required: true
+    type: str
+  ssh_user:
+    description:
+      - The SSH user to connect to the conversion hosts.
+    required: true
+    type: str
+  log_dir:
+    description:
+      - Complete path for log folder.
+    required: true
+    type: str
+  timeout:
+    description:
+      - Timeout for long running operations, in seconds.
+    required: false
+    default: 1800
+    type: int
+'''
+
+EXAMPLES = '''
+import_volumes.yml:
+
+- name: expose source volume
+  os_migrate.os_migrate.import_volumes_export:
+    cloud: "{{ cloud_vars_src }}"
+    conversion_host:
+      "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+    data: "{{ detached_volumes }}"
+    ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+    log_dir: "{{ os_migrate_data_dir }}/volume_logs"
+    timeout: "{{ os_migrate_timeout }}"
+  register: exports
+'''
+
+RETURN = '''
+data:
+  description: volumes imported
+  returned: Only on success.
+  type: list
+  sample:
+    - _info:
+        attachments: []
+        id: 0e9ff1ab-fb8d-4c12-81c4-29d519d09cb9
+        is_bootable: false
+        size: 5
+      _migration_params:
+        params:
+        availability_zone: nova
+        description: null
+        name: test-detached
+        volume_type: tripleo
+      type: openstack.network.ServerVolume
+
+log_file:
+  description: log file path
+  returned: Only on success.
+  type: str
+  sample: /root/os_migrate/tests/e2e/tmp/data/volume_logs/detached_volumes.log
+
+state_file:
+  description: transfer progress file for this conversion process.
+  returned: Only on success.
+  type: str
+  sample: /root/os_migrate/tests/e2e/tmp/data/volume_logs/detached_volumes.state
+
+transfer_uuid:
+  description: UUID to identify this transfer when needed
+  returned: Only on success.
+  type: str
+  sample: 9b8a64b3-c976-4103-b34e-995e4ab9f57b
+
+volume_map:
+  description:
+    - Mapping of source volume devices to NBD export URLs.
+    - This structure only has source-related fields filled out.
+  returned: Only after successfully moving volumes on source cloud.
+  type: dict
+  sample:
+    volume_map:
+      0e9ff1ab-fb8d-4c12-81c4-29d519d09cb9:
+      bootable: false
+      dest_dev: null
+      dest_id: null
+      image_id: null
+      name: test-detached3
+      port: 49166
+      progress: 0.0
+      size: 5
+      snap_id: null
+      source_dev: /dev/vdb
+      source_id: 0e9ff1ab-fb8d-4c12-81c4-29d519d09cb9
+      url: null
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+# Import openstack module utils from ansible_collections.openstack.cloud.plugins as per ansible 3+
+try:
+    from ansible_collections.openstack.cloud.plugins.module_utils.openstack \
+        import openstack_full_argument_spec, openstack_cloud_from_module
+except ImportError:
+    # If this fails fall back to ansible < 3 imports
+    from ansible.module_utils.openstack \
+        import openstack_full_argument_spec, openstack_cloud_from_module
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.volume_common \
+    import DEFAULT_TIMEOUT, OpenstackVolumeExport
+
+import uuid
+import os
+
+
+class OpenStackSourceVolume(OpenstackVolumeExport):
+    """ Export volumes from an OpenStack instance over NBD. """
+
+    def __init__(self, openstack_connection, source_conversion_host_id,
+                 ssh_key_path, ssh_user, volume_list=None, state_file=None, log_file=None, source_conversion_host_address=None,
+                 transfer_uuid=None, timeout=DEFAULT_TIMEOUT):
+        # UUID marker for child processes on conversion hosts.
+        transfer_uuid = str(uuid.uuid4())
+
+        super().__init__(
+            openstack_connection,
+            source_conversion_host_id,
+            ssh_key_path,
+            ssh_user,
+            transfer_uuid=transfer_uuid,
+            conversion_host_address=source_conversion_host_address,
+            state_file=state_file,
+            log_file=log_file,
+            timeout=timeout,
+        )
+        # Build up a list of VolumeMappings keyed by the original device path
+        # provided by the OpenStack API. Details:
+        #   source_dev:  Device path (like /dev/vdb) on source conversion host
+        #   source_id:   Volume ID on source cloud
+        #   dest_dev:    Device path on destination conversion host
+        #   dest_id:     Volume ID on destination cloud
+        #   snap_id:     Root volumes need snapshot+new volume
+        #   image_id:    Direct-from-image VMs create temporary snapshot image
+        #   name:        Save volume name to set on destination
+        #   size:        Volume size reported by OpenStack, in GB
+        #   port:        Port used to listen for NBD connections to this volume
+        #   url:         Final NBD export on destination conversion host
+        #   progress:    Transfer progress percentage
+        #   bootable:    Boolean flag for boot disks
+        self.volume_map = {}
+        self.volume_list = volume_list
+
+    def prepare_exports(self):
+        """
+        Attach the source volume to the source conversion host, and start
+        waiting for NBD connections.
+        """
+        self._get_root_and_data_volumes()
+        self.log.info('Data in the volume: %s', self.volume_list)
+        self._attach_volumes_to_converter()
+        self._export_volumes_from_converter()
+
+    def _get_root_and_data_volumes(self):
+        """
+        Volume mapping step one: get the IDs and sizes of all volumes on the
+        source VM. Key off the original device path to eventually preserve this
+        order on the destination.
+        """
+        for s_volume in self.volume_list:
+            volume = self.conn.get_volume_by_id(s_volume['_info']['id'])
+            self.log.info('Inspecting volume: %s', volume['id'])
+            dev_path = volume['id']
+            self.volume_map[dev_path] = dict(
+                source_dev=None, source_id=volume['id'], dest_dev=None,
+                dest_id=None, snap_id=None, image_id=None, name=volume['name'],
+                size=volume['size'], port=None, url=None, progress=None,
+                bootable=volume['bootable'])
+            self._update_progress(dev_path, 0.0)
+
+
+def run_module():
+    argument_spec = openstack_full_argument_spec(
+        data=dict(type='list', required=True),
+        conversion_host=dict(type='dict', required=True),
+        ssh_key_path=dict(type='str', required=True),
+        ssh_user=dict(type='str', required=True),
+        src_conversion_host_address=dict(type='str', default=None),
+        log_dir=dict(type='str', default=None),
+        timeout=dict(type='int', default=DEFAULT_TIMEOUT),
+    )
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+    )
+
+    sdk, conn = openstack_cloud_from_module(module)
+    volume_list = module.params['data']
+
+    # Required parameters
+    source_conversion_host_id = module.params['conversion_host']['id']
+    ssh_key_path = module.params['ssh_key_path']
+    ssh_user = module.params['ssh_user']
+
+    # Optional parameters
+    source_conversion_host_address = \
+        module.params.get('src_conversion_host_address', None)
+    log_dir = module.params['log_dir']
+    timeout = module.params['timeout']
+
+    # TODO implement the names of the files in the volume_common.py
+    log_file = os.path.join(log_dir, "detached_volumes") + '.log'
+    state_file = os.path.join(log_dir, "detached_volumes") + '.state'
+
+    source_volume = OpenStackSourceVolume(
+        conn,
+        source_conversion_host_id,
+        ssh_key_path,
+        ssh_user,
+        volume_list=volume_list,
+        source_conversion_host_address=source_conversion_host_address,
+        state_file=state_file,
+        log_file=log_file,
+        timeout=timeout,
+    )
+    source_volume.prepare_exports()
+    result['log_file'] = source_volume.log_file
+    result['state_file'] = source_volume.state_file
+    result['transfer_uuid'] = source_volume.transfer_uuid
+    result['volume_map'] = source_volume.volume_map
+    result['data'] = module.params['data']
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/import_volumes_src_cleanup.py
+++ b/os_migrate/plugins/modules/import_volumes_src_cleanup.py
@@ -1,0 +1,266 @@
+#!/usr/bin/python
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: import_volumes_src_cleanup
+
+short_description: Clean up temporary volumes after a volume migration
+
+extends_documentation_fragment: openstack
+
+version_added: "2.9.0"
+
+author: "OpenStack tenant migration tools (@os-migrate)"
+
+description:
+  - Remove any temporary snapshots or volumes associated with this volume migration.
+
+options:
+  auth:
+    description:
+      - Required if 'cloud' param not used
+    required: false
+    type: dict
+  auth_type:
+    description:
+      - Auth type plugin for destination OpenStack cloud. Can be omitted if using password authentication.
+    required: false
+    type: str
+  cloud:
+    description:
+      - Cloud resource from clouds.yml
+      - Required if 'auth' param not used
+    required: false
+    type: raw
+  validate_certs:
+    description:
+      - Validate HTTPS certificates when logging in to OpenStack.
+    required: false
+    type: bool
+  conversion_host:
+    description:
+      - Dictionary with information about the source conversion host (address, status, name, id)
+    required: true
+    type: dict
+  data:
+    description:
+      - Data structure with server parameters as loaded from OS-Migrate volumes YAML file.
+    required: true
+    type: dict
+  log_file:
+    description:
+      - Path to store a log file for this conversion process.
+    required: false
+    type: str
+  state_file:
+    description:
+      - Path to store a transfer progress file for this conversion process.
+    required: false
+    type: str
+  src_conversion_host_address:
+    description:
+      - Optional IP address of the source conversion host. Without this, the
+        plugin will use the 'access_ipv4' property of the conversion host instance.
+    required: false
+    type: str
+  ssh_key_path:
+    description:
+      - Path to an SSH private key authorized on the source cloud.
+    required: true
+    type: str
+  ssh_user:
+    description:
+      - The SSH user to connect to the conversion hosts.
+    required: true
+    type: str
+  transfer_uuid:
+    description:
+      - A UUID used to keep track of this tranfer's resources on the conversion hosts.
+      - Provided by the import_volumes_export_volumes module.
+    required: true
+    type: str
+  volume_map:
+    description:
+      - Dictionary providing information about the volumes to transfer.
+      - Provided by the import_volumes_export_volumes module.
+    required: true
+    type: dict
+  timeout:
+    description:
+      - Timeout for long running operations, in seconds.
+    required: false
+    default: 1800
+    type: int
+'''
+
+EXAMPLES = '''
+- name: expose source volume
+  os_migrate.os_migrate.import_volumes_export:
+    cloud: "{{ cloud_vars_src }}"
+    conversion_host:
+      "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+    data: "{{ detached_volumes }}"
+    ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+    log_dir: "{{ os_migrate_data_dir }}/volume_logs"
+    timeout: "{{ os_migrate_timeout }}"
+  register: exports
+
+- name: transfer volumes to destination
+  os_migrate.os_migrate.import_volumes_transfer:
+    cloud: dst
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+    conversion_host:
+      "{{ os_dst_conversion_host_info.openstack_conversion_host }}"
+    ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+    transfer_uuid: "{{ exports.transfer_uuid }}"
+    src_conversion_host_address:
+      "{{ os_src_conversion_host_info.openstack_conversion_host.address }}"
+    volume_map: "{{ exports.volume_map }}"
+    log_file: "{{ exports.log_file }}"
+    state_file: "{{ exports.state_file }}"
+    timeout: "{{ os_migrate_timeout }}"
+  register: transfer
+
+- name: clean up in the source cloud after migration
+  os_migrate.os_migrate.import_volumes_src_cleanup:
+    cloud: src
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+    conversion_host: "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+    ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+    transfer_uuid: "{{ exports.transfer_uuid }}"
+    volume_map: "{{ exports.volume_map }}"
+    log_file: "{{ exports.log_file }}"
+    state_file: "{{ exports.state_file }}"
+    timeout: "{{ os_migrate_timeout }}"
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+# Import openstack module utils from ansible_collections.openstack.cloud.plugins as per ansible 3+
+try:
+    from ansible_collections.openstack.cloud.plugins.module_utils.openstack \
+        import openstack_full_argument_spec, openstack_cloud_from_module
+except ImportError:
+    # If this fails fall back to ansible < 3 imports
+    from ansible.module_utils.openstack \
+        import openstack_full_argument_spec, openstack_cloud_from_module
+
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.volume_common \
+    import DEFAULT_TIMEOUT, OpenstackVolumeClean
+
+
+class OpenStackSourceCleanup(OpenstackVolumeClean):
+    """ Removes temporary migration volumes and snapshots from source cloud. """
+
+    def __init__(self, openstack_connection, source_conversion_host_id,
+                 ssh_key_path, ssh_user, transfer_uuid,
+                 volume_map, source_conversion_host_address=None, state_file=None,
+                 log_file=None, timeout=DEFAULT_TIMEOUT):
+
+        super().__init__(
+            openstack_connection,
+            source_conversion_host_id,
+            ssh_key_path,
+            ssh_user,
+            transfer_uuid,
+            conversion_host_address=source_conversion_host_address,
+            state_file=state_file,
+            log_file=log_file,
+            timeout=timeout,
+        )
+
+        # Required unique parameters:
+        # volume_map: Volume map returned by export_volumes module
+        self.volume_map = volume_map
+
+        # This will make _release_ports clean up ports from the export module
+        for path, mapping in volume_map.items():
+            port = mapping['port']
+            self.claimed_ports.append(port)
+
+    def close_exports(self):
+        self._converter_close_exports()
+        self._detach_volumes_from_source_converter()
+
+
+def run_module():
+    argument_spec = openstack_full_argument_spec(
+        conversion_host=dict(type='dict', required=True),
+        ssh_key_path=dict(type='str', required=True),
+        ssh_user=dict(type='str', required=True),
+        transfer_uuid=dict(type='str', required=True),
+        volume_map=dict(type='dict', required=True),
+        src_conversion_host_address=dict(type='str', default=None),
+        state_file=dict(type='str', default=None),
+        log_file=dict(type='str', default=None),
+        timeout=dict(type='int', default=DEFAULT_TIMEOUT),
+    )
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+    )
+
+    sdk, conn = openstack_cloud_from_module(module)
+
+    # Required parameters
+    source_conversion_host_id = module.params['conversion_host']['id']
+    ssh_key_path = module.params['ssh_key_path']
+    ssh_user = module.params['ssh_user']
+    transfer_uuid = module.params['transfer_uuid']
+    volume_map = module.params['volume_map']
+
+    # Optional parameters
+    source_conversion_host_address = \
+        module.params.get('src_conversion_host_address', None)
+    state_file = module.params.get('state_file', None)
+    log_file = module.params.get('log_file', None)
+    timeout = module.params['timeout']
+
+    host_cleanup = OpenStackSourceCleanup(
+        conn,
+        source_conversion_host_id,
+        ssh_key_path,
+        ssh_user,
+        transfer_uuid,
+        volume_map,
+        source_conversion_host_address=source_conversion_host_address,
+        state_file=state_file,
+        log_file=log_file,
+        timeout=timeout,
+    )
+    host_cleanup.close_exports()
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/import_volumes_transfer.py
+++ b/os_migrate/plugins/modules/import_volumes_transfer.py
@@ -1,0 +1,291 @@
+#!/usr/bin/python
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: import_volumes_transfer_volumes
+
+short_description: Create destination volumes and transfer source data.
+
+extends_documentation_fragment: openstack
+
+version_added: "2.9.0"
+
+author: "OpenStack tenant migration tools (@os-migrate)"
+
+description:
+  - "Connect to the destination cloud to create new volumes, and copy data from the source cloud."
+
+options:
+  auth:
+    description:
+      - Required if 'cloud' param not used
+    required: false
+    type: dict
+  auth_type:
+    description:
+      - Auth type plugin for destination OpenStack cloud. Can be omitted if using password authentication.
+    required: false
+    type: str
+  cloud:
+    description:
+      - Cloud resource from clouds.yml
+      - Required if 'auth' param not used
+    required: false
+    type: raw
+  validate_certs:
+    description:
+      - Validate HTTPS certificates when logging in to OpenStack.
+    required: false
+    type: bool
+  conversion_host:
+    description:
+      - Dictionary with information about the destination conversion host (address, status, name, id)
+    required: true
+    type: dict
+  log_file:
+    description:
+      - Path to store a log file for this conversion process.
+    required: false
+    type: str
+  src_conversion_host_address:
+    description:
+      - Require IP address of the source conversion host.
+      - This is used by the destination conversion host to initiate data transfer.
+    required: true
+    type: str
+  ssh_key_path:
+    description:
+      - Path to an SSH private key authorized on the destination cloud.
+    required: true
+    type: str
+  ssh_user:
+    description:
+      - The SSH user to connect to the conversion hosts.
+      - Provided by the import_volumes_export_volumes module.
+    required: true
+    type: str
+  state_file:
+    description:
+      - Path to store a transfer progress file for this conversion process.
+    required: false
+    type: str
+  dst_conversion_host_address:
+    description:
+      - Optional IP address of the destination conversion host. Without this, the
+        plugin will use the 'access_ipv4' property of the conversion host instance.
+    required: false
+    type: str
+  transfer_uuid:
+    description:
+      - A UUID used to keep track of this tranfer's resources on the conversion hosts.
+      - Provided by the import_volumes_export_volumes module.
+    required: true
+    type: str
+  volume_map:
+    description:
+      - Dictionary providing information about the volumes to transfer.
+      - Provided by the import_volumes_export_volumes module.
+    required: true
+    type: dict
+  timeout:
+    description:
+      - Timeout for long running operations, in seconds.
+    required: false
+    default: 1800
+    type: int
+'''
+
+EXAMPLES = '''
+- name: expose source volume
+  os_migrate.os_migrate.import_volumes_export:
+    cloud: "{{ cloud_vars_src }}"
+    conversion_host:
+      "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+    data: "{{ detached_volumes }}"
+    ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+    log_dir: "{{ os_migrate_data_dir }}/volume_logs"
+    timeout: "{{ os_migrate_timeout }}"
+  register: exports
+
+- name: transfer volumes to destination
+  os_migrate.os_migrate.import_volumes_transfer:
+    cloud: dst
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+    conversion_host:
+      "{{ os_dst_conversion_host_info.openstack_conversion_host }}"
+    ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+    transfer_uuid: "{{ exports.transfer_uuid }}"
+    src_conversion_host_address:
+      "{{ os_src_conversion_host_info.openstack_conversion_host.address }}"
+    volume_map: "{{ exports.volume_map }}"
+    log_file: "{{ exports.log_file }}"
+    state_file: "{{ exports.state_file }}"
+    timeout: "{{ os_migrate_timeout }}"
+  register: transfer
+'''
+
+RETURN = '''
+volume_map:
+  description:
+    - Updated mapping of source volume devices to NBD export URLs.
+    - Takes the input volume_map and fills out the destination-specific fields.
+  returned: Only after successfully transferring volumes from the source cloud.
+  type: dict
+  sample:
+    volume_map:
+      0e9ff1ab-fb8d-4c12-81c4-29d519d09cb9:
+      bootable: false
+      dest_dev: null
+      dest_id: null
+      image_id: null
+      name: test-detached3
+      port: 49166
+      progress: 0.0
+      size: 5
+      snap_id: null
+      source_dev: /dev/vdb
+      source_id: 0e9ff1ab-fb8d-4c12-81c4-29d519d09cb9
+      url: null
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+# Import openstack module utils from ansible_collections.openstack.cloud.plugins as per ansible 3+
+try:
+    from ansible_collections.openstack.cloud.plugins.module_utils.openstack \
+        import openstack_full_argument_spec, openstack_cloud_from_module
+except ImportError:
+    # If this fails fall back to ansible < 3 imports
+    from ansible.module_utils.openstack \
+        import openstack_full_argument_spec, openstack_cloud_from_module
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.volume_common \
+    import OpenstackVolumeTransfer, DEFAULT_TIMEOUT
+
+import re
+
+
+class OpenStackDestinationVolume(OpenstackVolumeTransfer):
+    def __init__(self, openstack_connection, destination_conversion_host_id,
+                 ssh_key_path, ssh_user, transfer_uuid, source_conversion_host_address,
+                 volume_map, destination_conversion_host_address=None,
+                 state_file=None, log_file=None, timeout=DEFAULT_TIMEOUT):
+
+        super().__init__(
+            openstack_connection,
+            destination_conversion_host_id,
+            ssh_key_path,
+            ssh_user,
+            transfer_uuid,
+            conversion_host_address=destination_conversion_host_address,
+            state_file=state_file,
+            log_file=log_file,
+            timeout=timeout,
+        )
+
+        # Required unique parameters:
+        # source_conversion_host_address: Source conversion host IP address for
+        #                                 direct connection from destination.
+        # volume_map: Volume map returned by export_volumes module
+        self.source_conversion_host_address = source_conversion_host_address
+        self.volume_map = volume_map
+
+        # Match for qemu_img progress percentage
+        self.qemu_progress_re = re.compile(r'\((\d+\.\d+)/100%\)')
+
+        # SSH tunnel process
+        self.forwarding_process = None
+        self.forwarding_process_command = None
+
+    def transfer_exports(self):
+        try:
+            self._create_forwarding_process()
+            self._create_destination_volumes()
+            self._attach_destination_volumes()
+            self._convert_destination_volumes()
+            self._detach_destination_volumes()
+        finally:
+            self._stop_forwarding_process()
+            self._release_ports()
+            self._converter_close_exports()
+
+
+def run_module():
+    argument_spec = openstack_full_argument_spec(
+        conversion_host=dict(type='dict', required=True),
+        ssh_key_path=dict(type='str', required=True),
+        ssh_user=dict(type='str', required=True),
+        transfer_uuid=dict(type='str', required=True),
+        src_conversion_host_address=dict(type='str', required=True),
+        volume_map=dict(type='dict', required=True),
+        dst_conversion_host_address=dict(type='str', default=None),
+        state_file=dict(type='str', default=None),
+        log_file=dict(type='str', default=None),
+        timeout=dict(type='int', default=DEFAULT_TIMEOUT),
+    )
+
+    result = dict(
+        changed=False,
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+    )
+
+    sdk, conn = openstack_cloud_from_module(module)
+
+    # Required parameters
+    destination_conversion_host_id = module.params['conversion_host']['id']
+    ssh_key_path = module.params['ssh_key_path']
+    ssh_user = module.params['ssh_user']
+    transfer_uuid = module.params['transfer_uuid']
+    source_conversion_host_address = \
+        module.params['src_conversion_host_address']
+    volume_map = module.params['volume_map']
+
+    # Optional parameters
+    destination_conversion_host_address = \
+        module.params.get('dst_conversion_host_address', None)
+    state_file = module.params.get('state_file', None)
+    log_file = module.params.get('log_file', None)
+    timeout = module.params['timeout']
+
+    destination_host = OpenStackDestinationVolume(
+        conn,
+        destination_conversion_host_id,
+        ssh_key_path,
+        ssh_user,
+        transfer_uuid,
+        source_conversion_host_address,
+        volume_map,
+        destination_conversion_host_address=destination_conversion_host_address,
+        state_file=state_file,
+        log_file=log_file,
+        timeout=timeout,
+    )
+    destination_host.transfer_exports()
+    result['volume_map'] = destination_host.volume_map
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/os_migrate/plugins/modules/import_workload_transfer_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_transfer_volumes.py
@@ -289,21 +289,14 @@ except ImportError:
         import openstack_full_argument_spec, openstack_cloud_from_module
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import server
-from ansible_collections.os_migrate.os_migrate.plugins.module_utils.server_volume \
-    import ServerVolume
 
-from ansible_collections.os_migrate.os_migrate.plugins.module_utils.workload_common \
-    import OpenStackHostBase, RemoteShell, use_lock, ATTACH_LOCK_FILE_DESTINATION, DEFAULT_TIMEOUT, DEVNULL
+from ansible_collections.os_migrate.os_migrate.plugins.module_utils.volume_common \
+    import OpenstackVolumeTransfer, DEFAULT_TIMEOUT
 
-import errno
-import fcntl
-import os
 import re
-import subprocess
-import time
 
 
-class OpenStackDestinationHost(OpenStackHostBase):
+class OpenStackDestinationVolume(OpenstackVolumeTransfer):
     def __init__(self, openstack_connection, destination_conversion_host_id,
                  ssh_key_path, ssh_user, transfer_uuid, source_conversion_host_address,
                  volume_map, ser_server, destination_conversion_host_address=None,
@@ -347,221 +340,6 @@ class OpenStackDestinationHost(OpenStackHostBase):
         finally:
             self._stop_forwarding_process()
             self._release_ports()
-
-    def _create_forwarding_process(self):
-        """
-        Find free ports on the destination conversion host and set up SSH
-        forwarding to the NBD ports listening on the source conversion host.
-        """
-        # It is expected that key authorization has already been set up from
-        # the destination conversion host to the source conversion host!
-        source_shell = RemoteShell(self.source_conversion_host_address,
-                                   ssh_user=self.shell.ssh_user)
-        forward_ports = ['-N', '-T']
-        for path, mapping in self.volume_map.items():
-            port = self._find_free_port()
-            forward = f"{port}:localhost:{mapping['port']}"
-            forward_ports.extend(['-L', forward])
-            url = 'nbd://localhost:' + str(port) + '/' + self.transfer_uuid
-            self.volume_map[path]['url'] = url
-        command = source_shell.ssh_preamble()
-        command.extend(forward_ports)
-        self.log.debug('SSH forwarding command: %s', ' '.join(command))
-        self.forwarding_process = self.shell.cmd_sub(command)
-        self.forwarding_process_command = ' '.join(command)
-
-        # Check qemu-img info on all the disks to make sure everything is ready
-        self.log.info('Waiting for valid qemu-img info on all exports...')
-        pending_disks = set(self.volume_map.keys())
-        for second in range(self.timeout):
-            try:
-                for disk in pending_disks.copy():
-                    mapping = self.volume_map[disk]
-                    url = mapping['url']
-                    cmd = ['qemu-img', 'info', url]
-                    image_info = self.shell.cmd_out(cmd)
-                    self.log.info('qemu-img info for %s: %s', disk, image_info)
-                    pending_disks.remove(disk)
-            except subprocess.CalledProcessError as error:
-                self.log.info('Got exception: %s', error)
-                self.log.info('Trying again.')
-                time.sleep(1)
-            else:
-                self.log.info('All volume exports ready.')
-                break
-        else:
-            raise RuntimeError('Timed out starting nbdkit exports!')
-
-    def _stop_forwarding_process(self):
-        self.log.info('Stopping export forwarding on source conversion host...')
-        self.log.debug('(PID was %s)', self.forwarding_process.pid)
-        if self.forwarding_process:
-            self.forwarding_process.terminate()
-
-        if self.forwarding_process_command:
-            self.log.info('Stopping forwarding from source conversion host...')
-            try:
-                pattern = 'pgrep -f "' + self.forwarding_process_command + '"'
-                pids = self.shell.cmd_out([pattern]).split('\n')
-                for pid in pids:  # There should really only be one of these
-                    try:
-                        out = self.shell.cmd_out(['sudo', 'kill', pid])
-                        self.log.debug('Stopped forwarding PID (%s). %s',
-                                       pid, out)
-                    except subprocess.CalledProcessError as err:
-                        self.log.debug('Unable to stop PID %s! %s',
-                                       pid, str(err))
-            except subprocess.CalledProcessError as err:
-                self.log.debug('Unable to get forwarding PID! %s', str(err))
-
-    def _create_destination_volumes(self):
-        """
-        Volume mapping step 5: create new volumes on the destination OpenStack,
-        and fill in dest_id with the new volumes.
-        """
-        self.log.info('Creating volumes on destination cloud')
-        volumes = list(map(ServerVolume.from_data, self.ser_server.params()['volumes']))
-        src_id_volumes = {vol.info()['id']: vol for vol in volumes}
-        for path, mapping in self.volume_map.items():
-            source_id = mapping['source_id']
-            sdk_params = {
-                'name': mapping['name'],
-                'bootable': mapping['bootable'],
-                'size': mapping['size'],
-                'wait': True,
-                'timeout': self.timeout,
-            }
-            if source_id in src_id_volumes:
-                sdk_params.update(src_id_volumes[source_id].sdk_params(self.conn))
-            elif path == '/dev/vda':
-                # This code path is exercised when the source VM has
-                # no boot volume but is being migrated with
-                # `boot_disk_copy: true` and a boot volume is being
-                # created in the destination.
-                # `None` value in boot_volume_params means we do not
-                # want to override that parameter.
-                boot_volume_params_defined = \
-                    dict(filter(lambda item: item[1] is not None,
-                                self.ser_server.migration_params()['boot_volume_params'].items()))
-                sdk_params.update(boot_volume_params_defined)
-            sdk_params.pop('volume_type', None)
-            new_volume = self.conn.create_volume(**sdk_params)
-            self.volume_map[path]['dest_id'] = new_volume.id
-
-    @use_lock(ATTACH_LOCK_FILE_DESTINATION)
-    def _attach_destination_volumes(self):
-        """
-        Volume mapping step 6: attach the new destination volumes to the
-        destination conversion host. Fill in the destination device name.
-        """
-        def update_dest(volume_mapping, dev_path):
-            volume_mapping['dest_dev'] = dev_path
-            return volume_mapping
-
-        def volume_id(volume_mapping):
-            return volume_mapping['dest_id']
-
-        self._attach_volumes(self.conn, 'destination', (self._converter,
-                                                        self.shell.cmd_out,
-                                                        update_dest,
-                                                        volume_id))
-
-    def _convert_destination_volumes(self):
-        """
-        Finally run the commands to copy the exported source volumes to the
-        local destination volumes. Attempt to sparsify the volumes to minimize
-        the amount of data sent over the network.
-        """
-        self.log.info('Converting volumes...')
-        for path, mapping in self.volume_map.items():
-            self.log.info('Converting source VM\'s %s: %s', path, str(mapping))
-            devname = os.path.basename(mapping['dest_dev'])
-            overlay = '/tmp/' + devname + '-' + self.transfer_uuid + '.qcow2'
-
-            def _log_convert(source_disk, source_format, mapping):
-                """ Write qemu-img convert progress to the wrapper log. """
-                self.log.info('Copying volume data...')
-                cmd = ['sudo', 'qemu-img', 'convert', '-p', '-f', source_format,
-                       '-O', 'host_device', source_disk, mapping['dest_dev']]
-                # Non-blocking output processing stolen from pre_copy.py
-                img_sub = self.shell.cmd_sub(cmd,
-                                             stdout=subprocess.PIPE,
-                                             stderr=subprocess.STDOUT,
-                                             stdin=DEVNULL,
-                                             universal_newlines=True, bufsize=1)
-                flags = fcntl.fcntl(img_sub.stdout, fcntl.F_GETFL)
-                flags |= os.O_NONBLOCK
-                fcntl.fcntl(img_sub.stdout, fcntl.F_SETFL, flags)
-                buf = b''
-                while img_sub.poll() is None:
-                    try:
-                        buf += os.read(img_sub.stdout.fileno(), 1)
-                    except (IOError, OSError) as err:
-                        if err.errno != errno.EAGAIN:
-                            raise
-                        time.sleep(1)
-                        continue
-                    if buf:
-                        try:
-                            matches = self.qemu_progress_re.search(buf.decode())
-                            if matches is not None:
-                                progress = float(matches.group(1))
-                                self._update_progress(path, progress)
-                                buf = b''
-                        except ValueError:
-                            self.log.debug('No match yet. %s', str(buf))
-                    else:
-                        time.sleep(1)
-                self.log.info('Conversion return code: %d', img_sub.returncode)
-                if img_sub.returncode != 0:
-                    try:
-                        out = img_sub.stdout.read()
-                    except (IOError, OSError) as err:
-                        self.log.debug('Error reading stderr? %s', str(err))
-                    raise RuntimeError('Failed to convert volume! ' + out)
-                # Just in case qemu-img returned before readline got to 100%
-                self._update_progress(path, 100.0)
-
-            try:
-                self.log.info('Attempting initial sparsify...')
-                environment = os.environ.copy()
-                environment['LIBGUESTFS_BACKEND'] = 'direct'
-
-                cmd = ['sudo', 'qemu-img', 'create', '-f', 'qcow2', '-b',
-                       mapping['url'], '-F', 'raw', overlay]
-                out = self.shell.cmd_out(cmd)
-                self.log.info('Overlay output: %s', out)
-
-                cmd = ['sudo', '--preserve-env=LIBGUESTFS_BACKEND',
-                       'virt-sparsify', '--in-place', overlay]
-                with open(self.log_file, 'a', encoding='utf8') as log_fd:
-                    img_sub = self.shell.cmd_sub(cmd,
-                                                 stdout=log_fd,
-                                                 stderr=subprocess.STDOUT,
-                                                 stdin=DEVNULL,
-                                                 env=environment)
-                    returncode = img_sub.wait()
-                    self.log.info('Sparsify return code: %d', returncode)
-                    if returncode != 0:
-                        raise RuntimeError('Failed to convert volume!')
-
-                _log_convert(overlay, 'qcow2', mapping)
-            except (OSError, RuntimeError, subprocess.CalledProcessError):
-                self.log.info('Sparsify failed, converting whole device...')
-                self.shell.cmd_val(['sudo', 'rm', '-f', overlay])
-                _log_convert(mapping['url'], 'raw', mapping)
-
-    @use_lock(ATTACH_LOCK_FILE_DESTINATION)
-    def _detach_destination_volumes(self):
-        """ Disconnect new volumes from destination conversion host. """
-        self.log.info('Detaching volumes from destination wrapper.')
-        for path, mapping in self.volume_map.items():
-            volume_id = mapping['dest_id']
-            volume = self.conn.get_volume_by_id(volume_id)
-            self.conn.detach_volume(server=self._converter(),
-                                    timeout=self.timeout,
-                                    volume=volume,
-                                    wait=True)
 
 
 def run_module():
@@ -607,7 +385,7 @@ def run_module():
     log_file = module.params.get('log_file', None)
     timeout = module.params['timeout']
 
-    destination_host = OpenStackDestinationHost(
+    destination_host = OpenStackDestinationVolume(
         conn,
         destination_conversion_host_id,
         ssh_key_path,

--- a/os_migrate/roles/conversion_host/tasks/conv_host_details.yml
+++ b/os_migrate/roles/conversion_host/tasks/conv_host_details.yml
@@ -1,0 +1,77 @@
+- name: conversion host operations
+  block:
+    - name: get source conversion host address
+      os_migrate.os_migrate.os_conversion_host_info:
+        cloud: src
+        server: "{{ hostvars['os_migrate_conv_src'].os_migrate_conversion_host_name }}"
+        filters: "{{ os_migrate_src_filters }}"
+        validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+        ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+        client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+        client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+      register: os_src_conversion_host_info
+      when:
+        - item["_migration_params"]["data_copy"]|default(true)
+
+    - name: fail if source conversion host is not active
+      ansible.builtin.fail:
+        msg: The source conversion host is not running!
+      when:
+        - os_src_conversion_host_info is defined
+        - os_src_conversion_host_info.openstack_conversion_host is defined
+        - os_src_conversion_host_info.openstack_conversion_host.status != "ACTIVE"
+        - item["_migration_params"]["data_copy"]|default(true)
+
+    - name: set source convertion host address
+      ansible.builtin.set_fact:
+        os_src_conversion_host_info: "{{ os_src_conversion_host_info }}"
+
+    - name: get destination conversion host address
+      os_migrate.os_migrate.os_conversion_host_info:
+        cloud: dst
+        server: "{{ hostvars['os_migrate_conv_dst'].os_migrate_conversion_host_name }}"
+        filters: "{{ os_migrate_dst_filters }}"
+        validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+        ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+        client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+        client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+      register: os_dst_conversion_host_info
+      when:
+        - item["_migration_params"]["data_copy"]|default(true)
+
+    - name: fail if destination conversion is not active
+      ansible.builtin.fail:
+        msg: The destination conversion host is not running!
+      when:
+        - os_dst_conversion_host_info is defined
+        - os_dst_conversion_host_info.openstack_conversion_host is defined
+        - os_dst_conversion_host_info.openstack_conversion_host.status != "ACTIVE"
+        - item["_migration_params"]["data_copy"]|default(true)
+
+    - name: set destination convertion host address
+      ansible.builtin.set_fact:
+        os_dst_conversion_host_info: "{{ os_dst_conversion_host_info }}"
+
+    # Depending on the virtualization hypervisor,
+    # the conversion host machines can take too
+    # much time to start.
+
+    - name: Wait until the dst conversion host is reachable
+      ansible.builtin.wait_for:
+        port: 22
+        host: '{{ os_dst_conversion_host_info.openstack_conversion_host.address }}'
+        search_regex: OpenSSH
+        sleep: 5
+        timeout: 600
+      when:
+        - item["_migration_params"]["data_copy"]|default(true)
+
+    - name: Wait until the src conversion host is reachable
+      ansible.builtin.wait_for:
+        port: 22
+        host: '{{ os_src_conversion_host_info.openstack_conversion_host.address }}'
+        search_regex: OpenSSH
+        sleep: 5
+        timeout: 600
+      when:
+        - item["_migration_params"]["data_copy"]|default(true)

--- a/os_migrate/roles/export_detached_volumes/README.md
+++ b/os_migrate/roles/export_detached_volumes/README.md
@@ -1,0 +1,9 @@
+The role export_detached_volumes
+scans the available detached volumes in the
+source tenant, creates an id-name pairs
+of the resources to export, filters them
+based on a regular expression, and serializes
+the result in the output folder.
+
+For further information about the role export_detached_volumes refer to the
+[official docs](https://os-migrate.github.io/os-migrate/roles/role-export_detached_volumes.html).

--- a/os_migrate/roles/export_detached_volumes/defaults/main.yml
+++ b/os_migrate/roles/export_detached_volumes/defaults/main.yml
@@ -1,0 +1,2 @@
+os_migrate_volumes_filter:
+  - regex: .*

--- a/os_migrate/roles/export_detached_volumes/meta/main.yml
+++ b/os_migrate/roles/export_detached_volumes/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: os-migrate
+  role_name: export_detached_volumes
+  description: os-migrate resource
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Fedora
+      versions:
+        - "34"
+  galaxy_tags: ["osmigrate"]
+dependencies:
+  - role: os_migrate.os_migrate.prelude_src

--- a/os_migrate/roles/export_detached_volumes/tasks/main.yml
+++ b/os_migrate/roles/export_detached_volumes/tasks/main.yml
@@ -1,0 +1,30 @@
+- name: scan all volumes in src
+  openstack.cloud.volume_info:
+    cloud: src
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  register: src_volumes_info
+
+- name: filter only detached volumes
+  ansible.builtin.set_fact:
+    src_detached_volumes_info: "{{ (
+      src_volumes_info.volumes
+        | os_migrate.os_migrate.stringfilter(os_migrate_volumes_filter,
+                                             attribute='name')
+        | selectattr('status', '!=' , 'in-use')
+        | json_query('[*].{name: name, id: id}')
+        | sort(attribute='id')
+        ) }}"
+
+- name: export detached volumes
+  os_migrate.os_migrate.export_detached_volume:
+    path: "{{ os_migrate_data_dir }}/detached_volumes.yml"
+    volume_id: "{{ item['id'] }}"
+    cloud: src
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  loop: "{{ src_detached_volumes_info }}"

--- a/os_migrate/roles/import_detached_volumes/README.md
+++ b/os_migrate/roles/import_detached_volumes/README.md
@@ -1,0 +1,8 @@
+The role import_detached_volumes
+will validate the serialized data of
+the exported detached volumes, will read the exported
+metadata, and it will create the resources
+in the destination tenant.
+
+For further information about the role import_detached_volumes refer to the
+[official docs](https://os-migrate.github.io/os-migrate/roles/role-import_detached_volumes.html).

--- a/os_migrate/roles/import_detached_volumes/defaults/main.yml
+++ b/os_migrate/roles/import_detached_volumes/defaults/main.yml
@@ -1,0 +1,4 @@
+os_migrate_conversion_keypair_private_path: "{{ os_migrate_data_dir }}/conversion/ssh.key"
+os_migrate_timeout: 1800
+os_migrate_detached_volumes_filter:
+  - regex: .*

--- a/os_migrate/roles/import_detached_volumes/meta/main.yml
+++ b/os_migrate/roles/import_detached_volumes/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  author: os-migrate
+  role_name: import_detached_volumes
+  description: os-migrate resource
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Fedora
+      versions:
+        - "34"
+  galaxy_tags: ["osmigrate"]
+dependencies:
+  - role: os_migrate.os_migrate.prelude_dst
+  - role: os_migrate.os_migrate.validate_resource_files
+    vars:
+      resource_files:
+        - "{{ os_migrate_data_dir }}/detached_volumes.yml"

--- a/os_migrate/roles/import_detached_volumes/tasks/import_volumes.yml
+++ b/os_migrate/roles/import_detached_volumes/tasks/import_volumes.yml
@@ -1,0 +1,62 @@
+- name: Open cloud.yaml and set cloud variables as ansible vars
+  ansible.builtin.include_vars:
+    file: "{{ os_migrate_clouds_path|default(os_migrate_data_dir ~ '/clouds.yaml') }}"
+    name: cloud_vars
+
+- name: Set block_storage_api_version for source cloud is defined
+  ansible.builtin.set_fact:
+    cloud_vars_src: "{{ cloud_vars.clouds['src'] | combine({'block_storage_api_version' : '3'}) }}"
+
+- name: expose source volume
+  os_migrate.os_migrate.import_volumes_export:
+    cloud: "{{ cloud_vars_src }}"
+    conversion_host:
+      "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+    data: "{{ detached_volumes }}"
+    ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+    log_dir: "{{ os_migrate_data_dir }}/volume_logs"
+    timeout: "{{ os_migrate_timeout }}"
+  register: exports
+  when:
+    - item["_migration_params"]["data_copy"]|default(true)
+
+- name: transfer volumes to destination
+  os_migrate.os_migrate.import_volumes_transfer:
+    cloud: dst
+    validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+    conversion_host:
+      "{{ os_dst_conversion_host_info.openstack_conversion_host }}"
+    ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+    transfer_uuid: "{{ exports.transfer_uuid }}"
+    src_conversion_host_address:
+      "{{ os_src_conversion_host_info.openstack_conversion_host.address }}"
+    volume_map: "{{ exports.volume_map }}"
+    log_file: "{{ exports.log_file }}"
+    state_file: "{{ exports.state_file }}"
+    timeout: "{{ os_migrate_timeout }}"
+  register: transfer
+  when:
+    - item["_migration_params"]["data_copy"]|default(true)
+
+- name: clean up in the source cloud after migration
+  os_migrate.os_migrate.import_volumes_src_cleanup:
+    cloud: src
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+    conversion_host: "{{ os_src_conversion_host_info.openstack_conversion_host }}"
+    ssh_key_path: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_user: "{{ os_migrate_conversion_host_ssh_user }}"
+    transfer_uuid: "{{ exports.transfer_uuid }}"
+    volume_map: "{{ exports.volume_map }}"
+    log_file: "{{ exports.log_file }}"
+    state_file: "{{ exports.state_file }}"
+    timeout: "{{ os_migrate_timeout }}"
+  when:
+    - item["_migration_params"]["data_copy"]|default(true)

--- a/os_migrate/roles/import_detached_volumes/tasks/main.yml
+++ b/os_migrate/roles/import_detached_volumes/tasks/main.yml
@@ -1,0 +1,32 @@
+- name: read detached_volumes resource file
+  os_migrate.os_migrate.read_resources:
+    path: "{{ os_migrate_data_dir }}/detached_volumes.yml"
+  register: read_detached_volumes
+
+- name: include the conversion hosts inventory
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.conversion_host
+    tasks_from: conv_hosts_inventory.yml
+
+- name: filter detached volumes to import
+  ansible.builtin.set_fact:
+    filtered_detached_volumes: "{{ (
+      read_detached_volumes.resources
+        | os_migrate.os_migrate.stringfilter(os_migrate_detached_volumes_filter, attribute='params.name')
+        ) }}"
+
+- name: create directory for detached volumes migration logs
+  ansible.builtin.file:
+    path: "{{ os_migrate_data_dir }}/volume_logs"
+    state: directory
+    mode: '0750'
+
+- name: check data copy state and run conversion host operations
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.conversion_host
+    tasks_from: conv_host_details.yml
+
+- name: import volumes
+  ansible.builtin.include_tasks: import_volumes.yml
+  vars:
+    detached_volumes: "{{ filtered_detached_volumes }}"

--- a/os_migrate/roles/import_workloads/tasks/main.yml
+++ b/os_migrate/roles/import_workloads/tasks/main.yml
@@ -22,8 +22,9 @@
     mode: '0750'
 
 - name: check data copy state and run conversion host operations
-  ansible.builtin.include_tasks: conv_host.yml
-  loop: "{{ filtered_workloads }}"
+  ansible.builtin.include_role:
+    name: os_migrate.os_migrate.conversion_host
+    tasks_from: conv_host_details.yml
 
 - name: import workloads
   ansible.builtin.include_tasks: workload.yml

--- a/tests/e2e/tasks/tenant/clean_workload.yml
+++ b/tests/e2e/tasks/tenant/clean_workload.yml
@@ -28,6 +28,8 @@
       volume: osm_volume_one
     - server: osm_server
       volume: osm_volume_two
+    - server: os_migrate_conv
+      volume: osm_detached_volume
   # The module will fail if server or volume don't exist.
   failed_when: false
 
@@ -149,6 +151,27 @@
 - name: Remove extra volumes 2
   openstack.cloud.volume:
     display_name: osm_volume_two
+    state: absent
+    auth: "{{ item.auth }}"
+    validate_certs: "{{ item.validate_certs }}"
+    ca_cert: "{{ item.ca_cert }}"
+    client_cert: "{{ item.client_cert }}"
+    client_key: "{{ item.client_key }}"
+  loop:
+    - auth: "{{ os_migrate_src_auth }}"
+      validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+    - auth: "{{ os_migrate_dst_auth }}"
+      validate_certs: "{{ os_migrate_dst_validate_certs|default(omit) }}"
+      ca_cert: "{{ os_migrate_dst_ca_cert|default(omit) }}"
+      client_cert: "{{ os_migrate_dst_client_cert|default(omit) }}"
+      client_key: "{{ os_migrate_dst_client_key|default(omit) }}"
+
+- name: Remove detached volume
+  openstack.cloud.volume:
+    display_name: osm_detached_volume
     state: absent
     auth: "{{ item.auth }}"
     validate_certs: "{{ item.validate_certs }}"

--- a/tests/e2e/tasks/tenant/multi_volume_migration/seed_workload.yml
+++ b/tests/e2e/tasks/tenant/multi_volume_migration/seed_workload.yml
@@ -18,6 +18,17 @@
     client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
     client_key: "{{ os_migrate_src_client_key|default(omit) }}"
 
+- name: Create detached osm_volume
+  openstack.cloud.volume:
+    display_name: osm_detached_volume
+    size: 1
+    auth: "{{ os_migrate_src_auth }}"
+    validate_certs: "{{ os_migrate_src_validate_certs|default(omit) }}"
+    ca_cert: "{{ os_migrate_src_ca_cert|default(omit) }}"
+    client_cert: "{{ os_migrate_src_client_cert|default(omit) }}"
+    client_key: "{{ os_migrate_src_client_key|default(omit) }}"
+  when: test_detached_volumes|default(false)|bool
+
 - name: Create osm_server
   openstack.cloud.server:
     name: osm_server

--- a/tests/e2e/tasks/tenant/run_workload.yml
+++ b/tests/e2e/tasks/tenant/run_workload.yml
@@ -17,6 +17,14 @@
         os_migrate_workloads_filter:
           - regex: '^osm_(?!uch)'
 
+    - name: export detached volumes
+      ansible.builtin.include_role:
+        name: os_migrate.os_migrate.export_detached_volumes
+      vars:
+        os_migrate_volumes_filter:
+          - regex: '^osm_detached_volume'
+      when: test_detached_volumes|default(false)|bool
+
     - name: set boot disk copy
       ansible.builtin.replace:
         path: "{{ os_migrate_data_dir }}/workloads.yml"
@@ -54,6 +62,11 @@
         that:
           - ( item | json_query('params.name') == 'osm_server' )
       loop: "{{ resources }}"
+
+    - name: import detached volumes
+      ansible.builtin.include_role:
+        name: os_migrate.os_migrate.import_detached_volumes
+      when: test_detached_volumes|default(false)|bool
 
     - name: import workloads
       ansible.builtin.include_role:

--- a/tests/e2e/test_as_tenant.yml
+++ b/tests/e2e/test_as_tenant.yml
@@ -235,6 +235,7 @@
       tags: always
       vars:
         workload_image: "{{ os_migrate_src_osm_server_image }}"
+        test_detached_volumes: true
 
     - name: assert workloads seeded properly
       ansible.builtin.include_tasks: tasks/common/test_seeded_workloads.yml
@@ -254,6 +255,7 @@
       tags: always
       vars:
         port_creation_mode: nova
+        test_detached_volumes: true
 
     - name: clean the workloads
       ansible.builtin.include_tasks: tasks/tenant/clean_workload.yml


### PR DESCRIPTION
Additions:
* Playbooks for the import/export of detached volumes
* Roles for the import/export of detached volumes
* Modules for import/export of detached volumes
* e2e test to include a detached volume migration
* Documentation files for new roles and modules for the autodoc
* Documentation and diagrams about the new workflow

Refactor:
* All methods in the various modules related to volumes are moved to the volumes_common.py to avoid code duplication
* Conversion hosts verifications moved to the role conv_host in the conv_host_details task
* Prepare_exports method set as abstract and implemented in each module since it has a different behaviour if we are migrating detached volumes or attached to a workload