### PR TITLE
Don't wrap jinja list in double quotes in set_fact

### DIFF
--- a/roles/export_security_group_rules/tasks/main.yml
+++ b/roles/export_security_group_rules/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create id-name pairs of security groups to export
   ansible.builtin.set_fact:
-    export_security_groups_ids_names: |
+    export_security_groups_ids_names:
       "{{ (src_security_groups_info.openstack_security_groups
         | json_query('[*].{name: name, id: id}')
           | sort(attribute='id')) }}"

--- a/roles/export_security_groups/tasks/main.yml
+++ b/roles/export_security_groups/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create id-name pairs of security groups to export
   ansible.builtin.set_fact:
-    export_security_groups_ids_names: |
+    export_security_groups_ids_names:
       "{{ (src_security_groups_info.openstack_security_groups
         | json_query('[*].{name: name, id: id}') | sort(attribute='id')) }}"
 

--- a/roles/export_user_project_role_assignments/tasks/main.yml
+++ b/roles/export_user_project_role_assignments/tasks/main.yml
@@ -13,7 +13,7 @@
 # https://github.com/os-migrate/os-migrate/issues/524
 - name: Create name tuples of user project role assignments to export
   ansible.builtin.set_fact:
-    export_user_project_role_assignments_ids_names: |
+    export_user_project_role_assignments_ids_names:
       "{{ (src_user_project_role_assignments_info.openstack_role_assignments
         | json_query('[*].{user_name: user.name, user_id: user.id,
          role_name: role.name, role_id: role.id, project_name: scope.project.name,
@@ -26,7 +26,7 @@
 # https://github.com/os-migrate/os-migrate/issues/524
 - name: Create name tuples of user project role assignments to export
   ansible.builtin.set_fact:
-    export_user_project_role_assignments_ids_names: |
+    export_user_project_role_assignments_ids_names:
       "{{ (export_user_project_role_assignments_ids_names
         | json_query('[?user_name != `VALUE_SPECIFIED_IN_NO_LOG_PARAMETER`]
           | [?role_name != `VALUE_SPECIFIED_IN_NO_LOG_PARAMETER`]
@@ -37,7 +37,7 @@
 
 - name: Filter names of user project role assignments to export
   ansible.builtin.set_fact:
-    export_user_project_role_assignments_ids_names: |
+    export_user_project_role_assignments_ids_names:
       "{{ (export_user_project_role_assignments_ids_names
         | from_yaml
         | os_migrate.os_migrate.stringfilter(os_migrate_user_filter,


### PR DESCRIPTION
Closes #744

Seems like this bug was introduced in massive reformat in 4e5809ae25fb71b5f84670c63fa0544b99b8a444