### PR TITLE
Change openstacksdk version in AEE to 4.5.0 to stop github CI from failing

### DIFF
--- a/aee/requirements.txt
+++ b/aee/requirements.txt
@@ -1,2 +1,2 @@
-openstacksdk==1.5.1
+openstacksdk==4.5.0
 PyYAML==6.0.2


### PR DESCRIPTION
CI is failing on `Build and push AEE image` because of openstacksdk version mismatch (https://github.com/os-migrate/os-migrate/actions/runs/23803816186/job/69371414280)

os_migrate requirements use 4.5.0, but ansible-builder in AEE uses old version 1.5.1

This error prevented new os_migrate 1.0.2 version from being pushed to galaxy. So I guess it will have to be pushed manually?