### PR TITLE
fix: preserve volume_image_metadata (UEFI/machine-type) on destination boot volumes

### DIFF
--- a/os_migrate/plugins/modules/import_workload_export_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_export_volumes.py
@@ -225,6 +225,7 @@ volume_map:
               "dest_dev": null,
               "dest_id": null,
               "image_id": null,
+              "image_metadata": {"hw_firmware_type": "uefi", "hw_machine_type": "q35"},
               "name": "migration-vm-boot",
               "port": 49164,
               "progress": 0.0,
@@ -307,6 +308,9 @@ class OpenStackSourceHost(OpenStackHostBase):
         #   url:         Final NBD export on destination conversion host
         #   progress:    Transfer progress percentage
         #   bootable:    Boolean flag for boot disks
+        #   image_metadata: Cinder volume_image_metadata of the source volume,
+        #                   carries hw_firmware_type/hw_machine_type etc. which
+        #                   Nova needs to build the destination domain XML
         self.volume_map = {}
 
         self.ser_server = ser_server
@@ -354,7 +358,8 @@ class OpenStackSourceHost(OpenStackHostBase):
                 source_dev=None, source_id=volume['id'], dest_dev=None,
                 dest_id=None, snap_id=None, image_id=None, name=volume['name'],
                 size=volume['size'], port=None, url=None, progress=None,
-                bootable=volume['bootable'])
+                bootable=volume['bootable'],
+                image_metadata=dict(volume.get('volume_image_metadata') or {}))
             self._update_progress(dev_path, 0.0)
 
     def _validate_volumes_match_data(self):
@@ -423,7 +428,8 @@ class OpenStackSourceHost(OpenStackHostBase):
                 source_dev=None, source_id=volume['id'], dest_dev=None,
                 dest_id=None, snap_id=None, image_id=image.id, name=volume['name'],
                 size=volume['size'], port=None, url=None, progress=None,
-                bootable=volume['bootable'])
+                bootable=volume['bootable'],
+                image_metadata=dict(volume.get('volume_image_metadata') or {}))
             self._update_progress('/dev/vda', 0.0)
         elif sourcevm.image and not self.ser_server.migration_params()['boot_disk_copy']:
             self.log.info('Image-based instance, boot_disk_copy disabled: skipping boot volume')

--- a/os_migrate/plugins/modules/import_workload_transfer_volumes.py
+++ b/os_migrate/plugins/modules/import_workload_transfer_volumes.py
@@ -265,6 +265,7 @@ volume_map:
             "dest_dev": "/dev/vdc",
             "dest_id": "3b7a57d7-8210-47f9-b592-a6627ae52d13",
             "image_id": null,
+            "image_metadata": {"hw_firmware_type": "uefi", "hw_machine_type": "q35"},
             "name": "migration-vm-boot",
             "port": 49196,
             "progress": 100.0,
@@ -447,6 +448,35 @@ class OpenStackDestinationHost(OpenStackHostBase):
             sdk_params.pop('volume_type', None)
             new_volume = self.conn.create_volume(**sdk_params)
             self.volume_map[path]['dest_id'] = new_volume.id
+            self._copy_volume_image_metadata(mapping, new_volume)
+
+    def _copy_volume_image_metadata(self, mapping, new_volume):
+        """
+        Copy the source volume's Cinder volume_image_metadata onto the freshly
+        created destination volume.
+
+        Cinder does not accept volume_image_metadata as a create_volume
+        parameter, so it has to be set afterwards. Without this, properties
+        such as hw_firmware_type=uefi and hw_machine_type=q35 are lost and
+        Nova builds the destination domain with SeaBIOS/i440fx. A UEFI guest
+        (any Windows Server 2016+, or a GPT/ESP Linux) then fails to boot with
+        "No bootable device", even though the disk contents transferred fine.
+        """
+        image_metadata = mapping.get('image_metadata') or {}
+        if not image_metadata:
+            return
+        self.log.info('Copying volume image metadata to destination volume '
+                      '%s: %s', new_volume.id, image_metadata)
+        try:
+            self.conn.block_storage.set_volume_image_metadata(
+                new_volume, **image_metadata)
+        except Exception as err:  # pylint: disable=broad-except
+            # Not fatal on its own, but the guest will likely not boot, so
+            # make the reason loud rather than failing mysteriously later.
+            self.log.warning(
+                'Failed to set volume image metadata on destination volume '
+                '%s: %s. The destination instance may fail to boot if the '
+                'source used UEFI firmware.', new_volume.id, str(err))
 
     @use_lock(ATTACH_LOCK_FILE_DESTINATION)
     def _attach_destination_volumes(self):


### PR DESCRIPTION
When migrating a VM whose boot volume carries Cinder volume_image_metadata (e.g. hw_firmware_type=uefi, hw_machine_type=q35), that metadata was previously dropped during import_workload_transfer_volumes. Nova falls back to SeaBIOS/i440fx when building the destination domain, so any UEFI guest (Windows Server 2016+, or a GPT/ESP-booting Linux) fails to boot with "No bootable device" even though the disk contents transferred correctly.

This carries volume_image_metadata from the source volume through volume_map (import_workload_export_volumes), and applies it to the newly created destination volume via conn.block_storage.set_volume_image_metadata (import_workload_transfer_volumes), since Cinder does not accept volume_image_metadata as a create_volume parameter.