### PR TITLE
Fix incorrect //os_migrate in few places in docs

### DIFF
--- a/docs/src/devel/dev-env-setup.rst
+++ b/docs/src/devel/dev-env-setup.rst
@@ -423,4 +423,4 @@ The following environment variables can be used when running e2e tests.
 - `ROOT_DIR`: Absolute directory path to OS Migrate source. When not set the default when run using OS Migrate developer
   toolbox this is set to `/root/os_migrate`.
 - `OS_MIGRATE`: Absolute directory path to the OS Migrate ansible collection. When not set the default when run using
-  os-migrate developer toolbox this is set to `/root/.ansible/collections/ansible_collections//os_migrate`.
+  os-migrate developer toolbox this is set to `/root/.ansible/collections/ansible_collections/os_migrate/os_migrate`.

--- a/docs/src/user/install-from-galaxy.rst
+++ b/docs/src/user/install-from-galaxy.rst
@@ -46,4 +46,4 @@ To install a particular release:
    ansible-galaxy collection install os_migrate.os_migrate:<VERSION>
 
 You can find available releases at `OS Migrate Galaxy page
-<https://galaxy.ansible.com//os_migrate>`_.
+<https://galaxy.ansible.com/os_migrate/os_migrate>`_.

--- a/docs/src/user/upgrade.rst
+++ b/docs/src/user/upgrade.rst
@@ -23,7 +23,7 @@ To upgrade/downgrade to a particular release:
    ansible-galaxy collection install os_migrate.os_migrate:<VERSION>
 
 You can find available releases at `OS Migrate Galaxy page
-<https://galaxy.ansible.com//os_migrate>`_.
+<https://galaxy.ansible.com/os_migrate/os_migrate>`_.
 
 Usage notes related to upgrading
 --------------------------------

--- a/docs/src/user/walkthrough.rst
+++ b/docs/src/user/walkthrough.rst
@@ -142,7 +142,7 @@ variables in the shell:
 
 .. code:: bash
 
-   export OSM_DIR=/home/migrator/.ansible/collections/ansible_collections//os_migrate
+   export OSM_DIR=/home/migrator/.ansible/collections/ansible_collections/os_migrate/os_migrate
    export OSM_CMD="ansible-playbook -v -i $OSM_DIR/localhost_inventory.yml -e @os-migrate-vars.yml"
 
 Pre-workload migration


### PR DESCRIPTION
Closes #742
As I said in the issue, the wrong path in the walkthrough guide is especially misleading to a new user