### PR TITLE
Remove community.crypto dependency

### DIFF
--- a/aee/requirements.yml
+++ b/aee/requirements.yml
@@ -1,7 +1,5 @@
 ---
 collections:
-  - name: community.crypto
-    version: ">=1.4.0"
   - name: community.general
     version: "<5.0.0"
   - name: openstack.cloud

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,6 @@ tags:
   - migrations
   - cloud
 dependencies:
-  community.crypto: ">=1.4.0"
   community.general: "<5.0.0"
   openstack.cloud: ">=2.3.0,<2.4.0"
 repository: "https://github.com/os-migrate/os-migrate"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,5 @@
 ---
 
 collections:
-    - name: community.crypto
-      version: ">=1.4.0"
     - name: community.general
       version: "<5.0.0"

--- a/roles/conversion_host/defaults/main.yml
+++ b/roles/conversion_host/defaults/main.yml
@@ -45,3 +45,6 @@ os_migrate_conversion_image_name: os_migrate_conv
 os_migrate_conversion_host_content_install: true
 
 os_migrate_conversion_floating_ip_address: false
+
+os_migrate_conversion_host_ssh_key_type: ed25519
+os_migrate_conversion_host_ssh_key_bits: 4096

--- a/roles/conversion_host/tasks/generate_keypair.yml
+++ b/roles/conversion_host/tasks/generate_keypair.yml
@@ -6,6 +6,8 @@
 
 - name: Generate a keypair for the conversion host
   ansible.builtin.shell: >
-    ssh-keygen -t rsa -b 4096 -f "{{ os_migrate_conversion_keypair_private_path }}" -N ""
+    ssh-keygen -t {{ os_migrate_conversion_host_ssh_key_type }}
+    {% if os_migrate_conversion_host_ssh_key_type != 'ed25519' %}-b {{ os_migrate_conversion_host_ssh_key_bits }}{% endif %}
+    -f "{{ os_migrate_conversion_keypair_private_path }}" -N ""
   args:
     creates: "{{ os_migrate_conversion_keypair_private_path }}"

--- a/roles/conversion_host/tasks/generate_keypair.yml
+++ b/roles/conversion_host/tasks/generate_keypair.yml
@@ -5,9 +5,7 @@
     mode: '0700'
 
 - name: Generate a keypair for the conversion host
-  ansible.builtin.user:
-    name: "{{ lookup('env', 'USER') }}"
-    generate_ssh_key: yes
-    ssh_key_bits: 4096
-    ssh_key_file: "{{ os_migrate_conversion_keypair_private_path }}"
-    ssh_key_type: rsa
+  ansible.builtin.shell: >
+    ssh-keygen -t rsa -b 4096 -f "{{ os_migrate_conversion_keypair_private_path }}" -N ""
+  args:
+    creates: "{{ os_migrate_conversion_keypair_private_path }}"

--- a/roles/conversion_host/tasks/generate_keypair.yml
+++ b/roles/conversion_host/tasks/generate_keypair.yml
@@ -5,5 +5,9 @@
     mode: '0700'
 
 - name: Generate a keypair for the conversion host
-  community.crypto.openssh_keypair:
-    path: "{{ os_migrate_conversion_keypair_private_path }}"
+  ansible.builtin.user:
+    name: "{{ lookup('env', 'USER') }}"
+    generate_ssh_key: yes
+    ssh_key_bits: 4096
+    ssh_key_file: "{{ os_migrate_conversion_keypair_private_path }}"
+    ssh_key_type: rsa

--- a/roles/conversion_host/tasks/link_prepare.yml
+++ b/roles/conversion_host/tasks/link_prepare.yml
@@ -9,7 +9,9 @@
 
 - name: Generate a keypair for the conversion host
   ansible.builtin.shell: >
-    ssh-keygen -t rsa -b 4096 -f "{{ os_migrate_conversion_link_keypair_private_path }}" -N ""
+    ssh-keygen -t {{ os_migrate_conversion_host_ssh_key_type }}
+    {% if os_migrate_conversion_host_ssh_key_type != 'ed25519' %}-b {{ os_migrate_conversion_host_ssh_key_bits }}{% endif %}
+    -f "{{ os_migrate_conversion_link_keypair_private_path }}" -N ""
   args:
     creates: "{{ os_migrate_conversion_link_keypair_private_path }}"
 

--- a/roles/conversion_host/tasks/link_prepare.yml
+++ b/roles/conversion_host/tasks/link_prepare.yml
@@ -7,13 +7,11 @@
     state: directory
     mode: '0700'
 
-- name: Generate a link keypair
-  ansible.builtin.user:
-    name: "{{ lookup('env', 'USER') }}"
-    generate_ssh_key: yes
-    ssh_key_bits: 4096
-    ssh_key_file: "{{ os_migrate_conversion_link_keypair_private_path }}"
-    ssh_key_type: rsa
+- name: Generate a keypair for the conversion host
+  ansible.builtin.shell: >
+    ssh-keygen -t rsa -b 4096 -f "{{ os_migrate_conversion_link_keypair_private_path }}" -N ""
+  args:
+    creates: "{{ os_migrate_conversion_link_keypair_private_path }}"
 
 - name: Wait for src conversion host reachability
   ansible.builtin.wait_for:

