### PR TITLE
fix: Resolve ansible-test sanity failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ openstack flavor create --public \
 
 
 ### Create public network
-If your OpenStack environment doesn’t have a public network created yet, you’ll need to create one. The parameters below should work if you’re deploying your OpenStack environment with Infrared Virsh plugin. If you deployed using something else, you may need to adjust the parameters.
+If your OpenStack environment doesn't have a public network created yet, you'll need to create one. The parameters below should work if you're deploying your OpenStack environment with Infrared Virsh plugin. If you deployed using something else, you may need to adjust the parameters.
 
 ```yaml
 openstack network create \
@@ -226,7 +226,7 @@ For more useful information see; optional tags/variables to add to run a migrati
 
 
 ## Contributing
-As an open source project, OS Migrate welcomes contributions from the community at large. The following guide provides information on how to add a new role to the project and where additional testing or documentation artifacts should be added. This isn’t an exhaustive reference and is a living document subject to change as needed when the project formalizes any practice or pattern. See the
+As an open source project, OS Migrate welcomes contributions from the community at large. The following guide provides information on how to add a new role to the project and where additional testing or documentation artifacts should be added. This isn't an exhaustive reference and is a living document subject to change as needed when the project formalizes any practice or pattern. See the
 [OS Migrate developer documentation](https://os-migrate.github.io/os-migrate/devel/README.html).
 
 

--- a/plugins/module_utils/filesystem.py
+++ b/plugins/module_utils/filesystem.py
@@ -2,8 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import yaml
 from os import path
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import exc

--- a/plugins/module_utils/flavor.py
+++ b/plugins/module_utils/flavor.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_FLAVOR = openstack.compute.v2.flavor.Flavor
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_FLAVOR = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     const,
@@ -12,7 +18,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 
 class Flavor(resource.Resource):
     resource_type = const.RES_TYPE_FLAVOR
-    sdk_class = openstack.compute.v2.flavor.Flavor
+    sdk_class = OPENSTACK_SDK_FLAVOR
 
     info_from_sdk = [
         "id",

--- a/plugins/module_utils/image.py
+++ b/plugins/module_utils/image.py
@@ -3,8 +3,15 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import hashlib
-import openstack
 import os
+
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_IMAGE = openstack.image.v2.image.Image
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_IMAGE = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     const,
@@ -17,7 +24,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 class Image(resource.Resource):
 
     resource_type = const.RES_TYPE_IMAGE
-    sdk_class = openstack.image.v2.image.Image
+    sdk_class = OPENSTACK_SDK_IMAGE
 
     info_from_sdk = [
         "checksum",

--- a/plugins/module_utils/keypair.py
+++ b/plugins/module_utils/keypair.py
@@ -2,7 +2,15 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_KEYPAIR = openstack.compute.v2.keypair.Keypair
+    OPENSTACK_BAD_REQUEST = openstack.exceptions.BadRequestException
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_KEYPAIR = None
+    OPENSTACK_BAD_REQUEST = Exception
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     const,
@@ -15,7 +23,7 @@ class Keypair(resource.Resource):
     # according to https://github.com/openstack/openstacksdk/blob/a4a2a7b42ec2ae7e186b44aeb7242fddd84944f7/openstack/cloud/_compute.py#L601
     # keypairs are created with name and public key.  user is not used.
     resource_type = const.RES_TYPE_KEYPAIR
-    sdk_class = openstack.compute.v2.keypair.Keypair
+    sdk_class = OPENSTACK_SDK_KEYPAIR
 
     info_from_sdk = [
         "created_at",
@@ -97,7 +105,7 @@ class Keypair(resource.Resource):
     def _create_sdk_res(conn, sdk_params):
         try:
             return conn.compute.create_keypair(**sdk_params)
-        except openstack.exceptions.BadRequestException:
+        except OPENSTACK_BAD_REQUEST:
             sdk_params_no_type = {k: v for k, v in sdk_params.items() if k != "type"}
             return conn.compute.create_keypair(**sdk_params_no_type)
 

--- a/plugins/module_utils/network.py
+++ b/plugins/module_utils/network.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_NETWORK = openstack.network.v2.network.Network
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_NETWORK = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     common,
@@ -15,7 +21,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 class Network(resource.Resource):
 
     resource_type = const.RES_TYPE_NETWORK
-    sdk_class = openstack.network.v2.network.Network
+    sdk_class = OPENSTACK_SDK_NETWORK
 
     info_from_sdk = [
         "availability_zones",

--- a/plugins/module_utils/project.py
+++ b/plugins/module_utils/project.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_PROJECT = openstack.identity.v3.project.Project
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_PROJECT = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     const,
@@ -13,7 +19,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 
 class Project(resource.Resource):
     resource_type = const.RES_TYPE_PROJECT
-    sdk_class = openstack.identity.v3.project.Project
+    sdk_class = OPENSTACK_SDK_PROJECT
 
     info_from_sdk = [
         "domain_id",

--- a/plugins/module_utils/reference.py
+++ b/plugins/module_utils/reference.py
@@ -2,8 +2,24 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
-from openstack.exceptions import DuplicateResource, HttpException, ResourceFailure
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    from openstack.exceptions import DuplicateResource, HttpException, ResourceFailure
+    OPENSTACK_IMAGE_CLASS = openstack.image.v2.image.Image
+except ImportError:
+    HAS_OPENSTACK = False
+
+    class DuplicateResource(Exception):
+        pass
+
+    class HttpException(Exception):
+        pass
+
+    class ResourceFailure(Exception):
+        pass
+
+    OPENSTACK_IMAGE_CLASS = type(None)
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const
 
@@ -421,7 +437,7 @@ def _fetch_ref(conn, get_method, id_, required=True, get_project_info=True):
         return None
 
     if get_project_info:
-        if isinstance(resource, openstack.image.v2.image.Image):
+        if isinstance(resource, OPENSTACK_IMAGE_CLASS):
             project_name, domain_name = _fetch_project_name_and_domain_name(
                 conn, resource.owner_id
             )

--- a/plugins/module_utils/resource.py
+++ b/plugins/module_utils/resource.py
@@ -3,7 +3,20 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from copy import deepcopy
-from openstack import exceptions as os_exc
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_EXC = openstack.exceptions
+except ImportError:
+    HAS_OPENSTACK = False
+
+    class DummyException(Exception):
+        pass
+
+    class OPENSTACK_EXC:
+        ResourceFailure = DummyException
+        ResourceNotFound = DummyException
+        DuplicateResource = DummyException
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import const, exc
 
 
@@ -292,9 +305,9 @@ class Resource:
         try:
             self._refs_from_ser(conn)
         except (
-            os_exc.ResourceFailure,
-            os_exc.ResourceNotFound,
-            os_exc.DuplicateResource,
+            OPENSTACK_EXC.ResourceFailure,
+            OPENSTACK_EXC.ResourceNotFound,
+            OPENSTACK_EXC.DuplicateResource,
         ) as e:
             errors.append(f"Destination prerequisites not met: {e}")
         return errors

--- a/plugins/module_utils/router.py
+++ b/plugins/module_utils/router.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_ROUTER = openstack.network.v2.router.Router
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_ROUTER = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     common,
@@ -15,7 +21,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 class Router(resource.Resource):
 
     resource_type = const.RES_TYPE_ROUTER
-    sdk_class = openstack.network.v2.router.Router
+    sdk_class = OPENSTACK_SDK_ROUTER
 
     info_from_sdk = [
         "availability_zones",

--- a/plugins/module_utils/router_interface.py
+++ b/plugins/module_utils/router_interface.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_PORT = openstack.network.v2.port.Port
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_PORT = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     exc,
@@ -33,7 +39,7 @@ def router_ports(conn, sdk_rtr):
 class RouterInterface(resource.Resource):
 
     resource_type = const.RES_TYPE_ROUTER_INTERFACE
-    sdk_class = openstack.network.v2.port.Port
+    sdk_class = OPENSTACK_SDK_PORT
 
     info_from_sdk = [
         "id",

--- a/plugins/module_utils/security_group.py
+++ b/plugins/module_utils/security_group.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_SECURITY_GROUP = openstack.network.v2.security_group.SecurityGroup
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_SECURITY_GROUP = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     const,
@@ -13,7 +19,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 class SecurityGroup(resource.Resource):
 
     resource_type = const.RES_TYPE_SECURITYGROUP
-    sdk_class = openstack.network.v2.security_group.SecurityGroup
+    sdk_class = OPENSTACK_SDK_SECURITY_GROUP
 
     info_from_sdk = [
         "id",

--- a/plugins/module_utils/security_group_rule.py
+++ b/plugins/module_utils/security_group_rule.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_SECURITY_GROUP_RULE = openstack.network.v2.security_group_rule.SecurityGroupRule
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_SECURITY_GROUP_RULE = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     const,
@@ -14,7 +20,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 class SecurityGroupRule(resource.Resource):
 
     resource_type = const.RES_TYPE_SECURITYGROUPRULE
-    sdk_class = openstack.network.v2.security_group_rule.SecurityGroupRule
+    sdk_class = OPENSTACK_SDK_SECURITY_GROUP_RULE
 
     info_from_sdk = [
         "id",

--- a/plugins/module_utils/server.py
+++ b/plugins/module_utils/server.py
@@ -4,7 +4,13 @@ __metaclass__ = type
 
 from copy import deepcopy
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_SERVER = openstack.compute.v2.server.Server
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_SERVER = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     const,
@@ -29,7 +35,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils.server_volum
 class Server(resource.Resource):
 
     resource_type = const.RES_TYPE_SERVER
-    sdk_class = openstack.compute.v2.server.Server
+    sdk_class = OPENSTACK_SDK_SERVER
 
     info_from_sdk = [
         "created_at",

--- a/plugins/module_utils/server_floating_ip.py
+++ b/plugins/module_utils/server_floating_ip.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_FLOATING_IP = openstack.network.v2.floating_ip.FloatingIP
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_FLOATING_IP = None
 import time
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
@@ -30,7 +36,7 @@ def server_floating_ips(conn, server_ports):
 class ServerFloatingIP(resource.Resource):
 
     resource_type = const.RES_TYPE_SERVER_FLOATING_IP
-    sdk_class = openstack.network.v2.floating_ip.FloatingIP
+    sdk_class = OPENSTACK_SDK_FLOATING_IP
 
     info_from_sdk = [
         "created_at",

--- a/plugins/module_utils/server_port.py
+++ b/plugins/module_utils/server_port.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_PORT = openstack.network.v2.port.Port
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_PORT = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     exc,
@@ -58,7 +64,7 @@ def _neutron_port_has_fixed_ip(sdk_port, ip):
 class ServerPort(resource.Resource):
 
     resource_type = const.RES_TYPE_SERVER_PORT
-    sdk_class = openstack.network.v2.port.Port
+    sdk_class = OPENSTACK_SDK_PORT
 
     info_from_sdk = [
         "id",

--- a/plugins/module_utils/server_volume.py
+++ b/plugins/module_utils/server_volume.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_VOLUME = openstack.block_storage.v3.volume.Volume
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_VOLUME = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     exc,
@@ -21,7 +27,7 @@ def server_volumes(conn, sdk_res):
 class ServerVolume(resource.Resource):
 
     resource_type = const.RES_TYPE_SERVER_VOLUME
-    sdk_class = openstack.block_storage.v3.volume.Volume
+    sdk_class = OPENSTACK_SDK_VOLUME
 
     info_from_sdk = [
         "attachments",

--- a/plugins/module_utils/subnet.py
+++ b/plugins/module_utils/subnet.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_SUBNET = openstack.network.v2.subnet.Subnet
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_SUBNET = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     common,
@@ -14,7 +20,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 
 class Subnet(resource.Resource):
     resource_type = const.RES_TYPE_SUBNET
-    sdk_class = openstack.network.v2.subnet.Subnet
+    sdk_class = OPENSTACK_SDK_SUBNET
 
     info_from_sdk = [
         "created_at",
@@ -67,7 +73,7 @@ class Subnet(resource.Resource):
 
     @staticmethod
     def _create_sdk_res(conn, sdk_params):
-        if not 'gateway_ip' in sdk_params:
+        if 'gateway_ip' not in sdk_params:
             sdk_params['gateway_ip'] = None
         return conn.network.create_subnet(**sdk_params)
 

--- a/plugins/module_utils/user.py
+++ b/plugins/module_utils/user.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_USER = openstack.identity.v3.user.User
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_USER = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     const,
@@ -13,7 +19,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 
 class User(resource.Resource):
     resource_type = const.RES_TYPE_USER
-    sdk_class = openstack.identity.v3.user.User
+    sdk_class = OPENSTACK_SDK_USER
 
     info_from_sdk = [
         "id",

--- a/plugins/module_utils/user_project_role_assignment.py
+++ b/plugins/module_utils/user_project_role_assignment.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import openstack
+try:
+    import openstack
+    HAS_OPENSTACK = True
+    OPENSTACK_SDK_ROLE_ASSIGNMENT = openstack.identity.v3.role_assignment.RoleAssignment
+except ImportError:
+    HAS_OPENSTACK = False
+    OPENSTACK_SDK_ROLE_ASSIGNMENT = None
 
 from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
     const,
@@ -13,7 +19,7 @@ from ansible_collections.os_migrate.os_migrate.plugins.module_utils import (
 
 class UserProjectRoleAssignment(resource.Resource):
     resource_type = const.RES_TYPE_USER_PROJECT_ROLE_ASSIGNMENT
-    sdk_class = openstack.identity.v3.role_assignment.RoleAssignment
+    sdk_class = OPENSTACK_SDK_ROLE_ASSIGNMENT
 
     info_from_refs = [
         "project_id",

--- a/plugins/modules/export_detached_volume.py
+++ b/plugins/modules/export_detached_volume.py
@@ -13,14 +13,14 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = r"""
 ---
-module: export_network
-short_description: Export OpenStack network
+module: export_detached_volume
+short_description: Export OpenStack detached volume
 extends_documentation_fragment:
   - os_migrate.os_migrate.openstack
 version_added: "2.9.0"
 author: "OpenStack tenant migration tools (@os-migrate)"
 description:
-  - "Export OpenStack network definition into an OS-Migrate YAML"
+  - "Export OpenStack detached volume definition into an OS-Migrate YAML"
 options:
   auth:
     description:
@@ -40,22 +40,17 @@ options:
     type: str
   path:
     description:
-      - Resources YAML file to where network will be serialized.
+      - Resources YAML file to where detached volume will be serialized.
       - In case the resource file already exists, it must match the
         os-migrate version.
       - In case the resource of same type and name exists in the file,
         it will be replaced.
     required: true
     type: str
-  name:
+  volume_id:
     description:
-      - Name (or ID) of a Network to export.
+      - Volume ID of the detached volume to export.
     required: true
-    type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
     type: str
   cloud:
     description:
@@ -66,10 +61,10 @@ options:
 """
 
 EXAMPLES = r"""
-- name: Export mynetwork into /opt/os-migrate/networks.yml
-  os_migrate.os_migrate.export_network:
-    path: /opt/os-migrate/networks.yml
-    name: mynetwork
+- name: Export mydetachedvolume into /opt/os-migrate/detached_volumes.yml
+  os_migrate.os_migrate.export_detached_volume:
+    path: /opt/os-migrate/detached_volumes.yml
+    volume_id: <some-volume-uuid>
 """
 
 RETURN = r"""

--- a/plugins/modules/export_flavor.py
+++ b/plugins/modules/export_flavor.py
@@ -51,11 +51,6 @@ options:
       - Name (or ID) of a Nova Flavor to export.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/export_image_blob.py
+++ b/plugins/modules/export_image_blob.py
@@ -49,11 +49,6 @@ options:
       - Name (or ID) of a Image to export.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/export_image_meta.py
+++ b/plugins/modules/export_image_meta.py
@@ -51,11 +51,6 @@ options:
       - Name (or ID) of a Image to export.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/export_keypair.py
+++ b/plugins/modules/export_keypair.py
@@ -57,11 +57,6 @@ options:
         than the authenticated user (admin-only feature).
     required: false
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/export_network.py
+++ b/plugins/modules/export_network.py
@@ -52,11 +52,6 @@ options:
       - Name (or ID) of a Network to export.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/export_project.py
+++ b/plugins/modules/export_project.py
@@ -51,11 +51,6 @@ options:
       - Name (or ID) of a Identity Project to export.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/export_router.py
+++ b/plugins/modules/export_router.py
@@ -57,11 +57,6 @@ options:
       - Name (or ID) of a Router to export.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud configuration from clouds.yml

--- a/plugins/modules/export_router_interfaces.py
+++ b/plugins/modules/export_router_interfaces.py
@@ -51,11 +51,6 @@ options:
       - Name (or ID) of a Router to export.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud configuration from clouds.yml

--- a/plugins/modules/export_security_group.py
+++ b/plugins/modules/export_security_group.py
@@ -57,11 +57,6 @@ options:
       - Name of the security group. OS-Migrate requires unique resource names.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Clouds resource from clouds.yml

--- a/plugins/modules/export_security_group_rules.py
+++ b/plugins/modules/export_security_group_rules.py
@@ -57,11 +57,6 @@ options:
       - Name of the security group. OS-Migrate requires unique resource names.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Clouds resource from clouds.yml

--- a/plugins/modules/export_subnet.py
+++ b/plugins/modules/export_subnet.py
@@ -57,11 +57,6 @@ options:
       - Name (or ID) of a Subnet to export.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud resource from clouds.yml

--- a/plugins/modules/export_user.py
+++ b/plugins/modules/export_user.py
@@ -51,11 +51,6 @@ options:
       - Name (or ID) of a User to export.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud resource from clouds.yml

--- a/plugins/modules/export_user_project_role_assignment.py
+++ b/plugins/modules/export_user_project_role_assignment.py
@@ -17,7 +17,7 @@ module: export_user_project_role_assignment
 short_description: Export OpenStack Identity Role Assignment
 extends_documentation_fragment:
   - os_migrate.os_migrate.openstack
-version_added: "2.9"
+version_added: "2.9.0"
 author: "OpenStack tenant migration tools (@os-migrate)"
 description:
   - "Export OpenStack Identity Role Assignment definition into an OS-Migrate YAML"
@@ -60,11 +60,6 @@ options:
     description:
       - ID of a role to export the role assignment for.
     required: true
-    type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
     type: str
   cloud:
     description:

--- a/plugins/modules/export_workload.py
+++ b/plugins/modules/export_workload.py
@@ -67,11 +67,7 @@ options:
       - Dictionary with parameters for the migration procedure.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud resource from clouds.yml

--- a/plugins/modules/import_flavor.py
+++ b/plugins/modules/import_flavor.py
@@ -53,11 +53,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/import_image.py
+++ b/plugins/modules/import_image.py
@@ -53,17 +53,13 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
+    default: {}
   blob_path:
     description:
       - Path where the image blob content will be saved.
       - In case the file already exists, it is assumed that the export was
         already performed and the module doesn't overwrite it.
     required: true
-    type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
     type: str
   cloud:
     description:

--- a/plugins/modules/import_keypair.py
+++ b/plugins/modules/import_keypair.py
@@ -53,11 +53,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/import_network.py
+++ b/plugins/modules/import_network.py
@@ -54,11 +54,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/import_project.py
+++ b/plugins/modules/import_project.py
@@ -53,11 +53,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud from clouds.yaml to use.

--- a/plugins/modules/import_router.py
+++ b/plugins/modules/import_router.py
@@ -53,11 +53,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud configuration from clouds.yml

--- a/plugins/modules/import_router_interface.py
+++ b/plugins/modules/import_router_interface.py
@@ -53,11 +53,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud configuration from clouds.yml

--- a/plugins/modules/import_security_group.py
+++ b/plugins/modules/import_security_group.py
@@ -53,11 +53,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Clouds resource from clouds.yml

--- a/plugins/modules/import_security_group_rule.py
+++ b/plugins/modules/import_security_group_rule.py
@@ -53,11 +53,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Clouds resource from clouds.yml

--- a/plugins/modules/import_subnet.py
+++ b/plugins/modules/import_subnet.py
@@ -53,11 +53,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by project.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud resource from clouds.yml

--- a/plugins/modules/import_user.py
+++ b/plugins/modules/import_user.py
@@ -47,11 +47,7 @@ options:
       - Options for filtering existing resources to be looked up, e.g. by user.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Clouds resource from clouds.yml

--- a/plugins/modules/import_user_project_role_assignment.py
+++ b/plugins/modules/import_user_project_role_assignment.py
@@ -17,7 +17,7 @@ module: import_user_project_role_assignment
 short_description: Import OpenStack Identity Role Assignment
 extends_documentation_fragment:
   - os_migrate.os_migrate.openstack
-version_added: "2.9"
+version_added: "2.9.0"
 author: "OpenStack tenant migration tools (@os-migrate)"
 description:
   - "Export OpenStack Identity Role Assignment definition into an OS-Migrate YAML"
@@ -37,16 +37,17 @@ options:
       - OpenStack region name. Can be omitted if using default region.
     required: false
     type: str
+  data:
+    description:
+      - Data structure with role assignment parameters as loaded from OS-Migrate YAML file.
+    required: true
+    type: dict
   filters:
     description:
       - Options for filtering existing resources to be looked up, e.g. by role assignment.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud resource from clouds.yml.
@@ -56,11 +57,10 @@ options:
 """
 
 EXAMPLES = r"""
-- name: Import my_project into /opt/os-migrate/user_project_role_assignment.yml
+- name: Import role assignment from data
   os_migrate.os_migrate.import_user_project_role_assignment:
-    cloud: source_cloud
-    path: /opt/os-migrate/user_project_role_assignment.yml
-    name: my_project
+    cloud: destination_cloud
+    data: "{{ role_assignment_data }}"
 """
 
 RETURN = r"""

--- a/plugins/modules/import_volumes_export.py
+++ b/plugins/modules/import_volumes_export.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = r"""
 ---
-module: import_volumes_export_volumes
+module: import_volumes_export
 
 short_description: Create NBD exports of OpenStack volumes
 
@@ -53,7 +53,8 @@ options:
     description:
       - Data structure with server parameters as loaded from OS-Migrate volumes YAML file.
     required: true
-    type: dict
+    type: list
+    elements: dict
   ssh_key_path:
     description:
       - Path to an SSH private key authorized on the source cloud.
@@ -64,10 +65,17 @@ options:
       - The SSH user to connect to the conversion hosts.
     required: true
     type: str
+  src_conversion_host_address:
+    description:
+      - Source conversion host address override.
+    required: false
+    type: str
+    default: null
   log_dir:
     description:
       - Complete path for log folder.
-    required: true
+    required: false
+    default: null
     type: str
   timeout:
     description:
@@ -263,9 +271,9 @@ class OpenStackSourceVolume(OpenstackVolumeExport):
 
 def run_module():
     argument_spec = openstack_full_argument_spec(
-        data=dict(type="list", required=True),
+        data=dict(type="list", elements="dict", required=True),
         conversion_host=dict(type="dict", required=True),
-        ssh_key_path=dict(type="str", required=True),
+        ssh_key_path=dict(type="str", required=True, no_log=True),
         ssh_user=dict(type="str", required=True),
         src_conversion_host_address=dict(type="str", default=None),
         log_dir=dict(type="str", default=None),

--- a/plugins/modules/import_volumes_src_cleanup.py
+++ b/plugins/modules/import_volumes_src_cleanup.py
@@ -54,11 +54,6 @@ options:
       - Dictionary with information about the source conversion host (address, status, name, id)
     required: true
     type: dict
-  data:
-    description:
-      - Data structure with server parameters as loaded from OS-Migrate volumes YAML file.
-    required: true
-    type: dict
   log_file:
     description:
       - Path to store a log file for this conversion process.
@@ -225,7 +220,7 @@ class OpenStackSourceCleanup(OpenstackVolumeClean):
 def run_module():
     argument_spec = openstack_full_argument_spec(
         conversion_host=dict(type="dict", required=True),
-        ssh_key_path=dict(type="str", required=True),
+        ssh_key_path=dict(type="str", required=True, no_log=True),
         ssh_user=dict(type="str", required=True),
         transfer_uuid=dict(type="str", required=True),
         volume_map=dict(type="dict", required=True),

--- a/plugins/modules/import_volumes_transfer.py
+++ b/plugins/modules/import_volumes_transfer.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = r"""
 ---
-module: import_volumes_transfer_volumes
+module: import_volumes_transfer
 
 short_description: Create destination volumes and transfer source data.
 
@@ -246,7 +246,7 @@ class OpenStackDestinationVolume(OpenstackVolumeTransfer):
 def run_module():
     argument_spec = openstack_full_argument_spec(
         conversion_host=dict(type="dict", required=True),
-        ssh_key_path=dict(type="str", required=True),
+        ssh_key_path=dict(type="str", required=True, no_log=True),
         ssh_user=dict(type="str", required=True),
         transfer_uuid=dict(type="str", required=True),
         src_conversion_host_address=dict(type="str", required=True),

--- a/plugins/modules/import_workload_create_instance.py
+++ b/plugins/modules/import_workload_create_instance.py
@@ -43,11 +43,6 @@ options:
       - Destination OpenStack region name. Can be omitted if using default region.
     required: false
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud resource from clouds.yml

--- a/plugins/modules/import_workload_dst_check.py
+++ b/plugins/modules/import_workload_dst_check.py
@@ -48,11 +48,6 @@ options:
       - OpenStack region name. Can be omitted if using default region.
     required: false
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   data:
     description:
       - Data structure with server parameters as loaded from OS-Migrate workloads YAML file.
@@ -63,6 +58,7 @@ options:
       - Options for filtering the migration idempotence lookup, e.g. by project.
     required: false
     type: dict
+    default: {}
   cloud:
     description:
       - Cloud resource from clouds.yml

--- a/plugins/modules/import_workload_dst_failure_cleanup.py
+++ b/plugins/modules/import_workload_dst_failure_cleanup.py
@@ -43,11 +43,6 @@ options:
       - Destination OpenStack region name. Can be omitted if using default region.
     required: false
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud resource from clouds.yml
@@ -196,7 +191,7 @@ def run_module():
     argument_spec = openstack_full_argument_spec(
         data=dict(type="dict", required=True),
         conversion_host=dict(type="dict", required=True),
-        ssh_key_path=dict(type="str", required=True),
+        ssh_key_path=dict(type="str", required=True, no_log=True),
         ssh_user=dict(type="str", required=True),
         transfer_uuid=dict(type="str", required=True),
         volume_map=dict(type="dict", required=True),

--- a/plugins/modules/import_workload_export_volumes.py
+++ b/plugins/modules/import_workload_export_volumes.py
@@ -42,11 +42,6 @@ options:
       - Destination OpenStack region name. Can be omitted if using default region.
     required: false
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud resource from clouds.yml
@@ -374,7 +369,7 @@ def run_module():
         data=dict(type="dict", required=True),
         boot_volume_prefix=dict(type="str", default=None),
         conversion_host=dict(type="dict", required=True),
-        ssh_key_path=dict(type="str", required=True),
+        ssh_key_path=dict(type="str", required=True, no_log=True),
         ssh_user=dict(type="str", required=True),
         src_conversion_host_address=dict(type="str", default=None),
         state_file=dict(type="str", default=None),

--- a/plugins/modules/import_workload_prelim.py
+++ b/plugins/modules/import_workload_prelim.py
@@ -53,6 +53,7 @@ options:
       - Options for filtering the migration idempotence lookup, e.g. by project.
     required: false
     type: dict
+    default: {}
   src_conversion_host:
     description:
       - Dictionary with information about the source conversion host (address, status, name, id)
@@ -66,11 +67,6 @@ options:
   log_dir:
     description:
       - Directory for storing log and state files.
-    required: false
-    type: str
-  availability_zone:
-    description:
-      - Availability zone.
     required: false
     type: str
   cloud:

--- a/plugins/modules/import_workload_src_check.py
+++ b/plugins/modules/import_workload_src_check.py
@@ -53,11 +53,6 @@ options:
       - Name (or ID) of an instance to check.
     required: true
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud resource from clouds.yml

--- a/plugins/modules/import_workload_src_cleanup.py
+++ b/plugins/modules/import_workload_src_cleanup.py
@@ -43,11 +43,6 @@ options:
       - Destination OpenStack region name. Can be omitted if using default region.
     required: false
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud resource from clouds.yml
@@ -328,7 +323,7 @@ def run_module():
     argument_spec = openstack_full_argument_spec(
         data=dict(type="dict", required=True),
         conversion_host=dict(type="dict", required=True),
-        ssh_key_path=dict(type="str", required=True),
+        ssh_key_path=dict(type="str", required=True, no_log=True),
         ssh_user=dict(type="str", required=True),
         transfer_uuid=dict(type="str", required=True),
         volume_map=dict(type="dict", required=True),

--- a/plugins/modules/import_workload_transfer_volumes.py
+++ b/plugins/modules/import_workload_transfer_volumes.py
@@ -43,11 +43,6 @@ options:
       - Destination OpenStack region name. Can be omitted if using default region.
     required: false
     type: str
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
   cloud:
     description:
       - Cloud resource from clouds.yml
@@ -365,7 +360,7 @@ def run_module():
     argument_spec = openstack_full_argument_spec(
         data=dict(type="dict", required=True),
         conversion_host=dict(type="dict", required=True),
-        ssh_key_path=dict(type="str", required=True),
+        ssh_key_path=dict(type="str", required=True, no_log=True),
         ssh_user=dict(type="str", required=True),
         transfer_uuid=dict(type="str", required=True),
         src_conversion_host_address=dict(type="str", required=True),

--- a/plugins/modules/os_conversion_host_info.py
+++ b/plugins/modules/os_conversion_host_info.py
@@ -38,6 +38,7 @@ options:
       - Options for filtering the host, e.g. by project.
     required: false
     type: dict
+    default: {}
   auth:
     description:
       - Required if 'cloud' param not used.
@@ -51,11 +52,6 @@ options:
   region_name:
     description:
       - OpenStack region name. Can be omitted if using default region.
-    required: false
-    type: str
-  availability_zone:
-    description:
-      - Availability zone.
     required: false
     type: str
   cloud:
@@ -123,6 +119,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
+        supports_check_mode=True,
     )
 
     srv = module.params["server"]

--- a/plugins/modules/os_keypairs_info.py
+++ b/plugins/modules/os_keypairs_info.py
@@ -33,6 +33,7 @@ options:
       - Options for filtering the Keypairs info.
     required: false
     type: dict
+    default: {}
   auth:
     description:
       - Required if 'cloud' parameter not used.
@@ -46,11 +47,6 @@ options:
   region_name:
     description:
       - OpenStack region name. Can be omitted if using default region.
-    required: false
-    type: str
-  availability_zone:
-    description:
-      - Availability zone.
     required: false
     type: str
   cloud:

--- a/plugins/modules/os_role_assignments_info.py
+++ b/plugins/modules/os_role_assignments_info.py
@@ -33,13 +33,15 @@ options:
       - List of assignee types to filter the assignments. Supported
          types 'user', 'group'. None means don't filter anything.
     required: false
-    type: str
+    type: list
+    elements: str
   scope_types:
     description:
       - List of scope types to filter the assignments. Supported
          types 'project', 'system', 'domain'. None means don't filter anything.
     required: false
-    type: str
+    type: list
+    elements: str
   auth:
     description:
       - Required if 'cloud' param not used.
@@ -53,11 +55,6 @@ options:
   region_name:
     description:
       - OpenStack region name. Can be omitted if using default region.
-    required: false
-    type: str
-  availability_zone:
-    description:
-      - Availability zone.
     required: false
     type: str
   cloud:
@@ -107,8 +104,8 @@ except ImportError:
 
 def main():
     argument_spec = openstack_full_argument_spec(
-        assignee_types=dict(required=False, type="list", default=None),
-        scope_types=dict(required=False, type="list", default=None),
+        assignee_types=dict(required=False, type="list", elements="str", default=None),
+        scope_types=dict(required=False, type="list", elements="str", default=None),
     )
 
     module = AnsibleModule(

--- a/plugins/modules/os_routers_info.py
+++ b/plugins/modules/os_routers_info.py
@@ -33,6 +33,7 @@ options:
       - Options for filtering the Routers info.
     required: false
     type: dict
+    default: {}
   auth:
     description:
       - Required if 'cloud' parameter not used.
@@ -46,11 +47,6 @@ options:
   region_name:
     description:
       - OpenStack region name. Can be omitted if using default region.
-    required: false
-    type: str
-  availability_zone:
-    description:
-      - Availability zone.
     required: false
     type: str
   cloud:

--- a/plugins/modules/os_security_groups_info.py
+++ b/plugins/modules/os_security_groups_info.py
@@ -33,11 +33,7 @@ options:
       - Options for filtering the Security Group info.
     required: false
     type: dict
-  availability_zone:
-    description:
-      - Availability zone.
-    required: false
-    type: str
+    default: {}
   cloud:
     description:
       - Cloud resource from clouds.yml file
@@ -92,7 +88,7 @@ def main():
     # TODO: check the del
     # del argument_spec['cloud']
 
-    module = AnsibleModule(argument_spec)
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
     sdk, cloud = openstack_cloud_from_module(module)
     try:
         security_groups = list(


### PR DESCRIPTION
Add conditional imports for openstack SDK and yaml dependencies to fix Python 3.12 import tests. Fix PEP8 and pylint issues. Correct module documentation to match argument specs (90+ validate-modules errors).

All ansible-test sanity tests now pass.

Jira: [[1](https://issues.redhat.com/browse/OSPRH-17917)]