### PR TITLE
Add Makefile target to build container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,62 @@
+ARG PYTHON_VERSION=3.12
+ARG BASE_IMAGE=quay.io/centos/centos:stream10
+
+FROM $BASE_IMAGE
+
+ARG PYTHON_VERSION
+
+LABEL maintainer="os-migrate team" \
+      description="OpenStack tenant migration tooling"
+
+RUN dnf upgrade --refresh -y --skip-broken --nobest && \
+    dnf install -y \
+        epel-release \
+        openssh-clients \
+        sshpass \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-devel \
+        python${PYTHON_VERSION}-pip \
+        python3-dnf \
+        rsync \
+        gcc \
+        git-core \
+        rhel-system-roles \
+        util-linux \
+        && dnf clean all
+
+WORKDIR /code
+
+COPY requirements.txt requirements-tests.txt ./
+
+RUN python${PYTHON_VERSION} -m venv /code/.venv && \
+    . /code/.venv/bin/activate && \
+    pip install --root-user-action ignore --upgrade pip && \
+    pip install --root-user-action ignore -r requirements.txt && \
+    pip install --root-user-action ignore -r requirements-tests.txt
+
+COPY . .
+
+RUN git clone --depth 1 --branch 2.5.0 \
+        https://github.com/openstack/ansible-collections-openstack.git \
+        /code/plugins/modules/_vendor/openstack.cloud && \
+    for mod in auth compute_flavor compute_flavor_info floating_ip identity_domain identity_role \
+        identity_user identity_user_info image image_info keypair network networks_info port project \
+        project_info role_assignment router security_group security_group_rule server \
+        server_action server_info server_volume subnet subnets_info volume volume_info; do \
+        ln -sf /code/plugins/modules/_vendor/openstack.cloud/plugins/modules/$mod.py \
+            /code/plugins/modules/$mod.py; \
+    done && \
+    for util in openstack ironic; do \
+        ln -sf /code/plugins/modules/_vendor/openstack.cloud/plugins/module_utils/$util.py \
+            /code/plugins/module_utils/$util.py; \
+    done
+
+RUN . /code/.venv/bin/activate && \
+    pip install ansible-core && \
+    ansible-galaxy collection build && \
+    ansible-galaxy collection install openstack.cloud community.general && \
+    ansible-galaxy collection install os_migrate-os_migrate-*.tar.gz --force-with-deps
+
+ENV PATH="/code/.venv/bin:${PATH}"
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ else
 endif
 
 # --- Phony Targets Definition ---
-.PHONY: all help build clean-build tests test-ansible-lint test-ansible-sanity test-ansible-units \
+.PHONY: all help build clean-build container-image container-image-clean \
+        tests test-ansible-lint test-ansible-sanity test-ansible-units \
         create-centos-container clean-centos-container check-root check-python-version \
         create-venv install-deps install generate-auth-files
 
@@ -90,6 +91,9 @@ help:
 	@echo "  test-e2e-tenant       - Launch e2e tenant tests"
 	@echo "  test-e2e-admin        - Launch e2e admin tests"
 	@echo "  generate-auth-files   - Generate auth files for e2e tests"
+	@echo ""
+	@echo "  container-image       - Build the container image from Containerfile"
+	@echo "  container-image-clean - Remove the built container image"
 	@echo ""
 	@echo "  create-centos-container - Create the CentOS container (if needed)"
 	@echo "  clean-centos-container  - Stop and remove the CentOS container"
@@ -189,6 +193,19 @@ clean-build:
 	else \
 		echo "Skipping removal, collection tarball name not determined from galaxy.yml."; \
 	fi
+
+# --- Container Image Build ---
+
+container-image: check-root
+	@echo "--- Building container image: $(CONTAINER_NAME) ---"
+	@$(CONTAINER_ENGINE) build -t $(CONTAINER_NAME) -f Containerfile \
+		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+		--build-arg BASE_IMAGE=$(CONTAINER_IMAGE) \
+		$(COLLECTION_ROOT)
+
+container-image-clean:
+	@echo "--- Removing container image: $(CONTAINER_NAME) ---"
+	@$(CONTAINER_ENGINE) rmi -f $(CONTAINER_NAME) 2>/dev/null || true
 
 # --- Container and Environment Setup Targets ---
 


### PR DESCRIPTION
This PR adds a new Makefile target that allows building a container
image for os-migrate.

Currently there is no straightforward way to build a containerized
version of os-migrate. This change introduces a `make` target to
simplify building the image locally and in CI/CD pipelines.