--- a/roles/conversion_host/tasks/link_prepare.yml
+++ b/roles/conversion_host/tasks/link_prepare.yml
@@ -8,8 +8,12 @@
     mode: '0700'
 
 - name: Generate a link keypair
-  community.crypto.openssh_keypair:
-    path: "{{ os_migrate_conversion_link_keypair_private_path }}"
+  ansible.builtin.user:
+    name: "{{ lookup('env', 'USER') }}"
+    generate_ssh_key: yes
+    ssh_key_bits: 4096
+    ssh_key_file: "{{ os_migrate_conversion_link_keypair_private_path }}"
+    ssh_key_type: rsa
 
 - name: Wait for src conversion host reachability
   ansible.builtin.wait_for:

--- a/tests/e2e/tasks/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tasks/tenant/seed_pre_workload.yml
@@ -104,14 +104,8 @@
     state: directory
 
 - name: Generate a keypair for the migration
-  # This will not regenerate the key if
-  # it already exists
-  ansible.builtin.user:
-    name: "{{ lookup('env', 'USER') }}"
-    generate_ssh_key: yes
-    ssh_key_bits: 4096
-    ssh_key_file: "{{ '~' | expanduser }}/ssh-ci/id_rsa"
-    ssh_key_type: rsa
+  ansible.builtin.shell: >
+    ssh-keygen -t ed25519 -f "{{ {{ '~' | expanduser }}/ssh-ci }}" -N ""
 
 - name: Create new keypair as osm_key
   os_migrate.os_migrate.keypair:

--- a/tests/e2e/tasks/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tasks/tenant/seed_pre_workload.yml
@@ -105,7 +105,7 @@
 
 - name: Generate a keypair for the migration
   ansible.builtin.shell: >
-    ssh-keygen -t ed25519 -f "{{ '~' | expanduser }}/ssh-ci/id_rsa }}" -N ""
+    ssh-keygen -t ed25519 -f "{{ '~' | expanduser }}/ssh-ci/id_rsa" -N ""
 
 - name: Create new keypair as osm_key
   os_migrate.os_migrate.keypair:

--- a/tests/e2e/tasks/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tasks/tenant/seed_pre_workload.yml
@@ -103,11 +103,21 @@
     mode: 0700
     state: directory
 
+- name: Ensure ssh-ci directory exists
+  ansible.builtin.file:
+    path: "{{ '~' | expanduser }}/ssh-ci"
+    state: directory
+    mode: '0700'
+
 - name: Generate a keypair for the migration
   # This will not regenerate the key if
   # it already exists
-  community.crypto.openssh_keypair:
-    path: "{{ '~' | expanduser }}/ssh-ci/id_rsa"
+  ansible.builtin.user:
+    name: "{{ lookup('env', 'USER') }}"
+    generate_ssh_key: yes
+    ssh_key_bits: 4096
+    ssh_key_file: "{{ '~' | expanduser }}/ssh-ci/id_rsa"
+    ssh_key_type: rsa
 
 - name: Create new keypair as osm_key
   os_migrate.os_migrate.keypair:

--- a/tests/e2e/tasks/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tasks/tenant/seed_pre_workload.yml
@@ -105,7 +105,7 @@
 
 - name: Generate a keypair for the migration
   ansible.builtin.shell: >
-    ssh-keygen -t ed25519 -f "{{ '~' | expanduser }}/ssh-ci }}" -N ""
+    ssh-keygen -t ed25519 -f "{{ '~' | expanduser }}/ssh-ci/id_rsa }}" -N ""
 
 - name: Create new keypair as osm_key
   os_migrate.os_migrate.keypair:

--- a/tests/e2e/tasks/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tasks/tenant/seed_pre_workload.yml
@@ -105,7 +105,7 @@
 
 - name: Generate a keypair for the migration
   ansible.builtin.shell: >
-    ssh-keygen -t ed25519 -f "{{ {{ '~' | expanduser }}/ssh-ci }}" -N ""
+    ssh-keygen -t ed25519 -f "{{ '~' | expanduser }}/ssh-ci }}" -N ""
 
 - name: Create new keypair as osm_key
   os_migrate.os_migrate.keypair:

--- a/tests/e2e/tasks/tenant/seed_pre_workload.yml
+++ b/tests/e2e/tasks/tenant/seed_pre_workload.yml
@@ -103,12 +103,6 @@
     mode: 0700
     state: directory
 
-- name: Ensure ssh-ci directory exists
-  ansible.builtin.file:
-    path: "{{ '~' | expanduser }}/ssh-ci"
-    state: directory
-    mode: '0700'
-
 - name: Generate a keypair for the migration
   # This will not regenerate the key if
   # it already exists


### PR DESCRIPTION
This pull request removes the community.crypto dependency.
In order to certified OS-Migrate we need to cut dependency to community collections and use either builtin or certificed/validated collections.