### PR TITLE
Fix openstacksdk version check after openstack.version was removed in 4.15.0

### DIFF
--- a/roles/prelude_common/tasks/main.yml
+++ b/roles/prelude_common/tasks/main.yml
@@ -15,7 +15,7 @@
 # under the License.
 
 - name: Get the current openstacksdk version
-  ansible.builtin.command: python3 -c "import openstack; print(openstack.version.__version__)"
+  ansible.builtin.command: python3 -c "import importlib.metadata; print(importlib.metadata.version('openstacksdk'))"
   register: _installed_openstacksdk_cmd
   changed_when: false
 


### PR DESCRIPTION
In https://github.com/openstack/openstacksdk/commit/3ae89d61b4f49b74a0f933c95e2df57a87816316 `openstack.version.__version__` was removed after being deprecated, so if I use openstacksdk 4.15.0 and attempt to run any os-migrate playbook then I get this error:
```
TASK [os_migrate.os_migrate.prelude_common : Get the current openstacksdk version] ***********************************************************************************************************
[ERROR]: Task failed: Module failed: The command exited with a non-zero return code.                                                                                                          
Origin: /home/cloud-user/.ansible/collections/ansible_collections/os_migrate/os_migrate/roles/prelude_common/tasks/main.yml:17:3
                                               
15 # under the License.                                                                                                                                                                       
16               
17 - name: Get the current openstacksdk version                                           
     ^ column 3                                                                                                                                                                               
                                               
fatal: [localhost]: FAILED! => {"changed": false, "changed_when_result": false, "cmd": ["python3", "-c", "import openstack; print(openstack.version.__version__)"], "delta": "0:00:00.403549",
 "end": "2026-06-14 20:01:09.831642", "msg": "The command exited with a non-zero return code.", "rc": 1, "start": "2026-06-14 20:01:09.428093", "stderr": "Traceback (most recent call last):\
n  File \"<string>\", line 1, in <module>\nAttributeError: module 'openstack' has no attribute 'version'", "stderr_lines": ["Traceback (most recent call last):", "  File \"<string>\", line 1
, in <module>", "AttributeError: module 'openstack' has no attribute 'version'"], "stdout": "", "stdout_lines": []}
```

This PR updates that check, so that it follows the convention in https://github.com/openstack/openstacksdk/commit/1295f43c0517abe96adb3313228d23a9466bb5ea#diff-1e026d353eaec1c415cd1f1d6100c8dabcc859caeeaa2f936aaad2c51bdf4ed7L870-R870

