### PR TITLE
fix min_disk/size mismatch in volume_common.py when instance is image-booted …

### DIFF
--- a/plugins/module_utils/volume_common.py
+++ b/plugins/module_utils/volume_common.py
@@ -701,7 +701,7 @@ class OpenstackVolumeExport(OpenStackVolumeBase):
                 wait=True,
                 name=image.name,
                 timeout=self.timeout,
-                size=image.min_disk,
+                size=image.size // (1024**3),
             )
             self.volume_map["/dev/vda"] = dict(
                 source_dev=None,


### PR DESCRIPTION
…and boot_disk_copy is true

When migrating an image-booted instance from Openstack Rocky we stumbled upon an instance that introduced us to a supposed bug.

os-migrate triggered the creation of a snapshot. The result was a snapshot with the "Min. Disk" value of "20" even though the snapshot is 40GByte in size.

when os-migrate triggered the creation of a volume, an error along the lines of "Size of specified image is larger..." appeared.

so I think it is better to use "size" instead of "min_disk" here
